### PR TITLE
feat(OPE-53): Integrate Matrix gateway into CLI with adapter tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6376,6 +6376,7 @@ dependencies = [
  "goose",
  "opengoose-core",
  "opengoose-discord",
+ "opengoose-matrix",
  "opengoose-persistence",
  "opengoose-profiles",
  "opengoose-provider-bridge",

--- a/crates/opengoose-cli/Cargo.toml
+++ b/crates/opengoose-cli/Cargo.toml
@@ -14,6 +14,7 @@ opengoose-core = { workspace = true }
 opengoose-discord = { workspace = true }
 opengoose-telegram = { workspace = true }
 opengoose-slack = { workspace = true }
+opengoose-matrix = { workspace = true }
 opengoose-tui = { workspace = true }
 opengoose-secrets = { workspace = true }
 opengoose-profiles = { workspace = true }

--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -8,6 +8,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use goose::gateway::Gateway;
 use opengoose_core::{Engine, GatewayBridge, start_gateways};
 use opengoose_discord::DiscordGateway;
+use opengoose_matrix::MatrixGateway;
 use opengoose_persistence::Database;
 use opengoose_secrets::{CredentialResolver, SecretKey};
 use opengoose_slack::SlackGateway;
@@ -65,6 +66,30 @@ async fn try_telegram(
     Some((gw, bridge))
 }
 
+/// Attempt to create a Matrix gateway from available credentials (requires both homeserver URL and access token).
+async fn try_matrix(
+    resolver: &CredentialResolver,
+    engine: &Arc<Engine>,
+    event_bus: &EventBus,
+) -> Option<(Arc<dyn Gateway>, Arc<GatewayBridge>)> {
+    let homeserver_url = resolver
+        .resolve_async(&SecretKey::MatrixHomeserverUrl)
+        .await
+        .ok()?;
+    let access_token = resolver
+        .resolve_async(&SecretKey::MatrixAccessToken)
+        .await
+        .ok()?;
+    let bridge = Arc::new(GatewayBridge::new(engine.clone()));
+    let gw: Arc<dyn Gateway> = Arc::new(MatrixGateway::new(
+        homeserver_url.value.as_str(),
+        access_token.value.as_str(),
+        bridge.clone(),
+        event_bus.clone(),
+    ));
+    Some((gw, bridge))
+}
+
 /// Attempt to create a Slack gateway from available credentials (requires both tokens).
 async fn try_slack(
     resolver: &CredentialResolver,
@@ -106,6 +131,7 @@ const GATEWAY_FACTORIES: &[GatewayFactoryFn] = &[
     |r, e, b| Box::pin(try_discord(r, e, b)),
     |r, e, b| Box::pin(try_telegram(r, e, b)),
     |r, e, b| Box::pin(try_slack(r, e, b)),
+    |r, e, b| Box::pin(try_matrix(r, e, b)),
 ];
 
 /// Collect all gateways for which credentials are available.
@@ -427,6 +453,8 @@ mod tests {
             ("telegram_bot_token", "telegram-token"),
             ("slack_bot_token", "slack-bot-token"),
             ("slack_app_token", "slack-app-token"),
+            ("matrix_homeserver_url", "https://matrix.example.com"),
+            ("matrix_access_token", "matrix-token"),
         ]);
         let event_bus = EventBus::new(16);
         let (gateways, bridges) =
@@ -437,8 +465,8 @@ mod tests {
             .map(|gateway| gateway.gateway_type())
             .collect();
 
-        assert_eq!(gateway_types, vec!["discord", "telegram", "slack"]);
-        assert_eq!(bridges.len(), 3);
+        assert_eq!(gateway_types, vec!["discord", "telegram", "slack", "matrix"]);
+        assert_eq!(bridges.len(), 4);
     }
 
     #[tokio::test]
@@ -450,6 +478,38 @@ mod tests {
 
         assert!(gateways.is_empty());
         assert!(bridges.is_empty());
+    }
+
+    #[tokio::test]
+    async fn collect_gateways_skips_matrix_without_both_required_credentials() {
+        // Only homeserver URL — no access token
+        let resolver =
+            resolver_with_store(&[("matrix_homeserver_url", "https://matrix.example.com")]);
+        let event_bus = EventBus::new(16);
+        let (gateways, bridges) =
+            collect_gateways(&resolver, test_engine(event_bus.clone()), &event_bus).await;
+
+        assert!(gateways.is_empty());
+        assert!(bridges.is_empty());
+    }
+
+    #[tokio::test]
+    async fn collect_gateways_builds_matrix_gateway_when_both_credentials_provided() {
+        let resolver = resolver_with_store(&[
+            ("matrix_homeserver_url", "https://matrix.example.com"),
+            ("matrix_access_token", "syt_test_token"),
+        ]);
+        let event_bus = EventBus::new(16);
+        let (gateways, bridges) =
+            collect_gateways(&resolver, test_engine(event_bus.clone()), &event_bus).await;
+
+        let gateway_types: Vec<_> = gateways
+            .iter()
+            .map(|gateway| gateway.gateway_type())
+            .collect();
+
+        assert_eq!(gateway_types, vec!["matrix"]);
+        assert_eq!(bridges.len(), 1);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -479,7 +539,7 @@ mod tests {
             .unwrap();
         let code = match event.kind {
             AppEventKind::PairingCodeGenerated { code } => code,
-            other => panic!("expected pairing code event, got {}", other),
+            other => unreachable!("expected pairing code event, got {}", other),
         };
 
         assert_eq!(

--- a/crates/opengoose-secrets/src/lib.rs
+++ b/crates/opengoose-secrets/src/lib.rs
@@ -41,6 +41,8 @@ pub enum SecretKey {
     TelegramBotToken,
     SlackBotToken,
     SlackAppToken,
+    MatrixHomeserverUrl,
+    MatrixAccessToken,
     Custom(String),
 }
 
@@ -52,6 +54,8 @@ impl SecretKey {
             Self::TelegramBotToken => "telegram_bot_token",
             Self::SlackBotToken => "slack_bot_token",
             Self::SlackAppToken => "slack_app_token",
+            Self::MatrixHomeserverUrl => "matrix_homeserver_url",
+            Self::MatrixAccessToken => "matrix_access_token",
             Self::Custom(s) => s.as_str(),
         }
     }
@@ -63,6 +67,8 @@ impl SecretKey {
             Self::TelegramBotToken => "TELEGRAM_BOT_TOKEN".into(),
             Self::SlackBotToken => "SLACK_BOT_TOKEN".into(),
             Self::SlackAppToken => "SLACK_APP_TOKEN".into(),
+            Self::MatrixHomeserverUrl => "MATRIX_HOMESERVER_URL".into(),
+            Self::MatrixAccessToken => "MATRIX_ACCESS_TOKEN".into(),
             Self::Custom(s) => s.to_uppercase(),
         }
     }
@@ -74,6 +80,8 @@ impl SecretKey {
             "telegram_bot_token" => Self::TelegramBotToken,
             "slack_bot_token" => Self::SlackBotToken,
             "slack_app_token" => Self::SlackAppToken,
+            "matrix_homeserver_url" => Self::MatrixHomeserverUrl,
+            "matrix_access_token" => Self::MatrixAccessToken,
             other => Self::Custom(other.to_owned()),
         }
     }


### PR DESCRIPTION
## Summary

- Adds `MatrixHomeserverUrl` and `MatrixAccessToken` to `SecretKey` enum in `opengoose-secrets`
- Adds `opengoose-matrix` as a dependency to `opengoose-cli`
- Implements `try_matrix()` factory function in `run.rs` and registers it in `GATEWAY_FACTORIES`
- Matrix gateway requires both `MATRIX_HOMESERVER_URL` and `MATRIX_ACCESS_TOKEN` credentials (similar to Slack's two-token requirement)

## Test plan

- [x] `collect_gateways_builds_all_supported_gateways_from_credentials` — now includes matrix (4 gateways total)
- [x] `collect_gateways_skips_matrix_without_both_required_credentials` — verifies partial creds are skipped
- [x] `collect_gateways_builds_matrix_gateway_when_both_credentials_provided` — verifies matrix-only credential set works
- [x] All 26 existing tests continue to pass

Closes OPE-53

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
