### PR TITLE
feat(tui): add composer editing and paging (OPE-48)

### DIFF
--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -13,8 +13,8 @@ use opengoose_secrets::{CredentialResolver, SecretKey};
 use opengoose_slack::SlackGateway;
 use opengoose_teams::scheduler;
 use opengoose_telegram::TelegramGateway;
-use opengoose_tui::{AppMode, TuiTracingLayer};
-use opengoose_types::EventBus;
+use opengoose_tui::{AppMode, ComposerRequest, TuiTracingLayer};
+use opengoose_types::{AppEventKind, EventBus};
 
 /// Helper to push a gateway + bridge pair.
 fn register(
@@ -174,6 +174,39 @@ fn spawn_periodic_cleanup(engine: Arc<Engine>, cancel: CancellationToken) {
     });
 }
 
+fn spawn_tui_composer_handler(
+    engine: Arc<Engine>,
+    event_bus: EventBus,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<ComposerRequest>,
+    cancel: CancellationToken,
+) {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                request = rx.recv() => {
+                    let Some(request) = request else {
+                        break;
+                    };
+                    if let Err(e) = engine
+                        .process_message_streaming(
+                            &request.session_key,
+                            Some("operator"),
+                            &request.content,
+                        )
+                        .await
+                    {
+                        event_bus.emit(AppEventKind::Error {
+                            context: "tui_compose".into(),
+                            message: e.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+    });
+}
+
 pub async fn execute() -> Result<()> {
     let event_bus = EventBus::new(256);
 
@@ -206,6 +239,13 @@ pub async fn execute() -> Result<()> {
     // Create the pairing channel upfront so the TUI can trigger pairing
     // code generation in both Normal and Setup→Normal flows.
     let (pairing_tx, pairing_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    let (composer_tx, composer_rx) = tokio::sync::mpsc::unbounded_channel::<ComposerRequest>();
+    spawn_tui_composer_handler(
+        engine.clone(),
+        event_bus.clone(),
+        composer_rx,
+        cancel.clone(),
+    );
 
     let resolver = CredentialResolver::new()?;
     let (gateways, bridges) = collect_gateways(&resolver, engine.clone(), &event_bus).await;
@@ -223,6 +263,7 @@ pub async fn execute() -> Result<()> {
                 AppMode::Setup,
                 Some(tx),
                 Some(pairing_tx),
+                Some(composer_tx.clone()),
             )
             .await
         });
@@ -259,8 +300,15 @@ pub async fn execute() -> Result<()> {
         start_gateways(gateways, bridges, cancel.clone()).await?;
         spawn_periodic_cleanup(engine.clone(), cancel.clone());
         scheduler::spawn_scheduler(engine.db().clone(), event_bus.clone(), cancel.clone());
-
-        opengoose_tui::run_tui(event_bus, cancel, AppMode::Normal, None, Some(pairing_tx)).await?;
+        opengoose_tui::run_tui(
+            event_bus,
+            cancel,
+            AppMode::Normal,
+            None,
+            Some(pairing_tx),
+            Some(composer_tx),
+        )
+        .await?;
     }
 
     Ok(())

--- a/crates/opengoose-tui/src/app/event_handler.rs
+++ b/crates/opengoose-tui/src/app/event_handler.rs
@@ -414,12 +414,13 @@ mod tests {
             message: "timed out while waiting".into(),
         }));
         assert_eq!(app.events.back().unwrap().level, EventLevel::Error);
-        assert!(app
-            .status_notice
-            .as_ref()
-            .unwrap()
-            .message
-            .contains("timed out"));
+        assert!(
+            app.status_notice
+                .as_ref()
+                .unwrap()
+                .message
+                .contains("timed out")
+        );
     }
 
     #[test]
@@ -491,11 +492,12 @@ mod tests {
         app.tick();
 
         assert!(app.status_notice.is_some());
-        assert!(app
-            .status_notice
-            .as_ref()
-            .unwrap()
-            .message
-            .contains("OAuth failed"));
+        assert!(
+            app.status_notice
+                .as_ref()
+                .unwrap()
+                .message
+                .contains("OAuth failed")
+        );
     }
 }

--- a/crates/opengoose-tui/src/app/state.rs
+++ b/crates/opengoose-tui/src/app/state.rs
@@ -9,10 +9,15 @@ use opengoose_secrets::{SecretStore, default_store};
 use opengoose_types::{Platform, SessionKey};
 use tokio::sync::{mpsc, oneshot};
 
+use crate::ComposerRequest;
+
 pub(crate) const MAX_MESSAGES: usize = 1000;
 pub(crate) const MAX_EVENTS: usize = 2000;
 const SESSION_HISTORY_LIMIT: usize = 200;
 const SESSION_LIST_LIMIT: i64 = 100;
+const COMPOSER_HISTORY_LIMIT: usize = 50;
+const LOCAL_COMPOSER_PLATFORM: &str = "tui";
+const LOCAL_COMPOSER_SESSION_ID: &str = "local";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AppMode {
@@ -67,6 +72,131 @@ pub struct SessionListEntry {
 pub struct StatusNotice {
     pub message: String,
     pub level: EventLevel,
+}
+
+pub struct ComposerState {
+    pub input: String,
+    pub cursor: usize,
+    pub history: VecDeque<String>,
+    pub history_index: Option<usize>,
+    pub history_draft: Option<String>,
+}
+
+impl ComposerState {
+    pub(crate) fn new() -> Self {
+        Self {
+            input: String::new(),
+            cursor: 0,
+            history: VecDeque::new(),
+            history_index: None,
+            history_draft: None,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.input.clear();
+        self.cursor = 0;
+        self.history_index = None;
+        self.history_draft = None;
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        self.history_index = None;
+        self.history_draft = None;
+        let index = byte_index_for_char(&self.input, self.cursor);
+        self.input.insert(index, c);
+        self.cursor += 1;
+    }
+
+    pub fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        self.history_index = None;
+        self.history_draft = None;
+        let end = byte_index_for_char(&self.input, self.cursor);
+        let start = byte_index_for_char(&self.input, self.cursor - 1);
+        self.input.replace_range(start..end, "");
+        self.cursor -= 1;
+    }
+
+    pub fn delete(&mut self) {
+        if self.cursor >= self.input.chars().count() {
+            return;
+        }
+        self.history_index = None;
+        self.history_draft = None;
+        let start = byte_index_for_char(&self.input, self.cursor);
+        let end = byte_index_for_char(&self.input, self.cursor + 1);
+        self.input.replace_range(start..end, "");
+    }
+
+    pub fn move_left(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    pub fn move_right(&mut self) {
+        self.cursor = (self.cursor + 1).min(self.input.chars().count());
+    }
+
+    pub fn move_home(&mut self) {
+        self.cursor = 0;
+    }
+
+    pub fn move_end(&mut self) {
+        self.cursor = self.input.chars().count();
+    }
+
+    pub fn push_history(&mut self, entry: String) {
+        if entry.is_empty() {
+            return;
+        }
+        self.history.retain(|existing| existing != &entry);
+        self.history.push_back(entry);
+        while self.history.len() > COMPOSER_HISTORY_LIMIT {
+            self.history.pop_front();
+        }
+        self.history_index = None;
+        self.history_draft = None;
+    }
+
+    pub fn history_previous(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+
+        match self.history_index {
+            Some(0) => {}
+            Some(index) => {
+                self.history_index = Some(index - 1);
+            }
+            None => {
+                self.history_draft = Some(self.input.clone());
+                self.history_index = Some(self.history.len() - 1);
+            }
+        }
+
+        if let Some(index) = self.history_index {
+            self.input = self.history[index].clone();
+            self.cursor = self.input.chars().count();
+        }
+    }
+
+    pub fn history_next(&mut self) {
+        let Some(index) = self.history_index else {
+            return;
+        };
+
+        if index + 1 < self.history.len() {
+            self.history_index = Some(index + 1);
+            self.input = self.history[index + 1].clone();
+        } else {
+            self.history_index = None;
+            self.input = self.history_draft.take().unwrap_or_default();
+        }
+
+        self.cursor = self.input.chars().count();
+    }
 }
 
 pub struct SecretInputState {
@@ -205,6 +335,7 @@ pub struct App {
     pub events: VecDeque<EventEntry>,
     pub sessions: Vec<SessionListEntry>,
     pub active_panel: Panel,
+    pub composer: ComposerState,
     pub messages_scroll: usize,
     pub events_scroll: usize,
     pub sessions_scroll: usize,
@@ -221,6 +352,7 @@ pub struct App {
     pub connected_platforms: HashSet<Platform>,
     pub active_sessions: HashSet<SessionKey>,
     pub messages_area_height: usize,
+    pub messages_area_width: usize,
     pub events_area_height: usize,
     pub sessions_area_height: usize,
     pub should_quit: bool,
@@ -238,6 +370,7 @@ pub struct App {
     pub model_loading_rx: Option<oneshot::Receiver<Vec<String>>>,
     /// Receiver for async OAuth completion.
     pub oauth_done_rx: Option<oneshot::Receiver<anyhow::Result<()>>>,
+    pub(crate) composer_tx: Option<mpsc::UnboundedSender<ComposerRequest>>,
     pub(crate) store: Arc<dyn SecretStore>,
     pub(crate) config_path: Option<PathBuf>,
     pub(crate) session_store: Option<Arc<SessionStore>>,
@@ -266,6 +399,7 @@ impl App {
             events: VecDeque::new(),
             sessions: Vec::new(),
             active_panel: Panel::Messages,
+            composer: ComposerState::new(),
             messages_scroll: 0,
             events_scroll: 0,
             sessions_scroll: 0,
@@ -282,6 +416,7 @@ impl App {
             connected_platforms: HashSet::new(),
             active_sessions: HashSet::new(),
             messages_area_height: 0,
+            messages_area_width: 0,
             events_area_height: 0,
             sessions_area_height: 0,
             should_quit: false,
@@ -294,6 +429,7 @@ impl App {
             provider_loading_rx: None,
             model_loading_rx: None,
             oauth_done_rx: None,
+            composer_tx: None,
             store,
             config_path,
             session_store: None,
@@ -310,6 +446,16 @@ impl App {
                 self.set_status_notice(message, EventLevel::Error);
             }
         }
+    }
+
+    pub fn set_composer_tx(&mut self, composer_tx: mpsc::UnboundedSender<ComposerRequest>) {
+        self.composer_tx = Some(composer_tx);
+    }
+
+    pub fn composer_session_key(&self) -> SessionKey {
+        self.selected_session
+            .clone()
+            .unwrap_or_else(Self::default_composer_session_key)
     }
 
     pub fn attach_session_store(&mut self, session_store: Arc<SessionStore>) {
@@ -457,6 +603,37 @@ impl App {
     pub fn set_agent_status(&mut self, status: AgentStatus, session_key: Option<SessionKey>) {
         self.agent_status = status;
         self.agent_status_session = session_key;
+    }
+
+    pub fn submit_composer(&mut self) {
+        let content = self.composer.input.clone();
+        if content.trim().is_empty() {
+            return;
+        }
+        let session_key = self.composer_session_key();
+
+        let Some(tx) = &self.composer_tx else {
+            let message = "Message sending is unavailable in the current TUI mode.".to_string();
+            self.push_event(&message, EventLevel::Error);
+            self.set_status_notice(message, EventLevel::Error);
+            return;
+        };
+
+        if tx
+            .send(ComposerRequest {
+                session_key,
+                content: content.clone(),
+            })
+            .is_err()
+        {
+            let message = "Failed to submit the message to the local engine.".to_string();
+            self.push_event(&message, EventLevel::Error);
+            self.set_status_notice(message, EventLevel::Error);
+            return;
+        }
+
+        self.composer.push_history(content);
+        self.composer.clear();
     }
 
     pub fn focus_sessions(&mut self) {
@@ -654,6 +831,21 @@ impl App {
             .cloned()
             .unwrap_or_default();
     }
+
+    fn default_composer_session_key() -> SessionKey {
+        SessionKey::direct(
+            Platform::Custom(LOCAL_COMPOSER_PLATFORM.to_string()),
+            LOCAL_COMPOSER_SESSION_ID,
+        )
+    }
+}
+
+fn byte_index_for_char(input: &str, char_idx: usize) -> usize {
+    input
+        .char_indices()
+        .nth(char_idx)
+        .map(|(idx, _)| idx)
+        .unwrap_or(input.len())
 }
 
 #[cfg(test)]
@@ -668,6 +860,21 @@ mod tests {
         assert!(s.status_message.is_none());
         assert!(s.title.is_none());
         assert!(s.is_secret);
+    }
+
+    #[test]
+    fn test_composer_state_editing_clears_history_navigation() {
+        let mut composer = ComposerState::new();
+        composer.push_history("alpha".into());
+        composer.push_history("beta".into());
+        composer.history_previous();
+        assert_eq!(composer.input, "beta");
+
+        composer.insert_char('!');
+
+        assert_eq!(composer.input, "beta!");
+        assert!(composer.history_index.is_none());
+        assert!(composer.history_draft.is_none());
     }
 
     #[test]
@@ -820,6 +1027,33 @@ mod tests {
         assert!(app.active_sessions.is_empty());
         assert!(app.active_teams.is_empty());
         assert!(app.cached_providers.is_empty());
+        assert_eq!(
+            app.composer_session_key(),
+            SessionKey::direct(Platform::Custom("tui".into()), "local")
+        );
+    }
+
+    #[test]
+    fn test_submit_composer_uses_local_session_when_none_selected() {
+        let mut app = App::new(AppMode::Normal, None, None);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.set_composer_tx(tx);
+        app.composer.input = "hello".into();
+        app.composer.cursor = 5;
+
+        app.submit_composer();
+
+        let request = rx.try_recv().unwrap();
+        assert_eq!(
+            request.session_key,
+            SessionKey::direct(Platform::Custom("tui".into()), "local")
+        );
+        assert_eq!(request.content, "hello");
+        assert!(app.composer.input.is_empty());
+        assert_eq!(
+            app.composer.history.back().map(String::as_str),
+            Some("hello")
+        );
     }
 
     #[test]

--- a/crates/opengoose-tui/src/input.rs
+++ b/crates/opengoose-tui/src/input.rs
@@ -35,37 +35,72 @@ pub fn handle_key(app: &mut App, key: KeyEvent) {
     }
 
     // Priority 6: Normal mode
-    match (key.code, key.modifiers) {
-        (KeyCode::Char('q'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
-            app.should_quit = true;
+    if key.modifiers.contains(KeyModifiers::CONTROL) {
+        match key.code {
+            KeyCode::Char('q') => app.should_quit = true,
+            KeyCode::Char('n') => app.request_new_session(),
+            KeyCode::Char('o') => {
+                app.command_palette.visible = true;
+                app.command_palette.input.clear();
+                app.command_palette.selected = 0;
+            }
+            _ => {}
         }
-        (KeyCode::Char('n'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
-            app.request_new_session();
-        }
-        (KeyCode::Char('o'), modifiers) if modifiers.contains(KeyModifiers::CONTROL) => {
-            app.command_palette.visible = true;
-            app.command_palette.input.clear();
-            app.command_palette.selected = 0;
-        }
-        (KeyCode::Char('q'), _) => app.should_quit = true,
-        (KeyCode::Tab, modifiers) if modifiers.contains(KeyModifiers::SHIFT) => {
+        return;
+    }
+
+    match key.code {
+        KeyCode::Tab if key.modifiers.contains(KeyModifiers::SHIFT) => {
             app.active_panel = match app.active_panel {
                 Panel::Sessions => Panel::Events,
                 Panel::Messages => Panel::Sessions,
                 Panel::Events => Panel::Messages,
             };
         }
-        (KeyCode::Tab, _) => {
+        KeyCode::Tab => {
             app.active_panel = match app.active_panel {
                 Panel::Sessions => Panel::Messages,
                 Panel::Messages => Panel::Events,
                 Panel::Events => Panel::Sessions,
             };
         }
-        (KeyCode::Char('j'), _) | (KeyCode::Down, _) => scroll_down(app),
-        (KeyCode::Char('k'), _) | (KeyCode::Up, _) => scroll_up(app),
-        (KeyCode::Char('G'), _) => scroll_to_bottom(app),
-        (KeyCode::Char('g'), _) => scroll_to_top(app),
+        _ if app.active_panel == Panel::Messages => handle_messages_key(app, key),
+        _ => handle_navigation_key(app, key),
+    }
+}
+
+fn handle_messages_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Enter => app.submit_composer(),
+        KeyCode::Left => app.composer.move_left(),
+        KeyCode::Right => app.composer.move_right(),
+        KeyCode::Home => app.composer.move_home(),
+        KeyCode::End => app.composer.move_end(),
+        KeyCode::Backspace => app.composer.backspace(),
+        KeyCode::Delete => app.composer.delete(),
+        KeyCode::Up => app.composer.history_previous(),
+        KeyCode::Down => app.composer.history_next(),
+        KeyCode::PageUp => page_up(app),
+        KeyCode::PageDown => page_down(app),
+        KeyCode::Char(c)
+            if !key
+                .modifiers
+                .intersects(KeyModifiers::ALT | KeyModifiers::SUPER) =>
+        {
+            app.composer.insert_char(c);
+        }
+        _ => {}
+    }
+}
+
+fn handle_navigation_key(app: &mut App, key: KeyEvent) {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => scroll_down(app),
+        KeyCode::Char('k') | KeyCode::Up => scroll_up(app),
+        KeyCode::PageUp => page_up(app),
+        KeyCode::PageDown => page_down(app),
+        KeyCode::Char('G') => scroll_to_bottom(app),
+        KeyCode::Char('g') => scroll_to_top(app),
         _ => {}
     }
 }
@@ -256,6 +291,54 @@ fn scroll_to_top(app: &mut App) {
     }
 }
 
+fn page_up(app: &mut App) {
+    match app.active_panel {
+        Panel::Sessions => {
+            let step = page_step(app.sessions_area_height);
+            app.select_session(app.selected_session_index.saturating_sub(step));
+        }
+        Panel::Messages => {
+            app.messages_scroll = app
+                .messages_scroll
+                .saturating_sub(page_step(app.messages_area_height));
+        }
+        Panel::Events => {
+            app.events_scroll = app
+                .events_scroll
+                .saturating_sub(page_step(app.events_area_height));
+        }
+    }
+}
+
+fn page_down(app: &mut App) {
+    match app.active_panel {
+        Panel::Sessions => {
+            if app.sessions.is_empty() {
+                return;
+            }
+            let step = page_step(app.sessions_area_height);
+            app.select_session((app.selected_session_index + step).min(app.sessions.len() - 1));
+        }
+        Panel::Messages => {
+            let max = app
+                .messages_line_count()
+                .saturating_sub(app.messages_area_height);
+            app.messages_scroll =
+                (app.messages_scroll + page_step(app.messages_area_height)).min(max);
+        }
+        Panel::Events => {
+            let max = app
+                .events_line_count()
+                .saturating_sub(app.events_area_height);
+            app.events_scroll = (app.events_scroll + page_step(app.events_area_height)).min(max);
+        }
+    }
+}
+
+fn page_step(height: usize) -> usize {
+    height.saturating_sub(1).max(1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,9 +365,15 @@ mod tests {
     // ── Normal mode tests ──────────────────────────────
 
     #[test]
-    fn test_handle_key_quit() {
+    fn test_handle_key_ctrl_quit() {
         let mut app = test_app();
-        handle_key(&mut app, key(KeyCode::Char('q')));
+        let ctrl_q = KeyEvent {
+            code: KeyCode::Char('q'),
+            modifiers: KeyModifiers::CONTROL,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        };
+        handle_key(&mut app, ctrl_q);
         assert!(app.should_quit);
     }
 
@@ -371,36 +460,56 @@ mod tests {
         app.active_panel = Panel::Messages;
         app.messages_scroll = 0;
         app.messages_area_height = 100; // Large area, nothing to scroll
-        handle_key(&mut app, key(KeyCode::Down));
+        handle_key(&mut app, key(KeyCode::PageDown));
         assert_eq!(app.messages_scroll, 0);
     }
 
     #[test]
-    fn test_scroll_up_messages_panel() {
+    fn test_up_down_navigate_composer_history() {
         let mut app = test_app();
         app.active_panel = Panel::Messages;
-        app.messages_scroll = 5;
+        app.composer.push_history("older".into());
+        app.composer.push_history("latest".into());
         handle_key(&mut app, key(KeyCode::Up));
-        assert_eq!(app.messages_scroll, 4);
+        assert_eq!(app.composer.input, "latest");
+        handle_key(&mut app, key(KeyCode::Up));
+        assert_eq!(app.composer.input, "older");
+        handle_key(&mut app, key(KeyCode::Down));
+        assert_eq!(app.composer.input, "latest");
     }
 
     #[test]
     fn test_scroll_to_top_messages() {
         let mut app = test_app();
         app.active_panel = Panel::Messages;
+        app.messages_area_height = 10;
         app.messages_scroll = 10;
-        handle_key(&mut app, key(KeyCode::Char('g')));
-        assert_eq!(app.messages_scroll, 0);
+        handle_key(&mut app, key(KeyCode::PageUp));
+        assert_eq!(app.messages_scroll, 1);
     }
 
     #[test]
     fn test_scroll_to_bottom_messages() {
         let mut app = test_app();
         app.active_panel = Panel::Messages;
-        app.messages_area_height = 10;
-        // No messages, so scroll stays 0
-        handle_key(&mut app, key(KeyCode::Char('G')));
-        assert_eq!(app.messages_scroll, 0);
+        app.messages_area_height = 3;
+        app.messages_area_width = 20;
+        for content in [
+            "one two three four five six seven eight nine ten",
+            "eleven twelve thirteen fourteen fifteen",
+            "sixteen seventeen eighteen nineteen twenty",
+        ] {
+            app.messages.push_back(crate::app::MessageEntry {
+                session_key: opengoose_types::SessionKey::dm(
+                    opengoose_types::Platform::Discord,
+                    "u",
+                ),
+                author: "a".into(),
+                content: content.into(),
+            });
+        }
+        handle_key(&mut app, key(KeyCode::PageDown));
+        assert!(app.messages_scroll > 0);
     }
 
     #[test]
@@ -409,6 +518,74 @@ mod tests {
         handle_key(&mut app, key(KeyCode::F(12)));
         assert!(!app.should_quit);
         assert_eq!(app.active_panel, Panel::Messages);
+    }
+
+    #[test]
+    fn test_messages_panel_typing_edits_composer() {
+        let mut app = test_app();
+        handle_key(&mut app, key(KeyCode::Char('h')));
+        handle_key(&mut app, key(KeyCode::Char('i')));
+        assert_eq!(app.composer.input, "hi");
+        assert_eq!(app.composer.cursor, 2);
+    }
+
+    #[test]
+    fn test_messages_panel_q_does_not_quit() {
+        let mut app = test_app();
+        handle_key(&mut app, key(KeyCode::Char('q')));
+        assert!(!app.should_quit);
+        assert_eq!(app.composer.input, "q");
+    }
+
+    #[test]
+    fn test_messages_panel_cursor_movement_and_backspace() {
+        let mut app = test_app();
+        app.composer.input = "helo".into();
+        app.composer.cursor = 4;
+        handle_key(&mut app, key(KeyCode::Left));
+        handle_key(&mut app, key(KeyCode::Char('l')));
+        handle_key(&mut app, key(KeyCode::Backspace));
+        assert_eq!(app.composer.input, "helo");
+        assert_eq!(app.composer.cursor, 3);
+    }
+
+    #[test]
+    fn test_messages_panel_home_end_move_cursor() {
+        let mut app = test_app();
+        app.composer.input = "hello".into();
+        app.composer.cursor = 2;
+
+        handle_key(&mut app, key(KeyCode::End));
+        assert_eq!(app.composer.cursor, 5);
+
+        handle_key(&mut app, key(KeyCode::Home));
+        assert_eq!(app.composer.cursor, 0);
+    }
+
+    #[test]
+    fn test_messages_panel_enter_submits_composer() {
+        let mut app = test_app();
+        let session_key =
+            opengoose_types::SessionKey::dm(opengoose_types::Platform::Discord, "user-1");
+        app.sessions.push(crate::app::SessionListEntry {
+            session_key: session_key.clone(),
+            active_team: None,
+            created_at: None,
+            updated_at: None,
+            is_active: true,
+        });
+        app.select_session(0);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        app.set_composer_tx(tx);
+        app.composer.input = "hello".into();
+        app.composer.cursor = 5;
+
+        handle_key(&mut app, key(KeyCode::Enter));
+
+        let request = rx.try_recv().unwrap();
+        assert_eq!(request.session_key, session_key);
+        assert_eq!(request.content, "hello");
+        assert!(app.composer.input.is_empty());
     }
 
     // ── Setup mode tests ───────────────────────────────

--- a/crates/opengoose-tui/src/lib.rs
+++ b/crates/opengoose-tui/src/lib.rs
@@ -14,10 +14,16 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use opengoose_types::EventBus;
+use opengoose_types::{EventBus, SessionKey};
 use ratatui::prelude::*;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone)]
+pub struct ComposerRequest {
+    pub session_key: SessionKey,
+    pub content: String,
+}
 
 /// Process a single TUI event, returning `true` if the loop should exit.
 fn process_event(app: &mut app::App, evt: event::TuiEvent) -> bool {
@@ -43,6 +49,7 @@ async fn run_loop<B: Backend<Error: Send + Sync + 'static>>(
             let layout = ui::layout::create_layout(size.into());
             app.sessions_area_height = layout.sessions.height.saturating_sub(2) as usize;
             app.messages_area_height = layout.messages.height.saturating_sub(2) as usize;
+            app.messages_area_width = layout.messages.width.saturating_sub(2) as usize;
             app.events_area_height = layout.events.height.saturating_sub(2) as usize;
         }
 
@@ -62,6 +69,7 @@ pub async fn run_tui(
     mode: AppMode,
     token_sender: Option<oneshot::Sender<String>>,
     pairing_tx: Option<mpsc::UnboundedSender<()>>,
+    composer_tx: Option<mpsc::UnboundedSender<ComposerRequest>>,
 ) -> Result<()> {
     // Install panic hook that restores terminal
     let original_hook = std::panic::take_hook();
@@ -78,6 +86,9 @@ pub async fn run_tui(
     let mut terminal = Terminal::new(backend)?;
 
     let mut app = app::App::new(mode, token_sender, pairing_tx);
+    if let Some(composer_tx) = composer_tx {
+        app.set_composer_tx(composer_tx);
+    }
     app.initialize_runtime_state();
     let mut events = event::EventHandler::new(event_bus.subscribe(), cancel.clone());
 
@@ -142,7 +153,7 @@ mod tests {
         let mut app = test_app();
         let key = KeyEvent {
             code: KeyCode::Char('q'),
-            modifiers: KeyModifiers::NONE,
+            modifiers: KeyModifiers::CONTROL,
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         };

--- a/crates/opengoose-tui/src/ui/composer.rs
+++ b/crates/opengoose-tui/src/ui/composer.rs
@@ -1,0 +1,112 @@
+use ratatui::Frame;
+use ratatui::layout::{Position, Rect};
+use ratatui::text::Span;
+use ratatui::widgets::{Block, Borders, Paragraph};
+
+use crate::app::{App, Panel};
+use crate::theme;
+
+pub fn render(f: &mut Frame, app: &App, area: Rect) {
+    let is_active = app.active_panel == Panel::Messages;
+    let title = format!(
+        " Compose to {} ",
+        App::format_session_label(&app.composer_session_key())
+    );
+
+    let block = Block::default()
+        .title(Span::styled(
+            title,
+            if is_active {
+                theme::title()
+            } else {
+                theme::muted()
+            },
+        ))
+        .borders(Borders::ALL)
+        .border_style(theme::border(is_active));
+
+    let inner = block.inner(area);
+    let width = inner.width as usize;
+    let offset = if width == 0 || app.composer.cursor < width {
+        0
+    } else {
+        app.composer.cursor + 1 - width
+    };
+
+    let text = app
+        .composer
+        .input
+        .chars()
+        .skip(offset)
+        .take(width)
+        .collect::<String>();
+    let paragraph = Paragraph::new(text).style(theme::bar()).block(block);
+    f.render_widget(paragraph, area);
+
+    if !is_active
+        || inner.width == 0
+        || inner.height == 0
+        || app.secret_input.visible
+        || app.provider_select.visible
+        || app.model_select.visible
+        || app.command_palette.visible
+    {
+        return;
+    }
+
+    let cursor_x = inner.x
+        + app
+            .composer
+            .cursor
+            .saturating_sub(offset)
+            .min(width.saturating_sub(1)) as u16;
+    f.set_cursor_position(Position {
+        x: cursor_x,
+        y: inner.y,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{AppMode, SessionListEntry};
+    use opengoose_types::{Platform, SessionKey};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    #[test]
+    fn test_render_sets_cursor_for_active_session() {
+        let backend = TestBackend::new(60, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new(AppMode::Normal, None, None);
+        app.sessions.push(SessionListEntry {
+            session_key: SessionKey::direct(Platform::Discord, "user-1"),
+            active_team: None,
+            created_at: None,
+            updated_at: None,
+            is_active: true,
+        });
+        app.select_session(0);
+        app.composer.input = "hello".into();
+        app.composer.cursor = 5;
+
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+        terminal
+            .backend_mut()
+            .assert_cursor_position(Position { x: 6, y: 1 });
+    }
+
+    #[test]
+    fn test_render_sets_cursor_for_local_composer() {
+        let backend = TestBackend::new(60, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new(AppMode::Normal, None, None);
+        app.composer.input = "hello".into();
+        app.composer.cursor = 5;
+
+        terminal.draw(|f| render(f, &app, f.area())).unwrap();
+        terminal
+            .backend_mut()
+            .assert_cursor_position(Position { x: 6, y: 1 });
+    }
+}

--- a/crates/opengoose-tui/src/ui/help_bar.rs
+++ b/crates/opengoose-tui/src/ui/help_bar.rs
@@ -3,20 +3,34 @@ use ratatui::layout::Rect;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 
-use crate::app::{App, AppMode};
+use crate::app::{App, AppMode, Panel};
 use crate::theme;
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let keys: &[(&str, &str)] = match app.mode {
         AppMode::Setup => &[("Enter", "Enter token"), ("q", "Quit")],
-        AppMode::Normal => &[
-            ("Ctrl+N", "New"),
-            ("Ctrl+O", "Cmd"),
-            ("Tab", "Pane"),
-            ("j/k", "Move"),
-            ("G/g", "Ends"),
-            ("Ctrl+Q", "Quit"),
-        ],
+        AppMode::Normal => match app.active_panel {
+            Panel::Messages => &[
+                ("Ctrl+N", "New"),
+                ("Ctrl+O", "Cmd"),
+                ("Tab", "Pane"),
+                ("Left/Right", "Cursor"),
+                ("Home/End", "Ends"),
+                ("Enter", "Send"),
+                ("Up/Down", "Hist"),
+                ("PgUp/Dn", "Scroll"),
+                ("Ctrl+Q", "Quit"),
+            ],
+            _ => &[
+                ("Ctrl+N", "New"),
+                ("Ctrl+O", "Cmd"),
+                ("Tab", "Pane"),
+                ("j/k", "Move"),
+                ("PgUp/Dn", "Page"),
+                ("G/g", "Ends"),
+                ("Ctrl+Q", "Quit"),
+            ],
+        },
     };
 
     let mut spans = Vec::new();
@@ -57,13 +71,14 @@ mod tests {
     #[test]
     fn test_render_normal_mode() {
         let app = App::new(AppMode::Normal, None, None);
-        let backend = TestBackend::new(80, 1);
+        let backend = TestBackend::new(120, 1);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| render(f, &app, f.area())).unwrap();
         let text = row_text(&terminal, 0);
         assert!(text.contains("Ctrl+N"));
         assert!(text.contains("Ctrl+O"));
         assert!(text.contains("Tab"));
+        assert!(text.contains("Enter"));
         assert!(text.contains("Ctrl+Q"));
     }
 

--- a/crates/opengoose-tui/src/ui/layout.rs
+++ b/crates/opengoose-tui/src/ui/layout.rs
@@ -5,6 +5,7 @@ pub struct AppLayout {
     pub sessions: Rect,
     pub messages: Rect,
     pub events: Rect,
+    pub composer: Rect,
     pub help_bar: Rect,
 }
 
@@ -14,6 +15,7 @@ pub fn create_layout(area: Rect) -> AppLayout {
         .constraints([
             Constraint::Length(1), // status bar
             Constraint::Min(5),    // body
+            Constraint::Length(3), // composer
             Constraint::Length(1), // help bar
         ])
         .split(area);
@@ -32,7 +34,8 @@ pub fn create_layout(area: Rect) -> AppLayout {
         sessions: body[0],
         messages: body[1],
         events: body[2],
-        help_bar: vertical[2],
+        composer: vertical[2],
+        help_bar: vertical[3],
     }
 }
 
@@ -47,11 +50,12 @@ mod tests {
 
         assert_eq!(layout.status_bar.height, 1);
         assert_eq!(layout.status_bar.y, 0);
+        assert_eq!(layout.composer.height, 3);
         assert_eq!(layout.help_bar.height, 1);
         assert_eq!(layout.help_bar.y, 39);
-        assert_eq!(layout.sessions.height, 38);
-        assert_eq!(layout.messages.height, 38);
-        assert_eq!(layout.events.height, 38);
+        assert_eq!(layout.sessions.height, 35);
+        assert_eq!(layout.messages.height, 35);
+        assert_eq!(layout.events.height, 35);
         assert!(layout.messages.width > layout.events.width);
         assert_eq!(
             layout.sessions.width + layout.messages.width + layout.events.width,
@@ -64,7 +68,8 @@ mod tests {
         let area = Rect::new(0, 0, 20, 10);
         let layout = create_layout(area);
         assert_eq!(layout.status_bar.height, 1);
+        assert_eq!(layout.composer.height, 3);
         assert_eq!(layout.help_bar.height, 1);
-        assert_eq!(layout.messages.height, 8);
+        assert_eq!(layout.messages.height, 5);
     }
 }

--- a/crates/opengoose-tui/src/ui/messages.rs
+++ b/crates/opengoose-tui/src/ui/messages.rs
@@ -1,52 +1,183 @@
 use ratatui::Frame;
-use ratatui::buffer::Buffer;
-use ratatui::layout::{Position, Rect};
-use ratatui::style::{Modifier, Style};
+use ratatui::layout::Rect;
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Paragraph, Widget};
+use ratatui::widgets::{Block, Borders, Paragraph};
 
 use crate::app::{App, MessageEntry, Panel};
 use crate::theme;
 
-struct SessionGroup<'a> {
-    label: String,
-    messages: Vec<&'a MessageEntry>,
+fn author_color(author: &str) -> ratatui::style::Color {
+    if author == "goose" {
+        theme::SUCCESS
+    } else {
+        theme::ACCENT
+    }
 }
 
-fn group_messages_by_session(app: &App) -> Vec<SessionGroup<'_>> {
-    let mut groups: Vec<SessionGroup<'_>> = Vec::new();
-    for msg in app.messages.iter() {
-        let label = msg.session_key.to_string();
-        if groups.last().is_none_or(|g| g.label != label) {
-            groups.push(SessionGroup {
-                label,
-                messages: vec![msg],
-            });
+fn split_long_word(word: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let mut chunks = Vec::new();
+    let chars = word.chars().collect::<Vec<_>>();
+    for chunk in chars.chunks(width) {
+        chunks.push(chunk.iter().collect());
+    }
+    chunks
+}
+
+fn wrap_segment(segment: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return Vec::new();
+    }
+    if segment.trim().is_empty() {
+        return vec![String::new()];
+    }
+
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in segment.split_whitespace() {
+        let word_width = word.chars().count();
+        if current.is_empty() {
+            if word_width <= width {
+                current.push_str(word);
+                continue;
+            }
+
+            lines.extend(split_long_word(word, width));
+            continue;
+        }
+
+        let current_width = current.chars().count();
+        if current_width + 1 + word_width <= width {
+            current.push(' ');
+            current.push_str(word);
+            continue;
+        }
+
+        lines.push(std::mem::take(&mut current));
+        if word_width <= width {
+            current.push_str(word);
         } else {
-            groups
-                .last_mut()
-                .expect("groups is non-empty in else branch")
-                .messages
-                .push(msg);
+            let mut chunks = split_long_word(word, width);
+            if let Some(last) = chunks.pop() {
+                lines.extend(chunks);
+                current = last;
+            }
         }
     }
-    groups
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+
+    lines
 }
 
-/// Total height of all session groups (Block borders + content + gaps).
-pub fn total_content_height(app: &App) -> usize {
-    if app.messages.is_empty() {
-        return 1;
+fn wrap_text(content: &str, width: usize) -> Vec<String> {
+    let normalized = content.replace('\r', "");
+    let mut lines = Vec::new();
+
+    for segment in normalized.split('\n') {
+        lines.extend(wrap_segment(segment, width));
     }
-    let groups = group_messages_by_session(app);
-    let mut h: usize = 0;
-    for (i, g) in groups.iter().enumerate() {
-        h += g.messages.len() + 2; // +2 for top/bottom block borders
-        if i < groups.len() - 1 {
-            h += 1; // gap between groups
+
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+
+    lines
+}
+
+fn render_message_lines(message: &MessageEntry, width: usize) -> Vec<Line<'static>> {
+    if width == 0 {
+        return Vec::new();
+    }
+
+    let prefix = format!("[{}] ", message.author);
+    let prefix_width = prefix.chars().count();
+    let body_style = Style::default().fg(theme::TEXT);
+    let prefix_style = Style::default().fg(author_color(&message.author));
+    let content = message.content.replace('\r', "");
+
+    if width <= prefix_width + 1 {
+        let mut lines = vec![Line::from(Span::styled(
+            prefix.trim_end().to_string(),
+            prefix_style,
+        ))];
+        if content.is_empty() {
+            return lines;
+        }
+        for segment in wrap_text(&content, width.saturating_sub(2).max(1)) {
+            lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(segment, body_style),
+            ]));
+        }
+        return lines;
+    }
+
+    let wrapped = wrap_text(&content, width.saturating_sub(prefix_width).max(1));
+    let indent = " ".repeat(prefix_width);
+
+    let mut lines = Vec::new();
+    if let Some(first) = wrapped.first() {
+        lines.push(Line::from(vec![
+            Span::styled(prefix.clone(), prefix_style),
+            Span::styled(first.clone(), body_style),
+        ]));
+    }
+
+    for segment in wrapped.into_iter().skip(1) {
+        lines.push(Line::from(vec![
+            Span::raw(indent.clone()),
+            Span::styled(segment, body_style),
+        ]));
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            prefix.trim_end().to_string(),
+            prefix_style,
+        )));
+    }
+
+    lines
+}
+
+fn rendered_lines_for_width(app: &App, width: usize) -> Vec<Line<'static>> {
+    if app.messages.is_empty() {
+        return vec![Line::default()];
+    }
+
+    let mut lines = Vec::new();
+    for (index, message) in app.messages.iter().enumerate() {
+        lines.extend(render_message_lines(message, width.max(1)));
+        if index + 1 < app.messages.len() {
+            lines.push(Line::default());
         }
     }
-    h
+
+    if lines.is_empty() {
+        lines.push(Line::default());
+    }
+
+    lines
+}
+
+pub fn total_content_height(app: &App) -> usize {
+    total_content_height_for_width(app, app.messages_area_width as u16)
+}
+
+pub fn total_content_height_for_width(app: &App, width: u16) -> usize {
+    rendered_lines_for_width(app, width as usize).len().max(1)
 }
 
 pub fn render(f: &mut Frame, app: &App, area: Rect) {
@@ -68,7 +199,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         let empty_text = if app.selected_session.is_some() {
             "  No conversation history loaded for this session yet."
         } else {
-            "  Select a session on the left or press Ctrl+N to start one."
+            "  Start typing below to begin a local conversation."
         };
         let empty = Paragraph::new(empty_text)
             .style(theme::muted())
@@ -80,97 +211,13 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let inner = outer_block.inner(area);
     f.render_widget(outer_block, area);
 
-    let groups = group_messages_by_session(app);
-
-    // Calculate total height
-    let total_height = total_content_height(app);
-    if total_height == 0 || inner.width == 0 || inner.height == 0 {
+    if inner.width == 0 || inner.height == 0 {
         return;
     }
 
-    // Render all session groups into a temporary buffer
-    let mut temp_buf = Buffer::empty(Rect {
-        x: 0,
-        y: 0,
-        width: inner.width,
-        height: total_height as u16,
-    });
-
-    let mut y: u16 = 0;
-    for (i, group) in groups.iter().enumerate() {
-        let group_height = group.messages.len() as u16 + 2;
-        let group_rect = Rect {
-            x: 0,
-            y,
-            width: inner.width,
-            height: group_height,
-        };
-
-        let session_block = Block::default()
-            .title(Span::styled(
-                format!(" {} ", group.label),
-                Style::default()
-                    .fg(theme::SECONDARY)
-                    .add_modifier(Modifier::BOLD),
-            ))
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme::SECONDARY));
-
-        let lines: Vec<Line> = group
-            .messages
-            .iter()
-            .map(|msg| {
-                let author_color = if msg.author == "goose" {
-                    theme::SUCCESS
-                } else {
-                    theme::ACCENT
-                };
-                // Strip Discord markdown and collapse newlines for TUI
-                let plain = msg.content.replace("**", "").replace('\n', " ");
-                let content = if plain.chars().count() > 120 {
-                    format!("{}...", plain.chars().take(117).collect::<String>())
-                } else {
-                    plain
-                };
-                Line::from(vec![
-                    Span::styled(
-                        format!("[{}]", msg.author),
-                        Style::default().fg(author_color),
-                    ),
-                    Span::styled(format!(" {}", content), Style::default().fg(theme::TEXT)),
-                ])
-            })
-            .collect();
-
-        let para = Paragraph::new(lines).block(session_block);
-        para.render(group_rect, &mut temp_buf);
-
-        y += group_height;
-        if i < groups.len() - 1 {
-            y += 1; // gap between groups
-        }
-    }
-
-    // Copy visible portion from temp buffer into the frame
-    let scroll = app.messages_scroll;
-    let frame_buf = f.buffer_mut();
-    for dy in 0..inner.height {
-        let src_y = scroll + dy as usize;
-        if src_y >= total_height {
-            break;
-        }
-        for dx in 0..inner.width {
-            if let Some(src_cell) = temp_buf.cell(Position {
-                x: dx,
-                y: src_y as u16,
-            }) && let Some(dst_cell) = frame_buf.cell_mut(Position {
-                x: inner.x + dx,
-                y: inner.y + dy,
-            }) {
-                *dst_cell = src_cell.clone();
-            }
-        }
-    }
+    let lines = rendered_lines_for_width(app, inner.width as usize);
+    let paragraph = Paragraph::new(lines).scroll((app.messages_scroll as u16, 0));
+    f.render_widget(paragraph, inner);
 }
 
 #[cfg(test)]
@@ -182,47 +229,17 @@ mod tests {
     use ratatui::backend::TestBackend;
 
     fn test_app() -> App {
-        App::new(AppMode::Normal, None, None)
+        let mut app = App::new(AppMode::Normal, None, None);
+        app.messages_area_width = 24;
+        app
     }
 
-    fn add_msg(app: &mut App, session: &str, author: &str, content: &str) {
+    fn add_msg(app: &mut App, author: &str, content: &str) {
         app.messages.push_back(MessageEntry {
-            session_key: SessionKey::dm(Platform::Discord, session),
+            session_key: SessionKey::dm(Platform::Discord, "user-1"),
             author: author.into(),
             content: content.into(),
         });
-    }
-
-    #[test]
-    fn test_group_messages_single_session() {
-        let mut app = test_app();
-        add_msg(&mut app, "user1", "alice", "hello");
-        add_msg(&mut app, "user1", "goose", "hi");
-        let groups = group_messages_by_session(&app);
-        assert_eq!(groups.len(), 1);
-        assert_eq!(groups[0].messages.len(), 2);
-    }
-
-    #[test]
-    fn test_group_messages_multiple_sessions() {
-        let mut app = test_app();
-        add_msg(&mut app, "user1", "alice", "hello");
-        add_msg(&mut app, "user2", "bob", "hey");
-        add_msg(&mut app, "user2", "goose", "reply");
-        let groups = group_messages_by_session(&app);
-        assert_eq!(groups.len(), 2);
-        assert_eq!(groups[0].messages.len(), 1);
-        assert_eq!(groups[1].messages.len(), 2);
-    }
-
-    #[test]
-    fn test_group_messages_alternating_sessions() {
-        let mut app = test_app();
-        add_msg(&mut app, "user1", "alice", "a");
-        add_msg(&mut app, "user2", "bob", "b");
-        add_msg(&mut app, "user1", "alice", "c");
-        let groups = group_messages_by_session(&app);
-        assert_eq!(groups.len(), 3); // each change creates a new group
     }
 
     #[test]
@@ -232,24 +249,33 @@ mod tests {
     }
 
     #[test]
-    fn test_total_content_height_one_group() {
+    fn test_total_content_height_includes_message_gap() {
         let mut app = test_app();
-        add_msg(&mut app, "user1", "alice", "hello");
-        add_msg(&mut app, "user1", "goose", "hi");
-        // 2 messages + 2 borders = 4
-        assert_eq!(total_content_height(&app), 4);
+        add_msg(&mut app, "alice", "hello");
+        add_msg(&mut app, "goose", "world");
+
+        assert_eq!(total_content_height(&app), 3);
     }
 
     #[test]
-    fn test_total_content_height_two_groups() {
+    fn test_total_content_height_counts_wrapped_lines() {
         let mut app = test_app();
-        add_msg(&mut app, "user1", "alice", "hello");
-        add_msg(&mut app, "user2", "bob", "hey");
-        // group1: 1 msg + 2 borders = 3
-        // gap: 1
-        // group2: 1 msg + 2 borders = 3
-        // total: 7
-        assert_eq!(total_content_height(&app), 7);
+        app.messages_area_width = 12;
+        add_msg(
+            &mut app,
+            "alice",
+            "this is a much longer message that should wrap across lines",
+        );
+
+        assert!(total_content_height(&app) > 3);
+    }
+
+    #[test]
+    fn test_total_content_height_preserves_newlines() {
+        let mut app = test_app();
+        add_msg(&mut app, "alice", "first line\nsecond line");
+
+        assert_eq!(total_content_height(&app), 2);
     }
 
     #[test]
@@ -257,81 +283,38 @@ mod tests {
         let app = test_app();
         let backend = TestBackend::new(60, 20);
         let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| render(f, &app, f.area())).unwrap();
-        let buf = terminal.backend().buffer().clone();
-        let text: String = (0..buf.area.width)
-            .map(|x| {
-                buf.cell(Position { x, y: 1 })
-                    .unwrap()
-                    .symbol()
-                    .chars()
-                    .next()
-                    .unwrap_or(' ')
-            })
-            .collect();
-        assert!(text.contains("Select a session"));
-    }
 
-    #[test]
-    fn test_render_with_messages() {
-        let mut app = test_app();
-        add_msg(&mut app, "user1", "alice", "hello world");
-        let backend = TestBackend::new(60, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| render(f, &app, f.area())).unwrap();
-        // Just verify it doesn't panic and renders something
-        let buf = terminal.backend().buffer().clone();
-        assert!(buf.area.width > 0);
-    }
-
-    #[test]
-    fn test_render_with_long_message_truncated() {
-        let mut app = test_app();
-        let long_msg = "x".repeat(200);
-        add_msg(&mut app, "user1", "alice", &long_msg);
-        let backend = TestBackend::new(80, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| render(f, &app, f.area())).unwrap();
-        // Should not panic
-    }
-
-    #[test]
-    fn test_render_with_goose_author() {
-        let mut app = test_app();
-        add_msg(&mut app, "user1", "goose", "response");
-        let backend = TestBackend::new(60, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| render(f, &app, f.area())).unwrap();
     }
 
     #[test]
-    fn test_render_with_markdown_content() {
+    fn test_render_wrapped_message() {
         let mut app = test_app();
-        add_msg(&mut app, "user1", "alice", "**bold** text\nnewline");
-        let backend = TestBackend::new(60, 20);
+        add_msg(
+            &mut app,
+            "alice",
+            "line one is long enough to wrap onto the next line in the panel",
+        );
+        let backend = TestBackend::new(30, 12);
         let mut terminal = Terminal::new(backend).unwrap();
+
         terminal.draw(|f| render(f, &app, f.area())).unwrap();
     }
 
     #[test]
     fn test_render_with_scroll() {
         let mut app = test_app();
-        for i in 0..20 {
-            add_msg(&mut app, &format!("user{i}"), "alice", &format!("msg {i}"));
-        }
-        app.messages_scroll = 5;
-        let backend = TestBackend::new(60, 10);
+        app.messages_area_width = 16;
+        app.messages_scroll = 2;
+        add_msg(&mut app, "alice", "one two three four five six seven eight");
+        add_msg(
+            &mut app,
+            "goose",
+            "nine ten eleven twelve thirteen fourteen",
+        );
+        let backend = TestBackend::new(28, 8);
         let mut terminal = Terminal::new(backend).unwrap();
-        terminal.draw(|f| render(f, &app, f.area())).unwrap();
-    }
 
-    #[test]
-    fn test_render_inactive_panel() {
-        let mut app = test_app();
-        app.active_panel = Panel::Events;
-        add_msg(&mut app, "user1", "alice", "hello");
-        let backend = TestBackend::new(60, 20);
-        let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| render(f, &app, f.area())).unwrap();
     }
 }

--- a/crates/opengoose-tui/src/ui/mod.rs
+++ b/crates/opengoose-tui/src/ui/mod.rs
@@ -1,12 +1,13 @@
 mod command_palette;
+mod composer;
 mod events_panel;
 mod help_bar;
 pub(crate) mod layout;
 pub(crate) mod messages;
 mod model_select;
 mod provider_select;
-mod sessions;
 mod secret_input;
+mod sessions;
 mod setup_wizard;
 mod status_bar;
 
@@ -26,6 +27,7 @@ pub fn render_app(f: &mut Frame, app: &App) {
             sessions::render(f, app, chunks.sessions);
             messages::render(f, app, chunks.messages);
             events_panel::render(f, app, chunks.events);
+            composer::render(f, app, chunks.composer);
             help_bar::render(f, app, chunks.help_bar);
 
             if app.command_palette.visible {

--- a/crates/opengoose-tui/src/ui/sessions.rs
+++ b/crates/opengoose-tui/src/ui/sessions.rs
@@ -55,7 +55,10 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
                     Style::default().fg(theme::ACCENT),
                 ),
                 Span::raw(" "),
-                Span::styled(if session.is_active { "●" } else { "○" }, Style::default().fg(status_color)),
+                Span::styled(
+                    if session.is_active { "●" } else { "○" },
+                    Style::default().fg(status_color),
+                ),
                 Span::raw(" "),
                 Span::styled(App::format_session_label(&session.session_key), label_style),
             ];


### PR DESCRIPTION
## Summary
- add a bottom composer to the TUI messages panel with cursor movement, history navigation, and enter-to-send
- wire composer submissions into the local engine, including a local fallback session when no remote session is selected
- wrap message content in the conversation view and add page-based scrolling plus updated panel help/layout

## Testing
- cargo fmt --all --check
- cargo test -p opengoose-tui --lib
- cargo test -p opengoose-cli
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
