### PR TITLE
docs: add rustdoc to opengoose-web and opengoose-cli public APIs

### DIFF
--- a/crates/opengoose-cli/src/cmd/alert.rs
+++ b/crates/opengoose-cli/src/cmd/alert.rs
@@ -8,6 +8,7 @@ use opengoose_persistence::{AlertCondition, AlertMetric, AlertStore, Database};
 use crate::cmd::output::format_table;
 
 #[derive(Subcommand)]
+/// Subcommands for `opengoose alert`.
 pub enum AlertAction {
     /// List all alert rules
     List,
@@ -53,6 +54,7 @@ pub enum AlertAction {
     },
 }
 
+/// Dispatch and execute the selected alert subcommand.
 pub fn execute(action: AlertAction) -> Result<()> {
     match action {
         AlertAction::List => cmd_list(),

--- a/crates/opengoose-cli/src/cmd/auth.rs
+++ b/crates/opengoose-cli/src/cmd/auth.rs
@@ -12,6 +12,7 @@ use opengoose_secrets::{ConfigFile, KeyringBackend, SecretKey, SecretStore};
 #[command(
     after_help = "Examples:\n  opengoose auth list\n  opengoose auth login openai\n  opengoose --json auth models anthropic"
 )]
+/// Subcommands for `opengoose auth`.
 pub enum AuthAction {
     /// Authenticate with an AI provider (supports OAuth and API key)
     #[command(after_help = "Example:\n  opengoose auth login openai")]
@@ -51,6 +52,7 @@ pub enum AuthAction {
     },
 }
 
+/// Dispatch and execute the selected auth subcommand.
 pub async fn execute(action: AuthAction, output: CliOutput) -> Result<()> {
     match action {
         AuthAction::Login { provider } => cmd_login(provider.as_deref(), output).await,

--- a/crates/opengoose-cli/src/cmd/message.rs
+++ b/crates/opengoose-cli/src/cmd/message.rs
@@ -8,6 +8,7 @@ use tokio::sync::broadcast::error::RecvError;
 use opengoose_persistence::{AgentMessageStore, Database};
 
 #[derive(Subcommand)]
+/// Subcommands for `opengoose message`.
 pub enum MessageAction {
     /// Send a directed message from one agent to another
     Send {
@@ -63,6 +64,7 @@ pub enum MessageAction {
     },
 }
 
+/// Dispatch and execute the selected message subcommand.
 pub async fn execute(action: MessageAction) -> Result<()> {
     match action {
         MessageAction::Send {

--- a/crates/opengoose-cli/src/cmd/mod.rs
+++ b/crates/opengoose-cli/src/cmd/mod.rs
@@ -1,13 +1,26 @@
+/// Monitoring alert rule management (`opengoose alert`).
 pub mod alert;
+/// AI provider authentication and credential management (`opengoose auth`).
 pub mod auth;
+/// Inter-agent messaging commands (`opengoose message`).
 pub mod message;
+/// CLI output formatting helpers (text tables, JSON, error display).
 pub mod output;
+/// Plugin lifecycle management (`opengoose plugin`).
 pub mod plugin;
+/// Agent profile management (`opengoose profile`).
 pub mod profile;
+/// Remote agent connection management (`opengoose remote`).
 pub mod remote;
+/// Main runtime entry point (`opengoose run`).
 pub mod run;
+/// Cron schedule management (`opengoose schedule`).
 pub mod schedule;
+/// Skill package management (`opengoose skill`).
 pub mod skill;
+/// Team definition and execution management (`opengoose team`).
 pub mod team;
+/// Event trigger management (`opengoose trigger`).
 pub mod trigger;
+/// Web dashboard server (`opengoose web`).
 pub mod web;

--- a/crates/opengoose-cli/src/cmd/output.rs
+++ b/crates/opengoose-cli/src/cmd/output.rs
@@ -5,22 +5,28 @@ use anyhow::Error;
 use clap::Error as ClapError;
 use serde::Serialize;
 
+/// Whether the CLI should emit human-readable text or machine-readable JSON.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum OutputMode {
+    /// Human-readable text with optional ANSI color.
     Text,
+    /// Pretty-printed JSON on stdout.
     Json,
 }
 
 impl OutputMode {
+    /// Select output mode from the `--json` flag value.
     pub fn from_json_flag(json: bool) -> Self {
         if json { Self::Json } else { Self::Text }
     }
 
+    /// Returns `true` when JSON output is selected.
     pub fn is_json(self) -> bool {
         matches!(self, Self::Json)
     }
 }
 
+/// Holds the selected output mode and terminal capabilities for the current invocation.
 #[derive(Clone, Copy, Debug)]
 pub struct CliOutput {
     mode: OutputMode,
@@ -28,6 +34,7 @@ pub struct CliOutput {
 }
 
 impl CliOutput {
+    /// Create a new output context, detecting color support for text mode.
     pub fn new(mode: OutputMode) -> Self {
         Self {
             mode,
@@ -35,18 +42,22 @@ impl CliOutput {
         }
     }
 
+    /// Return the active output mode.
     pub fn mode(self) -> OutputMode {
         self.mode
     }
 
+    /// Returns `true` when JSON output is selected.
     pub fn is_json(self) -> bool {
         self.mode.is_json()
     }
 
+    /// Format `text` as a bold cyan heading (plain text when color is off).
     pub fn heading(self, text: &str) -> String {
         self.paint(text, "1;36")
     }
 
+    /// Pretty-print `value` as JSON to stdout.
     pub fn print_json<T: Serialize>(self, value: &T) -> anyhow::Result<()> {
         println!("{}", serde_json::to_string_pretty(value)?);
         Ok(())
@@ -61,6 +72,7 @@ impl CliOutput {
     }
 }
 
+/// Format `headers` and `rows` as an aligned text table.
 pub fn format_table(headers: &[&str], rows: &[Vec<String>]) -> String {
     let mut widths: Vec<usize> = headers.iter().map(|header| header.len()).collect();
     for row in rows {
@@ -99,6 +111,7 @@ fn push_table_row(output: &mut String, row: &[String], widths: &[usize]) {
     output.push('\n');
 }
 
+/// Print a user-friendly error (with optional hint) to stderr in the active output mode.
 pub fn print_error(output: CliOutput, err: &Error) {
     let friendly = FriendlyError::from_error(err);
 
@@ -126,6 +139,7 @@ pub fn print_error(output: CliOutput, err: &Error) {
     }
 }
 
+/// Print a clap argument-parsing error and return the appropriate exit code.
 pub fn print_clap_error(requested_json: bool, err: ClapError) -> ExitCode {
     let exit_code = ExitCode::from(err.exit_code() as u8);
 

--- a/crates/opengoose-cli/src/cmd/plugin.rs
+++ b/crates/opengoose-cli/src/cmd/plugin.rs
@@ -10,6 +10,7 @@ use opengoose_teams::plugin::{
 };
 
 #[derive(Subcommand)]
+/// Subcommands for `opengoose plugin`.
 pub enum PluginAction {
     /// Install a plugin from a local path
     Install {
@@ -42,6 +43,7 @@ pub enum PluginAction {
     Discover,
 }
 
+/// Dispatch and execute the selected plugin subcommand.
 pub fn execute(action: PluginAction) -> Result<()> {
     match action {
         PluginAction::Install { path } => cmd_install(path),

--- a/crates/opengoose-cli/src/cmd/profile.rs
+++ b/crates/opengoose-cli/src/cmd/profile.rs
@@ -11,6 +11,7 @@ use opengoose_profiles::{AgentProfile, ProfileStore};
 #[command(
     after_help = "Examples:\n  opengoose profile list\n  opengoose profile show developer\n  opengoose --json profile list"
 )]
+/// Subcommands for `opengoose profile`.
 pub enum ProfileAction {
     /// List all agent profiles
     #[command(after_help = "Examples:\n  opengoose profile list\n  opengoose --json profile list")]
@@ -45,6 +46,7 @@ pub enum ProfileAction {
     },
 }
 
+/// Dispatch and execute the selected profile subcommand.
 pub fn execute(action: ProfileAction, output: CliOutput) -> Result<()> {
     match action {
         ProfileAction::List => cmd_list(output),

--- a/crates/opengoose-cli/src/cmd/remote.rs
+++ b/crates/opengoose-cli/src/cmd/remote.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 const DEFAULT_BASE: &str = "http://127.0.0.1:8080";
 
 #[derive(Subcommand)]
+/// Subcommands for `opengoose remote`.
 pub enum RemoteAction {
     /// Connect to an OpenGoose server as a remote agent
     Connect {
@@ -43,6 +44,7 @@ struct RemoteAgentInfo {
     last_heartbeat_secs: u64,
 }
 
+/// Dispatch and execute the selected remote subcommand.
 pub async fn execute(action: RemoteAction) -> Result<()> {
     match action {
         RemoteAction::Connect { url, key, name } => cmd_connect(&url, key.as_deref(), &name).await,

--- a/crates/opengoose-cli/src/cmd/schedule.rs
+++ b/crates/opengoose-cli/src/cmd/schedule.rs
@@ -7,6 +7,7 @@ use opengoose_persistence::{Database, ScheduleStore};
 use opengoose_teams::scheduler;
 
 #[derive(Subcommand)]
+/// Subcommands for `opengoose schedule`.
 pub enum ScheduleAction {
     /// Add a new cron schedule
     Add {
@@ -46,6 +47,7 @@ pub enum ScheduleAction {
     },
 }
 
+/// Dispatch and execute the selected schedule subcommand.
 pub fn execute(action: ScheduleAction) -> Result<()> {
     match action {
         ScheduleAction::Add {

--- a/crates/opengoose-cli/src/cmd/skill.rs
+++ b/crates/opengoose-cli/src/cmd/skill.rs
@@ -6,6 +6,7 @@ use clap::Subcommand;
 use opengoose_profiles::{Skill, SkillStore};
 
 #[derive(Subcommand)]
+/// Subcommands for `opengoose skill`.
 pub enum SkillAction {
     /// List all installed skills
     List,
@@ -35,6 +36,7 @@ pub enum SkillAction {
     },
 }
 
+/// Dispatch and execute the selected skill subcommand.
 pub fn execute(action: SkillAction) -> Result<()> {
     match action {
         SkillAction::List => cmd_list(),

--- a/crates/opengoose-cli/src/cmd/team.rs
+++ b/crates/opengoose-cli/src/cmd/team.rs
@@ -14,6 +14,7 @@ use opengoose_types::EventBus;
 #[command(
     after_help = "Examples:\n  opengoose team list\n  opengoose team show code-review\n  opengoose --json team list"
 )]
+/// Subcommands for `opengoose team`.
 pub enum TeamAction {
     /// List all team definitions
     #[command(after_help = "Examples:\n  opengoose team list\n  opengoose --json team list")]
@@ -70,6 +71,7 @@ pub enum TeamAction {
     },
 }
 
+/// Dispatch and execute the selected team subcommand.
 pub async fn execute(action: TeamAction, output: CliOutput) -> Result<()> {
     match action {
         TeamAction::List => cmd_list(output),

--- a/crates/opengoose-cli/src/cmd/trigger.rs
+++ b/crates/opengoose-cli/src/cmd/trigger.rs
@@ -7,6 +7,7 @@ use opengoose_persistence::{Database, TriggerStore};
 use opengoose_teams::triggers;
 
 #[derive(Subcommand)]
+/// Subcommands for `opengoose trigger`.
 pub enum TriggerAction {
     /// Add a new event trigger
     Add {
@@ -49,6 +50,7 @@ pub enum TriggerAction {
     },
 }
 
+/// Dispatch and execute the selected trigger subcommand.
 pub fn execute(action: TriggerAction) -> Result<()> {
     match action {
         TriggerAction::Add {

--- a/crates/opengoose-web/src/data.rs
+++ b/crates/opengoose-web/src/data.rs
@@ -12,6 +12,7 @@ use opengoose_teams::{TeamDefinition, TeamStore, all_defaults as default_teams};
 use opengoose_types::SessionKey;
 use urlencoding::encode;
 
+/// A single metric card rendered on the dashboard (label, value, footnote, tone).
 #[derive(Clone)]
 pub struct MetricCard {
     pub label: String,
@@ -20,6 +21,7 @@ pub struct MetricCard {
     pub tone: &'static str,
 }
 
+/// An alert banner displayed on the dashboard.
 #[derive(Clone)]
 pub struct AlertCard {
     pub eyebrow: String,
@@ -28,6 +30,7 @@ pub struct AlertCard {
     pub tone: &'static str,
 }
 
+/// One segment of a stacked status bar (e.g. "Running 3" at 40% width).
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct StatusSegment {
@@ -37,6 +40,7 @@ pub struct StatusSegment {
     pub width: u8,
 }
 
+/// A single bar in the duration trend chart.
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct TrendBar {
@@ -47,6 +51,7 @@ pub struct TrendBar {
     pub height: u8,
 }
 
+/// One row in the activity feed timeline.
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct ActivityItem {
@@ -57,12 +62,14 @@ pub struct ActivityItem {
     pub tone: &'static str,
 }
 
+/// A label/value metadata row shown in detail panels.
 #[derive(Clone)]
 pub struct MetaRow {
     pub label: String,
     pub value: String,
 }
 
+/// Summary row for the session list sidebar.
 #[derive(Clone)]
 pub struct SessionListItem {
     pub title: String,
@@ -76,6 +83,7 @@ pub struct SessionListItem {
     pub active: bool,
 }
 
+/// A single chat message bubble in the session detail view.
 #[derive(Clone)]
 pub struct MessageBubble {
     pub role_label: String,
@@ -86,6 +94,7 @@ pub struct MessageBubble {
     pub alignment: &'static str,
 }
 
+/// Full detail panel for a selected session, including messages and metadata.
 #[derive(Clone)]
 pub struct SessionDetailView {
     pub title: String,
@@ -96,6 +105,7 @@ pub struct SessionDetailView {
     pub empty_hint: String,
 }
 
+/// View-model for the sessions page (list + selected detail).
 #[derive(Clone)]
 pub struct SessionsPageView {
     pub mode_label: String,
@@ -104,6 +114,7 @@ pub struct SessionsPageView {
     pub selected: SessionDetailView,
 }
 
+/// Summary row for the orchestration run list sidebar.
 #[derive(Clone)]
 pub struct RunListItem {
     pub title: String,
@@ -119,6 +130,7 @@ pub struct RunListItem {
     pub active: bool,
 }
 
+/// A single work item row in the run detail panel.
 #[derive(Clone)]
 pub struct WorkItemView {
     pub title: String,
@@ -129,6 +141,7 @@ pub struct WorkItemView {
     pub indent_class: &'static str,
 }
 
+/// A broadcast message shown in the run detail panel.
 #[derive(Clone)]
 pub struct BroadcastView {
     pub sender: String,
@@ -136,6 +149,7 @@ pub struct BroadcastView {
     pub content: String,
 }
 
+/// Full detail panel for a selected orchestration run.
 #[derive(Clone)]
 pub struct RunDetailView {
     pub title: String,
@@ -149,6 +163,7 @@ pub struct RunDetailView {
     pub empty_hint: String,
 }
 
+/// View-model for the runs page (list + selected detail).
 #[derive(Clone)]
 pub struct RunsPageView {
     pub mode_label: String,
@@ -157,6 +172,7 @@ pub struct RunsPageView {
     pub selected: RunDetailView,
 }
 
+/// A single inter-agent message row in the queue detail table.
 #[derive(Clone)]
 pub struct QueueMessageView {
     pub sender: String,
@@ -170,6 +186,7 @@ pub struct QueueMessageView {
     pub error: String,
 }
 
+/// Full detail panel for a selected message queue run.
 #[derive(Clone)]
 pub struct QueueDetailView {
     pub title: String,
@@ -181,6 +198,7 @@ pub struct QueueDetailView {
     pub empty_hint: String,
 }
 
+/// View-model for the queue page (run list + selected detail).
 #[derive(Clone)]
 pub struct QueuePageView {
     pub mode_label: String,
@@ -189,12 +207,14 @@ pub struct QueuePageView {
     pub selected: QueueDetailView,
 }
 
+/// A configuration setting row in the agent detail panel.
 #[derive(Clone)]
 pub struct SettingRow {
     pub label: String,
     pub value: String,
 }
 
+/// An agent extension (skill entry) row in the agent detail panel.
 #[derive(Clone)]
 pub struct ExtensionRow {
     pub name: String,
@@ -202,6 +222,7 @@ pub struct ExtensionRow {
     pub summary: String,
 }
 
+/// Summary row for the agent list sidebar.
 #[derive(Clone)]
 pub struct AgentListItem {
     pub title: String,
@@ -213,6 +234,7 @@ pub struct AgentListItem {
     pub active: bool,
 }
 
+/// Full detail panel for a selected agent profile.
 #[derive(Clone)]
 pub struct AgentDetailView {
     pub title: String,
@@ -226,6 +248,7 @@ pub struct AgentDetailView {
     pub yaml: String,
 }
 
+/// View-model for the agents page (list + selected detail).
 #[derive(Clone)]
 pub struct AgentsPageView {
     pub mode_label: String,
@@ -234,6 +257,7 @@ pub struct AgentsPageView {
     pub selected: AgentDetailView,
 }
 
+/// Summary row for the team list sidebar.
 #[derive(Clone)]
 pub struct TeamListItem {
     pub title: String,
@@ -245,12 +269,14 @@ pub struct TeamListItem {
     pub active: bool,
 }
 
+/// A toast-style notice shown after an action (e.g. team save).
 #[derive(Clone)]
 pub struct Notice {
     pub text: String,
     pub tone: &'static str,
 }
 
+/// Detail/editor panel for a selected team definition.
 #[derive(Clone)]
 pub struct TeamEditorView {
     pub title: String,
@@ -263,6 +289,7 @@ pub struct TeamEditorView {
     pub notice: Option<Notice>,
 }
 
+/// View-model for the teams page (list + selected editor).
 #[derive(Clone)]
 pub struct TeamsPageView {
     pub mode_label: String,
@@ -271,6 +298,7 @@ pub struct TeamsPageView {
     pub selected: TeamEditorView,
 }
 
+/// Aggregated view-model for the main dashboard page.
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct DashboardView {
@@ -289,6 +317,7 @@ pub struct DashboardView {
     pub runs: Vec<RunListItem>,
 }
 
+/// Load all data needed for the dashboard page from the database.
 pub fn load_dashboard(db: Arc<Database>) -> Result<DashboardView> {
     let session_store = SessionStore::new(db.clone());
     let session_stats = session_store.stats()?;
@@ -486,6 +515,7 @@ pub fn load_dashboard(db: Arc<Database>) -> Result<DashboardView> {
     })
 }
 
+/// Load the sessions page view-model, optionally selecting a session by key.
 pub fn load_sessions_page(db: Arc<Database>, selected: Option<String>) -> Result<SessionsPageView> {
     let store = SessionStore::new(db);
     let session_rows = store.list_sessions(24)?;
@@ -528,6 +558,7 @@ pub fn load_sessions_page(db: Arc<Database>, selected: Option<String>) -> Result
     })
 }
 
+/// Load the detail panel for a single session.
 pub fn load_session_detail(
     db: Arc<Database>,
     selected: Option<String>,
@@ -535,6 +566,7 @@ pub fn load_session_detail(
     Ok(load_sessions_page(db, selected)?.selected)
 }
 
+/// Load the runs page view-model, optionally selecting a run by ID.
 pub fn load_runs_page(db: Arc<Database>, selected: Option<String>) -> Result<RunsPageView> {
     let run_store = OrchestrationStore::new(db.clone());
     let runs = run_store.list_runs(None, 20)?;
@@ -566,10 +598,12 @@ pub fn load_runs_page(db: Arc<Database>, selected: Option<String>) -> Result<Run
     })
 }
 
+/// Load the detail panel for a single orchestration run.
 pub fn load_run_detail(db: Arc<Database>, selected: Option<String>) -> Result<RunDetailView> {
     Ok(load_runs_page(db, selected)?.selected)
 }
 
+/// Load the agents page view-model, optionally selecting an agent by name.
 pub fn load_agents_page(selected: Option<String>) -> Result<AgentsPageView> {
     let agents = load_profiles_catalog()?;
     let using_defaults = agents.iter().all(|profile| !profile.is_live);
@@ -613,10 +647,12 @@ pub fn load_agents_page(selected: Option<String>) -> Result<AgentsPageView> {
     })
 }
 
+/// Load the detail panel for a single agent profile.
 pub fn load_agent_detail(selected: Option<String>) -> Result<AgentDetailView> {
     Ok(load_agents_page(selected)?.selected)
 }
 
+/// Load the teams page view-model, optionally selecting a team by name.
 pub fn load_teams_page(selected: Option<String>) -> Result<TeamsPageView> {
     let teams = load_teams_catalog()?;
     let using_defaults = teams.iter().all(|team| !team.is_live);
@@ -664,10 +700,12 @@ pub fn load_teams_page(selected: Option<String>) -> Result<TeamsPageView> {
     })
 }
 
+/// Load the YAML editor panel for a single team definition.
 pub fn load_team_editor(selected: Option<String>) -> Result<TeamEditorView> {
     Ok(load_teams_page(selected)?.selected)
 }
 
+/// Save edited team YAML and return the refreshed editor view.
 pub fn save_team_yaml(original_name: String, yaml: String) -> Result<TeamEditorView> {
     let parsed = TeamDefinition::from_yaml(&yaml);
     match parsed {
@@ -709,6 +747,7 @@ pub fn save_team_yaml(original_name: String, yaml: String) -> Result<TeamEditorV
     }
 }
 
+/// Load the queue page view-model, optionally selecting a run by ID.
 pub fn load_queue_page(db: Arc<Database>, selected: Option<String>) -> Result<QueuePageView> {
     let run_store = OrchestrationStore::new(db.clone());
     let runs = run_store.list_runs(None, 20)?;
@@ -739,6 +778,7 @@ pub fn load_queue_page(db: Arc<Database>, selected: Option<String>) -> Result<Qu
     })
 }
 
+/// Load the detail panel for a queue run's message traffic.
 pub fn load_queue_detail(db: Arc<Database>, selected: Option<String>) -> Result<QueueDetailView> {
     Ok(load_queue_page(db, selected)?.selected)
 }

--- a/crates/opengoose-web/src/error.rs
+++ b/crates/opengoose-web/src/error.rs
@@ -9,27 +9,35 @@ use serde::Serialize;
 /// with a consistent JSON error body for API routes.
 #[derive(Debug, thiserror::Error)]
 pub enum WebError {
+    /// Resource not found (HTTP 404).
     #[error("not found: {0}")]
     NotFound(String),
 
+    /// Client sent an invalid request (HTTP 400).
     #[error("bad request: {0}")]
     BadRequest(String),
 
+    /// Unexpected server-side failure (HTTP 500).
     #[error("internal error: {0}")]
     Internal(String),
 
+    /// Propagated from the persistence layer.
     #[error("persistence error: {0}")]
     Persistence(#[from] opengoose_persistence::PersistenceError),
 
+    /// Propagated from team store operations.
     #[error("team error: {0}")]
     Team(#[from] opengoose_teams::TeamError),
 
+    /// Propagated from profile store operations.
     #[error("profile error: {0}")]
     Profile(#[from] opengoose_profiles::ProfileError),
 
+    /// Template rendering failure.
     #[error("template error: {0}")]
     Template(#[from] askama::Error),
 
+    /// Catch-all for other errors.
     #[error("{0}")]
     Other(#[from] anyhow::Error),
 }

--- a/crates/opengoose-web/src/handlers/agents.rs
+++ b/crates/opengoose-web/src/handlers/agents.rs
@@ -5,11 +5,14 @@ use serde::Serialize;
 use super::AppError;
 use crate::state::AppState;
 
+/// JSON response item representing an agent profile name.
 #[derive(Serialize)]
 pub struct AgentItem {
+    /// Profile name (e.g. "developer", "researcher").
     pub name: String,
 }
 
+/// GET /api/agents — list all installed agent profiles.
 pub async fn list_agents(State(state): State<AppState>) -> Result<Json<Vec<AgentItem>>, AppError> {
     let names = state.profile_store.list()?;
     Ok(Json(

--- a/crates/opengoose-web/src/handlers/alerts.rs
+++ b/crates/opengoose-web/src/handlers/alerts.rs
@@ -9,6 +9,7 @@ use crate::state::AppState;
 
 // ── Response types ────────────────────────────────────────────────────────────
 
+/// JSON response representing a persisted alert rule.
 #[derive(Serialize)]
 pub struct AlertRuleResponse {
     pub id: String,
@@ -38,6 +39,7 @@ impl From<AlertRule> for AlertRuleResponse {
     }
 }
 
+/// JSON response representing a single alert trigger event.
 #[derive(Serialize)]
 pub struct AlertHistoryResponse {
     pub id: i32,
@@ -63,6 +65,7 @@ impl From<AlertHistoryEntry> for AlertHistoryResponse {
 
 // ── Request types ─────────────────────────────────────────────────────────────
 
+/// JSON request body for creating a new alert rule.
 #[derive(Deserialize)]
 pub struct CreateAlertRequest {
     pub name: String,

--- a/crates/opengoose-web/src/handlers/dashboard.rs
+++ b/crates/opengoose-web/src/handlers/dashboard.rs
@@ -5,15 +5,22 @@ use serde::Serialize;
 use super::AppError;
 use crate::state::AppState;
 
+/// Aggregate counts returned by the dashboard JSON endpoint.
 #[derive(Serialize)]
 pub struct DashboardStats {
+    /// Total number of chat sessions.
     pub session_count: i64,
+    /// Total number of stored messages across all sessions.
     pub message_count: i64,
+    /// Total number of orchestration runs.
     pub run_count: i64,
+    /// Number of installed agent profiles.
     pub agent_count: usize,
+    /// Number of installed team definitions.
     pub team_count: usize,
 }
 
+/// GET /api/dashboard — return aggregate system statistics.
 pub async fn get_dashboard(
     State(state): State<AppState>,
 ) -> Result<Json<DashboardStats>, AppError> {

--- a/crates/opengoose-web/src/handlers/mod.rs
+++ b/crates/opengoose-web/src/handlers/mod.rs
@@ -1,9 +1,16 @@
+/// JSON API handlers for agent profiles.
 pub mod agents;
+/// JSON API handlers for monitoring alert rules and history.
 pub mod alerts;
+/// JSON API handler for aggregate dashboard statistics.
 pub mod dashboard;
+/// WebSocket gateway and REST endpoints for remote agent connections.
 pub mod remote_agents;
+/// JSON API handlers for orchestration runs.
 pub mod runs;
+/// JSON API handlers for chat sessions and messages.
 pub mod sessions;
+/// JSON API handlers for team definitions.
 pub mod teams;
 
 /// Handler-level error type.

--- a/crates/opengoose-web/src/handlers/remote_agents.rs
+++ b/crates/opengoose-web/src/handlers/remote_agents.rs
@@ -75,12 +75,18 @@ pub async fn disconnect_remote(
     }
 }
 
+/// JSON response describing a currently connected remote agent.
 #[derive(Serialize)]
 pub struct RemoteAgentInfo {
+    /// Registered agent name.
     pub name: String,
+    /// Capabilities advertised during handshake.
     pub capabilities: Vec<String>,
+    /// Network endpoint the agent connected from.
     pub endpoint: String,
+    /// Seconds since the agent connected.
     pub connected_secs: u64,
+    /// Seconds since the last heartbeat was received.
     pub last_heartbeat_secs: u64,
 }
 

--- a/crates/opengoose-web/src/handlers/runs.rs
+++ b/crates/opengoose-web/src/handlers/runs.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::AppError;
 use crate::state::AppState;
 
+/// JSON response item for a single orchestration run.
 #[derive(Serialize)]
 pub struct RunItem {
     pub team_run_id: String,
@@ -19,9 +20,12 @@ pub struct RunItem {
     pub updated_at: String,
 }
 
+/// Query parameters for `GET /api/runs`.
 #[derive(Deserialize)]
 pub struct ListQuery {
+    /// Optional status filter (e.g. "running", "completed").
     pub status: Option<String>,
+    /// Maximum number of runs to return (default 50).
     #[serde(default = "default_limit")]
     pub limit: i64,
 }
@@ -30,6 +34,7 @@ fn default_limit() -> i64 {
     50
 }
 
+/// GET /api/runs — list orchestration runs with optional status filter.
 pub async fn list_runs(
     State(state): State<AppState>,
     Query(q): Query<ListQuery>,

--- a/crates/opengoose-web/src/handlers/sessions.rs
+++ b/crates/opengoose-web/src/handlers/sessions.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::AppError;
 use crate::state::AppState;
 
+/// JSON response item for a single chat session.
 #[derive(Serialize)]
 pub struct SessionItem {
     pub session_key: String,
@@ -13,8 +14,10 @@ pub struct SessionItem {
     pub updated_at: String,
 }
 
+/// Query parameters for `GET /api/sessions`.
 #[derive(Deserialize)]
 pub struct ListQuery {
+    /// Maximum number of sessions to return (default 50).
     #[serde(default = "default_limit")]
     pub limit: i64,
 }
@@ -23,6 +26,7 @@ fn default_limit() -> i64 {
     50
 }
 
+/// GET /api/sessions — list recent chat sessions.
 pub async fn list_sessions(
     State(state): State<AppState>,
     Query(q): Query<ListQuery>,
@@ -41,6 +45,7 @@ pub async fn list_sessions(
     ))
 }
 
+/// JSON response item for a single chat message.
 #[derive(Serialize)]
 pub struct MessageItem {
     pub role: String,
@@ -49,8 +54,10 @@ pub struct MessageItem {
     pub created_at: String,
 }
 
+/// Query parameters for `GET /api/sessions/{session_key}/messages`.
 #[derive(Deserialize)]
 pub struct MessagesQuery {
+    /// Maximum number of messages to return (default 100).
     #[serde(default = "default_msg_limit")]
     pub limit: usize,
 }
@@ -59,6 +66,7 @@ fn default_msg_limit() -> usize {
     100
 }
 
+/// GET /api/sessions/{session_key}/messages — list messages for a session.
 pub async fn get_messages(
     State(state): State<AppState>,
     Path(session_key): Path<String>,

--- a/crates/opengoose-web/src/handlers/teams.rs
+++ b/crates/opengoose-web/src/handlers/teams.rs
@@ -5,11 +5,14 @@ use serde::Serialize;
 use super::AppError;
 use crate::state::AppState;
 
+/// JSON response item representing a team definition name.
 #[derive(Serialize)]
 pub struct TeamItem {
+    /// Team name (e.g. "code-review", "feature-dev").
     pub name: String,
 }
 
+/// GET /api/teams — list all installed team definitions.
 pub async fn list_teams(State(state): State<AppState>) -> Result<Json<Vec<TeamItem>>, AppError> {
     let names = state.team_store.list()?;
     Ok(Json(

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -1,11 +1,16 @@
+/// Dashboard view-model structs and data loaders for the HTML templates.
 pub mod data;
+/// Typed error types for web handlers with HTTP status code mapping.
 pub mod error;
 mod handlers;
 mod pages;
 mod state;
 
+/// Re-exported error type for web API and page handlers.
 pub use error::WebError;
+/// Re-exported shared application state for all handlers.
 pub use state::AppState;
+/// Alias kept for backward compatibility.
 pub use state::AppState as SharedAppState;
 
 use std::convert::Infallible;
@@ -41,8 +46,10 @@ use crate::data::{
     load_teams_page, save_team_yaml,
 };
 
+/// Configuration for the web dashboard server.
 #[derive(Debug, Clone, Copy)]
 pub struct WebOptions {
+    /// Socket address to bind the HTTP listener to.
     pub bind: SocketAddr,
 }
 
@@ -62,6 +69,10 @@ struct PageState {
 type WebResult = Result<Html<String>, (StatusCode, Html<String>)>;
 type PartialResult = Result<String, (StatusCode, Html<String>)>;
 
+/// Start the web dashboard and JSON API server.
+///
+/// Binds to the address in `options`, serves HTML pages, static assets,
+/// REST endpoints under `/api/`, and the remote-agent WebSocket gateway.
 pub async fn serve(options: WebOptions) -> Result<()> {
     let db = Arc::new(Database::open()?);
     let state = PageState { db: db.clone() };

--- a/crates/opengoose-web/src/pages.rs
+++ b/crates/opengoose-web/src/pages.rs
@@ -29,6 +29,7 @@ pub struct ErrorPage {
 }
 
 impl ErrorPage {
+    /// Build a 404 error page for `path`.
     pub fn not_found(path: &str) -> Self {
         Self {
             page_title: "Page not found".into(),
@@ -46,6 +47,7 @@ impl ErrorPage {
         }
     }
 
+    /// Build a 500 error page with the given technical detail string.
     pub fn internal_error(detail: &str) -> Self {
         Self {
             page_title: "Internal error".into(),

--- a/crates/opengoose-web/src/state.rs
+++ b/crates/opengoose-web/src/state.rs
@@ -7,11 +7,17 @@ use opengoose_teams::TeamStore;
 /// Shared application state passed to all handlers.
 #[derive(Clone)]
 pub struct AppState {
+    /// Underlying SQLite database handle.
     pub db: Arc<Database>,
+    /// Store for chat sessions and message history.
     pub session_store: Arc<SessionStore>,
+    /// Store for team orchestration runs.
     pub orchestration_store: Arc<OrchestrationStore>,
+    /// Store for agent profile YAML definitions.
     pub profile_store: Arc<ProfileStore>,
+    /// Store for team YAML definitions.
     pub team_store: Arc<TeamStore>,
+    /// Store for monitoring alert rules and history.
     pub alert_store: Arc<AlertStore>,
 }
 


### PR DESCRIPTION
## Summary

- Add `///` doc comments to all public structs, enums, functions, type aliases, and module declarations in `opengoose-web` and `opengoose-cli`
- `opengoose-web`: ~100 items documented across `lib.rs`, `data.rs`, `error.rs`, `state.rs`, `pages.rs`, and all handler modules
- `opengoose-cli`: ~50 items documented across all `cmd/` modules including enums, execute functions, output helpers, and module declarations

Closes OPE-59

## Test plan

- [x] `cargo doc --no-deps -p opengoose-web -p opengoose-cli` builds with zero warnings
- [x] `cargo test -p opengoose-web -p opengoose-cli` — all 25 tests pass
- [x] `cargo clippy -p opengoose-web -p opengoose-cli -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
