### PR TITLE
refactor: replace panic! with unreachable! in test match arms (OPE-52)

### DIFF
--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -479,7 +479,7 @@ mod tests {
             .unwrap();
         let code = match event.kind {
             AppEventKind::PairingCodeGenerated { code } => code,
-            other => panic!("expected pairing code event, got {}", other),
+            other => unreachable!("expected pairing code event, got {}", other),
         };
 
         assert_eq!(

--- a/crates/opengoose-core/src/bridge.rs
+++ b/crates/opengoose-core/src/bridge.rs
@@ -367,7 +367,7 @@ mod tests {
         let pairing = rx.try_recv().unwrap();
         let code = match pairing.kind {
             AppEventKind::PairingCodeGenerated { code } => code,
-            other => panic!("expected pairing code event, got {}", other),
+            other => unreachable!("expected pairing code event, got {}", other),
         };
         assert_eq!(
             store.consume_pending_code(&code).await.unwrap(),

--- a/crates/opengoose-persistence/src/run_status.rs
+++ b/crates/opengoose-persistence/src/run_status.rs
@@ -39,7 +39,7 @@ mod tests {
                 assert!(msg.contains("RunStatus"));
                 assert!(msg.contains("bogus"));
             }
-            other => panic!("expected InvalidEnumValue, got: {:?}", other),
+            other => unreachable!("expected InvalidEnumValue, got: {:?}", other),
         }
     }
 

--- a/crates/opengoose-secrets/src/resolver.rs
+++ b/crates/opengoose-secrets/src/resolver.rs
@@ -226,7 +226,7 @@ mod tests {
                 assert_eq!(key, "missing_key");
                 assert_eq!(env_var, "OPENGOOSE_DEFINITELY_NOT_SET_99999");
             }
-            other => panic!("expected NotFound, got: {:?}", other),
+            other => unreachable!("expected NotFound, got: {:?}", other),
         }
     }
 

--- a/crates/opengoose-teams/src/recipe_bridge.rs
+++ b/crates/opengoose-teams/src/recipe_bridge.rs
@@ -552,7 +552,7 @@ mod tests {
                 assert_eq!(code, "print('hello')");
                 assert_eq!(dependencies.as_ref().unwrap(), &vec!["numpy".to_string()]);
             }
-            other => panic!("expected InlinePython, got {:?}", other),
+            other => unreachable!("expected InlinePython, got {:?}", other),
         }
 
         let back = recipe_to_profile(&recipe);
@@ -591,7 +591,7 @@ mod tests {
         let recipe = profile_to_recipe(&profile);
         match &recipe.extensions.as_ref().unwrap()[0] {
             ExtensionConfig::Platform { name, .. } => assert_eq!(name, "summon"),
-            other => panic!("expected Platform, got {:?}", other),
+            other => unreachable!("expected Platform, got {:?}", other),
         }
 
         let back = recipe_to_profile(&recipe);

--- a/crates/opengoose-teams/src/remote.rs
+++ b/crates/opengoose-teams/src/remote.rs
@@ -265,7 +265,7 @@ mod tests {
                 assert_eq!(api_key, "key");
                 assert_eq!(capabilities, vec!["code-review"]);
             }
-            _ => panic!("wrong variant"),
+            _ => unreachable!("wrong variant"),
         }
     }
 
@@ -385,7 +385,7 @@ mod tests {
             ProtocolMessage::MessageRelay { payload, .. } => {
                 assert_eq!(payload, "test");
             }
-            _ => panic!("wrong message type"),
+            _ => unreachable!("wrong message type"),
         }
     }
 

--- a/crates/opengoose-tui/src/tracing_layer.rs
+++ b/crates/opengoose-tui/src/tracing_layer.rs
@@ -75,7 +75,7 @@ mod tests {
                 assert_eq!(level, "INFO");
                 assert!(message.contains("test message"));
             }
-            other => panic!("expected TracingEvent, got: {:?}", other),
+            other => unreachable!("expected TracingEvent, got: {:?}", other),
         }
     }
 
@@ -96,7 +96,7 @@ mod tests {
                 assert_eq!(level, "ERROR");
                 assert!(message.contains("oh no"));
             }
-            other => panic!("expected TracingEvent, got: {:?}", other),
+            other => unreachable!("expected TracingEvent, got: {:?}", other),
         }
     }
 
@@ -116,7 +116,7 @@ mod tests {
             AppEventKind::TracingEvent { message, .. } => {
                 assert!(message.contains("counted"));
             }
-            _ => panic!("expected TracingEvent"),
+            _ => unreachable!("expected TracingEvent"),
         }
     }
 
@@ -139,7 +139,7 @@ mod tests {
                 // Should have the field or target
                 assert!(!message.is_empty());
             }
-            _ => panic!("expected TracingEvent"),
+            _ => unreachable!("expected TracingEvent"),
         }
     }
 
@@ -159,7 +159,7 @@ mod tests {
             AppEventKind::TracingEvent { message, .. } => {
                 assert!(message.contains("str message"));
             }
-            _ => panic!("expected TracingEvent"),
+            _ => unreachable!("expected TracingEvent"),
         }
     }
 }


### PR DESCRIPTION
## Summary

Replaces all 13 `panic!()` calls with `unreachable!()` in test code fallthrough match arms.

- All occurrences were in `#[test]` / `#[tokio::test]` functions inside `#[cfg(test)]` blocks
- `unreachable!()` is the idiomatic Rust macro for match arms that should never be reached
- Same runtime behavior and error messages preserved
- Files changed: `opengoose-persistence`, `opengoose-secrets`, `opengoose-cli`, `opengoose-core`, `opengoose-teams`, `opengoose-tui`

## Test plan

- [x] All 190 unit tests in modified crates pass
- [x] No `panic!` calls remain outside `#[should_panic]` annotations

Closes OPE-52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
