### PR TITLE
fix: allow releaseassets.githubusercontent.com in perf-improver network config

### DIFF
--- a/.github/workflows/daily-perf-improver.md
+++ b/.github/workflows/daily-perf-improver.md
@@ -29,6 +29,7 @@ network:
   - python
   - rust
   - java
+  - "releaseassets.githubusercontent.com"
 
 safe-outputs:
   add-comment:


### PR DESCRIPTION
## Summary

- `daily-perf-improver` 워크플로우 실행 시 `releaseassets.githubusercontent.com` 도메인이 방화벽에 의해 차단되는 문제 수정
- `.github/workflows/daily-perf-improver.md`의 `network.allowed` 목록에 해당 도메인 추가

## 변경 사항

```yaml
network:
  allowed:
  - ...
  - "releaseassets.githubusercontent.com"  # 추가
```

## 관련 이슈

PR #39 실행 로그에서 발생한 firewall 경고:
> ⚠️ Firewall blocked 1 domain: releaseassets.githubusercontent.com
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
