### PR TITLE
Replace manual Cargo caching with Swatinem/rust-cache action

### DIFF
--- a/.github/workflows/ci-quality-gate.yml
+++ b/.github/workflows/ci-quality-gate.yml
@@ -77,16 +77,7 @@ jobs:
           components: clippy
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libxcb1-dev libdbus-1-dev pkg-config
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       - run: cargo clippy --workspace --all-targets --all-features
 
   test:
@@ -101,16 +92,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libxcb1-dev libdbus-1-dev pkg-config
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-
-            ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       - run: cargo test --workspace
 
   quality-gate:


### PR DESCRIPTION
## Summary
Replaced manual Cargo cache configuration using `actions/cache@v5` with the specialized `Swatinem/rust-cache@v2.8.2` action across CI workflows.

## Key Changes
- Removed manual cache path configuration for `~/.cargo/registry`, `~/.cargo/git`, and `target` directories
- Replaced with `Swatinem/rust-cache@v2.8.2` in both the `clippy` and `test` jobs
- Simplified cache key management by delegating to the specialized Rust caching action

## Benefits
- Uses a purpose-built action optimized for Rust/Cargo caching
- Reduces boilerplate configuration in CI workflows
- Likely includes better handling of Rust-specific cache invalidation and optimization
- Easier to maintain and update caching strategy going forward

https://claude.ai/code/session_016GxGzC6qB3CanmcC7B95jL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
