### PR TITLE
feat(channels): improve adapter connection stability (OPE-47)

### DIFF
--- a/crates/opengoose-discord/src/gateway.rs
+++ b/crates/opengoose-discord/src/gateway.rs
@@ -130,7 +130,7 @@ impl Gateway for DiscordGateway {
                             Event::Ready(ready) => {
                                 let app_id = ready.application.id;
                                 application_id = Some(app_id);
-                                info!(?app_id, "discord bot connected");
+                                info!(?app_id, "discord gateway connected");
                                 self.event_bus.emit(AppEventKind::ChannelReady {
                                     platform: Platform::Discord,
                                 });

--- a/crates/opengoose-matrix/src/gateway.rs
+++ b/crates/opengoose-matrix/src/gateway.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use tracing::{error, info, warn};
@@ -24,6 +25,11 @@ const MATRIX_MAX_LEN: usize = 32_768;
 
 /// Long-poll timeout for /sync (milliseconds).
 const SYNC_TIMEOUT_MS: u64 = 30_000;
+
+/// HTTP client timeout. Must exceed SYNC_TIMEOUT_MS (30 s) to avoid
+/// cutting off long-poll responses. We add 15 s of buffer for network
+/// latency and server processing overhead.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Maximum reconnect attempts before giving up.
 const MAX_RECONNECT_ATTEMPTS: u32 = 10;
@@ -55,10 +61,19 @@ impl MatrixGateway {
         bridge: Arc<GatewayBridge>,
         event_bus: EventBus,
     ) -> Self {
+        // The sync endpoint uses its own long-poll timeout (SYNC_TIMEOUT_MS).
+        // For all other requests (whoami, send_event, etc.) we want a shorter
+        // deadline so the caller doesn't block indefinitely on network issues.
+        // reqwest's per-request timeout overrides the client default, so the
+        // 30 s here only applies to non-sync requests.
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .expect("failed to build reqwest client");
         Self {
             homeserver_url: homeserver_url.into().trim_end_matches('/').to_string(),
             access_token: access_token.into(),
-            client: reqwest::Client::new(),
+            client,
             bridge,
             event_bus,
             txn_counter: AtomicU64::new(0),
@@ -311,10 +326,11 @@ impl MatrixGateway {
                 Err(e) => {
                     reconnect_attempts += 1;
                     if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
+                        error!(%e, "matrix sync loop giving up after max reconnect attempts");
                         return Err(e);
                     }
-                    let delay = std::time::Duration::from_secs(2u64.pow(reconnect_attempts.min(5)));
-                    warn!(%e, ?delay, "matrix /sync error, retrying...");
+                    let delay = Duration::from_secs(2u64.pow(reconnect_attempts.min(5)));
+                    warn!(%e, attempt = reconnect_attempts, ?delay, "matrix /sync error, retrying...");
                     tokio::select! {
                         _ = cancel.cancelled() => break,
                         _ = tokio::time::sleep(delay) => {}
@@ -359,6 +375,7 @@ impl Gateway for MatrixGateway {
             }
         };
 
+        info!("matrix gateway connected");
         self.event_bus.emit(AppEventKind::ChannelReady {
             platform: Platform::Custom("matrix".to_string()),
         });

--- a/crates/opengoose-telegram/src/gateway.rs
+++ b/crates/opengoose-telegram/src/gateway.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use tracing::{error, info, warn};
@@ -76,6 +77,12 @@ struct SentMessage {
 /// Telegram message size limit.
 const TELEGRAM_MAX_LEN: usize = 4096;
 
+/// Timeout for individual Telegram API requests.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Maximum reconnect attempts before giving up.
+const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+
 /// Telegram channel gateway implementing the goose `Gateway` trait.
 ///
 /// Wraps goose's `TelegramGateway` for message sending and config validation,
@@ -113,7 +120,10 @@ impl TelegramGateway {
 
         Self {
             bot_token: token,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .build()
+                .expect("failed to build reqwest client"),
             inner,
             bridge,
             event_bus,
@@ -309,6 +319,7 @@ impl Gateway for TelegramGateway {
 
         let mut offset: Option<i64> = None;
         let mut ready_emitted = false;
+        let mut reconnect_attempts: u32 = 0;
 
         loop {
             tokio::select! {
@@ -323,8 +334,10 @@ impl Gateway for TelegramGateway {
                 result = self.get_updates(offset) => {
                     match result {
                         Ok(updates) => {
+                            reconnect_attempts = 0;
                             // Emit ready only after first successful poll
                             if !ready_emitted {
+                                info!("telegram gateway connected");
                                 self.event_bus.emit(AppEventKind::ChannelReady {
                                     platform: Platform::Telegram,
                                 });
@@ -390,8 +403,33 @@ impl Gateway for TelegramGateway {
                             }
                         }
                         Err(e) => {
-                            warn!(%e, "telegram getUpdates error, retrying...");
-                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                            reconnect_attempts += 1;
+                            if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
+                                let reason = format!("getUpdates failed after {MAX_RECONNECT_ATTEMPTS} attempts: {e}");
+                                error!(%e, "telegram gateway giving up after max reconnect attempts");
+                                self.event_bus.emit(AppEventKind::ChannelDisconnected {
+                                    platform: Platform::Telegram,
+                                    reason: reason.clone(),
+                                });
+                                self.event_bus.emit(AppEventKind::Error {
+                                    context: "telegram".into(),
+                                    message: reason,
+                                });
+                                break;
+                            }
+                            let delay = Duration::from_secs(2u64.pow(reconnect_attempts.min(5)));
+                            warn!(%e, attempt = reconnect_attempts, ?delay, "telegram getUpdates error, retrying...");
+                            tokio::select! {
+                                _ = cancel.cancelled() => {
+                                    info!("telegram gateway shutting down during reconnect");
+                                    self.event_bus.emit(AppEventKind::ChannelDisconnected {
+                                        platform: Platform::Telegram,
+                                        reason: "shutdown".into(),
+                                    });
+                                    break;
+                                }
+                                _ = tokio::time::sleep(delay) => {}
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Improves connection stability and resilience across Discord, Telegram, and Matrix channel adapters.

- **Telegram reconnection**: replaced flat 5s sleep with exponential backoff (2^n seconds, capped at 32s, max 10 attempts); on final failure emits `ChannelDisconnected` + `Error` events
- **Telegram timeout**: added 60s `reqwest` client timeout to prevent indefinite hangs
- **Matrix timeout**: added 45s `reqwest` client timeout (15s buffer above the 30s long-poll window)
- **Matrix logging**: added attempt counter to retry warning; final failure now logs at `error` level
- **Discord logging**: normalized log message to `"discord gateway connected"` for consistency

## Test plan

- [ ] 39 unit tests across `opengoose-discord`, `opengoose-matrix`, `opengoose-telegram` pass
- [ ] Workspace compiles cleanly (`cargo build --workspace`)
- [ ] Manual: simulate network drop on Telegram bot — verify exponential backoff in logs
- [ ] Manual: confirm Telegram gateway emits `ChannelDisconnected` after max attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
