### PR TITLE
fix: improve memory management, session tracking, and graceful shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ crossterm = "0.29"
 nucleo-matcher = "0.3"
 
 async-trait = "0.1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"

--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -17,7 +17,7 @@ async fn launch_discord(
     cancel: CancellationToken,
 ) -> Result<Arc<OpenGooseGateway>> {
     let (response_tx, response_rx) =
-        tokio::sync::mpsc::unbounded_channel::<(SessionKey, String)>();
+        tokio::sync::mpsc::channel::<(SessionKey, String)>(256);
 
     let gateway = Arc::new(OpenGooseGateway::new(response_tx, event_bus.clone()));
 
@@ -86,6 +86,11 @@ pub async fn execute() -> Result<()> {
         }
     });
 
+    // Create the pairing channel upfront so the TUI can trigger pairing
+    // code generation in both Normal and Setup→Normal flows.
+    let (pairing_tx, pairing_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    let mut pairing_rx = Some(pairing_rx);
+
     let resolver = CredentialResolver::new()?;
     match resolver.resolve_async(&SecretKey::DiscordBotToken).await {
         Ok(cred) => {
@@ -93,8 +98,9 @@ pub async fn execute() -> Result<()> {
             let token = cred.value.as_str().to_string();
             let gateway = launch_discord(token, event_bus.clone(), cancel.clone()).await?;
 
-            let (pairing_tx, pairing_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-            spawn_pairing_handler(gateway, pairing_rx, cancel.clone());
+            if let Some(rx) = pairing_rx.take() {
+                spawn_pairing_handler(gateway, rx, cancel.clone());
+            }
 
             opengoose_tui::run_tui(
                 event_bus,
@@ -112,7 +118,14 @@ pub async fn execute() -> Result<()> {
             let tui_bus = event_bus.clone();
             let tui_cancel = cancel.clone();
             let mut tui_handle = tokio::spawn(async move {
-                opengoose_tui::run_tui(tui_bus, tui_cancel, AppMode::Setup, Some(tx), None).await
+                opengoose_tui::run_tui(
+                    tui_bus,
+                    tui_cancel,
+                    AppMode::Setup,
+                    Some(tx),
+                    Some(pairing_tx),
+                )
+                .await
             });
 
             // Wait for either the token or TUI exit
@@ -122,9 +135,9 @@ pub async fn execute() -> Result<()> {
                         let gateway =
                             launch_discord(token, event_bus, cancel.clone()).await?;
 
-                        let (_pairing_tx, pairing_rx) =
-                            tokio::sync::mpsc::unbounded_channel::<()>();
-                        spawn_pairing_handler(gateway, pairing_rx, cancel.clone());
+                        if let Some(rx) = pairing_rx.take() {
+                            spawn_pairing_handler(gateway, rx, cancel.clone());
+                        }
                     }
                     // In both Ok and Err cases, wait for TUI to finish
                     tui_handle.await??;

--- a/crates/opengoose-core/src/gateway.rs
+++ b/crates/opengoose-core/src/gateway.rs
@@ -17,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 /// Receives events from the Discord adapter, relays them to Goose,
 /// and forwards Goose responses back via response_tx.
 pub struct OpenGooseGateway {
-    response_tx: tokio::sync::mpsc::UnboundedSender<(SessionKey, String)>,
+    response_tx: tokio::sync::mpsc::Sender<(SessionKey, String)>,
     handler: tokio::sync::RwLock<Option<GatewayHandler>>,
     pairing_store: tokio::sync::RwLock<Option<Arc<PairingStore>>>,
     event_bus: EventBus,
@@ -25,7 +25,7 @@ pub struct OpenGooseGateway {
 
 impl OpenGooseGateway {
     pub fn new(
-        response_tx: tokio::sync::mpsc::UnboundedSender<(SessionKey, String)>,
+        response_tx: tokio::sync::mpsc::Sender<(SessionKey, String)>,
         event_bus: EventBus,
     ) -> Self {
         Self {
@@ -127,7 +127,7 @@ impl Gateway for OpenGooseGateway {
                 session_key: session_key.clone(),
                 content: body.clone(),
             });
-            if self.response_tx.send((session_key.clone(), body.clone())).is_err() {
+            if self.response_tx.send((session_key.clone(), body.clone())).await.is_err() {
                 warn!(%session_key, "response channel closed, dropping message");
             }
 

--- a/crates/opengoose-discord/src/adapter.rs
+++ b/crates/opengoose-discord/src/adapter.rs
@@ -18,7 +18,7 @@ const DISCORD_MAX_LEN: usize = 2000;
 pub struct DiscordAdapter {
     token: String,
     gateway: Arc<OpenGooseGateway>,
-    response_rx: tokio::sync::mpsc::UnboundedReceiver<(SessionKey, String)>,
+    response_rx: tokio::sync::mpsc::Receiver<(SessionKey, String)>,
     http: Arc<HttpClient>,
     event_bus: EventBus,
 }
@@ -27,7 +27,7 @@ impl DiscordAdapter {
     pub fn new(
         token: String,
         gateway: Arc<OpenGooseGateway>,
-        response_rx: tokio::sync::mpsc::UnboundedReceiver<(SessionKey, String)>,
+        response_rx: tokio::sync::mpsc::Receiver<(SessionKey, String)>,
         event_bus: EventBus,
     ) -> Self {
         let http = Arc::new(HttpClient::new(token.clone()));
@@ -56,27 +56,45 @@ impl DiscordAdapter {
 
         let cancel_clone = cancel.clone();
 
-        // Spawn response-sending loop in a separate task
+        // Spawn response-sending loop in a separate task with graceful drain
         let response_handle = tokio::spawn({
             let http = http.clone();
             let mut rx = response_rx;
+            let cancel_resp = cancel.clone();
 
             async move {
-                while let Some((session_key, body)) = rx.recv().await {
-                    let channel_id = match session_key.thread_id.parse::<u64>() {
-                        Ok(id) => Id::<ChannelMarker>::new(id),
-                        Err(_) => {
-                            warn!(thread_id = %session_key.thread_id, "invalid channel id");
-                            continue;
+                loop {
+                    tokio::select! {
+                        _ = cancel_resp.cancelled() => {
+                            // Drain remaining messages with a 5-second deadline
+                            let deadline = tokio::time::sleep(std::time::Duration::from_secs(5));
+                            tokio::pin!(deadline);
+                            loop {
+                                tokio::select! {
+                                    biased;
+                                    _ = &mut deadline => {
+                                        warn!("response drain deadline exceeded, dropping remaining");
+                                        break;
+                                    }
+                                    msg = rx.recv() => {
+                                        match msg {
+                                            Some((session_key, body)) => {
+                                                send_response(&http, &session_key, &body).await;
+                                            }
+                                            None => break,
+                                        }
+                                    }
+                                }
+                            }
+                            break;
                         }
-                    };
-                    for chunk in split_message(&body, DISCORD_MAX_LEN) {
-                        if let Err(e) = http
-                            .create_message(channel_id)
-                            .content(chunk)
-                            .await
-                        {
-                            error!(%e, "failed to send discord message");
+                        msg = rx.recv() => {
+                            match msg {
+                                Some((session_key, body)) => {
+                                    send_response(&http, &session_key, &body).await;
+                                }
+                                None => break,
+                            }
                         }
                     }
                 }
@@ -120,8 +138,33 @@ impl DiscordAdapter {
             }
         }
 
-        response_handle.abort();
+        // Wait for the response task to drain and exit gracefully
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            response_handle,
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => warn!(%e, "response task panicked"),
+            Err(_) => warn!("response task did not finish within timeout"),
+        }
         Ok(())
+    }
+}
+
+async fn send_response(http: &HttpClient, session_key: &SessionKey, body: &str) {
+    let channel_id = match session_key.thread_id.parse::<u64>() {
+        Ok(id) => Id::<ChannelMarker>::new(id),
+        Err(_) => {
+            warn!(thread_id = %session_key.thread_id, "invalid channel id");
+            return;
+        }
+    };
+    for chunk in split_message(body, DISCORD_MAX_LEN) {
+        if let Err(e) = http.create_message(channel_id).content(chunk).await {
+            error!(%e, "failed to send discord message");
+        }
     }
 }
 

--- a/crates/opengoose-tui/src/app.rs
+++ b/crates/opengoose-tui/src/app.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::time::Instant;
 
 use anyhow::Result;
@@ -86,7 +86,7 @@ pub struct App {
     pub pairing_tx: Option<mpsc::UnboundedSender<()>>,
     pub pairing_code: Option<String>,
     pub discord_connected: bool,
-    pub session_count: u32,
+    pub active_sessions: HashSet<SessionKey>,
     pub messages_area_height: usize,
     pub events_area_height: usize,
     pub should_quit: bool,
@@ -114,7 +114,7 @@ impl App {
             discord_connected: false,
             messages_area_height: 0,
             events_area_height: 0,
-            session_count: 0,
+            active_sessions: HashSet::new(),
             should_quit: false,
             start_time: Instant::now(),
         }
@@ -203,25 +203,35 @@ impl App {
             AppEventKind::PairingCodeGenerated { code } => {
                 self.pairing_code = Some(code.clone());
             }
-            AppEventKind::PairingCompleted { .. } => {
-                self.session_count += 1;
+            AppEventKind::PairingCompleted { session_key } => {
+                self.active_sessions.insert(session_key.clone());
+            }
+            AppEventKind::SessionDisconnected { session_key, .. } => {
+                self.active_sessions.remove(session_key);
             }
             AppEventKind::Error { .. } => {}
             AppEventKind::TracingEvent { .. } => {}
         }
 
-        // All events go to the events panel
-        let level = match &event.kind {
-            AppEventKind::Error { .. } => EventLevel::Error,
-            _ => EventLevel::Info,
-        };
-        self.events.push_back(EventEntry {
-            summary: event.kind.to_string(),
-            level,
-            timestamp: Instant::now(),
-        });
-        if self.events.len() > MAX_EVENTS {
-            self.events.pop_front();
+        // All events go to the events panel — except message events which
+        // are already shown in the messages panel.
+        let shown_in_messages = matches!(
+            &event.kind,
+            AppEventKind::MessageReceived { .. } | AppEventKind::ResponseSent { .. }
+        );
+        if !shown_in_messages {
+            let level = match &event.kind {
+                AppEventKind::Error { .. } => EventLevel::Error,
+                _ => EventLevel::Info,
+            };
+            self.events.push_back(EventEntry {
+                summary: event.kind.to_string(),
+                level,
+                timestamp: Instant::now(),
+            });
+            if self.events.len() > MAX_EVENTS {
+                self.events.pop_front();
+            }
         }
     }
 

--- a/crates/opengoose-tui/src/command.rs
+++ b/crates/opengoose-tui/src/command.rs
@@ -70,7 +70,18 @@ pub fn execute(app: &mut App, id: CommandId) {
             }
         }
         CommandId::ListSessions => {
-            // TODO: show sessions overlay
+            if app.active_sessions.is_empty() {
+                app.push_event("no active sessions", crate::app::EventLevel::Info);
+            } else {
+                let labels: Vec<String> = app
+                    .active_sessions
+                    .iter()
+                    .map(|key| format!("active: {key}"))
+                    .collect();
+                for label in &labels {
+                    app.push_event(label, crate::app::EventLevel::Info);
+                }
+            }
         }
         CommandId::ClearMessages => app.clear_messages(),
         CommandId::ClearEvents => app.clear_events(),

--- a/crates/opengoose-tui/src/event.rs
+++ b/crates/opengoose-tui/src/event.rs
@@ -1,5 +1,5 @@
 use crossterm::event::{self, Event, KeyEvent};
-use opengoose_types::AppEvent;
+use opengoose_types::{AppEvent, AppEventKind};
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -58,7 +58,16 @@ impl EventHandler {
                                     break;
                                 }
                             }
-                            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                let _ = tx_bus.send(TuiEvent::AppEvent(AppEvent {
+                                    kind: AppEventKind::Error {
+                                        context: "event_bus".into(),
+                                        message: format!("{n} events dropped due to lag"),
+                                    },
+                                    timestamp: std::time::Instant::now(),
+                                }));
+                                continue;
+                            }
                             Err(broadcast::error::RecvError::Closed) => break,
                         }
                     }

--- a/crates/opengoose-tui/src/ui/status_bar.rs
+++ b/crates/opengoose-tui/src/ui/status_bar.rs
@@ -16,7 +16,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
 
     let left_label = " OpenGoose v0.1.0";
     let separator = "  ";
-    let sessions_text = format!("Sessions: {}", app.session_count);
+    let sessions_text = format!("Sessions: {}", app.active_sessions.len());
     let discord_label = "Discord: ";
     let trailing = " ";
 

--- a/crates/opengoose-types/src/events.rs
+++ b/crates/opengoose-types/src/events.rs
@@ -19,6 +19,7 @@ pub enum AppEventKind {
     ResponseSent { session_key: SessionKey, content: String },
     PairingCodeGenerated { code: String },
     PairingCompleted { session_key: SessionKey },
+    SessionDisconnected { session_key: SessionKey, reason: String },
     Error { context: String, message: String },
     TracingEvent { level: String, message: String },
 }
@@ -32,6 +33,9 @@ impl fmt::Display for AppEventKind {
             Self::ResponseSent { .. } => write!(f, "response sent"),
             Self::PairingCodeGenerated { code } => write!(f, "pairing code: {code}"),
             Self::PairingCompleted { session_key } => write!(f, "paired: {session_key}"),
+            Self::SessionDisconnected { session_key, reason } => {
+                write!(f, "session disconnected: {session_key} ({reason})")
+            }
             Self::Error { context, message } => write!(f, "error [{context}]: {message}"),
             Self::TracingEvent { level, message } => write!(f, "[{level}] {message}"),
         }


### PR DESCRIPTION
## Summary
- **Bounded response channel**: `unbounded_channel` → `channel(256)` to prevent unbounded memory growth when Discord API is slow
- **Fix Setup→Normal pairing bug**: Pairing channel was dropped immediately after creation in Setup mode, making "Generate Pairing Code" command non-functional after token entry
- **Graceful response shutdown**: Replace `response_handle.abort()` with cancel-aware drain loop (5s deadline) + timeout await (10s), preventing in-flight message loss
- **Broadcast lag warning**: Emit error event instead of silently dropping when TUI subscriber falls behind
- **Event dedup**: Skip `MessageReceived`/`ResponseSent` events from events panel since they're already shown in messages panel
- **Session lifecycle tracking**: Replace monotonic `session_count: u32` with `HashSet<SessionKey>` for accurate active session tracking, add `SessionDisconnected` event variant, implement `ListSessions` command

## Test plan
- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy --workspace` has no new warnings
- [ ] Start in Setup mode (no token) → enter token → Normal mode → "Generate Pairing Code" works
- [ ] Ctrl+C during message sending → pending messages drain before exit (check logs)
- [ ] Events panel does not show "message from X" / "response sent" entries
- [ ] Status bar shows accurate `Sessions: N` from HashSet
- [ ] Rapid message burst doesn't cause unbounded memory growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)