### PR TITLE
feat(OPE-68): workflow event trigger system for automated workflow execution

### DIFF
--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -334,7 +334,7 @@ pub async fn execute() -> Result<()> {
         start_gateways(gateways, bridges, cancel.clone()).await?;
         spawn_periodic_cleanup(engine.clone(), cancel.clone());
         scheduler::spawn_scheduler(engine.db().clone(), event_bus.clone(), cancel.clone());
-                        spawn_event_bus_trigger_watcher(engine.db().clone(), event_bus.clone(), cancel.clone());
+        spawn_event_bus_trigger_watcher(engine.db().clone(), event_bus.clone(), cancel.clone());
         opengoose_tui::run_tui(
             event_bus,
             cancel,

--- a/crates/opengoose-teams/src/lib.rs
+++ b/crates/opengoose-teams/src/lib.rs
@@ -27,8 +27,8 @@ pub use recipe_bridge::{profile_to_recipe, recipe_to_profile};
 pub use remote::{ProtocolMessage, RemoteAgent, RemoteAgentRegistry, RemoteConfig};
 pub use runner::{AgentOutput, AgentRunner};
 pub use store::TeamStore;
-pub use triggers::spawn_event_bus_trigger_watcher;
 pub use team::{
     FanOutConfig, MergeStrategy, OrchestrationPattern, RouterConfig, RouterStrategy, TeamAgent,
     TeamDefinition,
 };
+pub use triggers::spawn_event_bus_trigger_watcher;

--- a/crates/opengoose-teams/src/triggers.rs
+++ b/crates/opengoose-teams/src/triggers.rs
@@ -156,16 +156,16 @@ pub fn matches_on_message_event(condition_json: &str, author: &str, content: &st
         Err(_) => return false,
     };
 
-    if let Some(ref expected) = cond.from_author {
-        if expected != author {
-            return false;
-        }
+    if let Some(ref expected) = cond.from_author
+        && expected != author
+    {
+        return false;
     }
 
-    if let Some(ref needle) = cond.content_contains {
-        if !content.contains(needle.as_str()) {
-            return false;
-        }
+    if let Some(ref needle) = cond.content_contains
+        && !content.contains(needle.as_str())
+    {
+        return false;
     }
 
     true
@@ -178,10 +178,10 @@ pub fn matches_on_session_event(condition_json: &str, platform: &str) -> bool {
         Err(_) => return false,
     };
 
-    if let Some(ref expected) = cond.platform {
-        if expected != platform {
-            return false;
-        }
+    if let Some(ref expected) = cond.platform
+        && expected != platform
+    {
+        return false;
     }
 
     true
@@ -194,10 +194,10 @@ pub fn matches_on_schedule_event(condition_json: &str, completed_team: &str) -> 
         Err(_) => return false,
     };
 
-    if let Some(ref expected) = cond.team {
-        if expected != completed_team {
-            return false;
-        }
+    if let Some(ref expected) = cond.team
+        && expected != completed_team
+    {
+        return false;
     }
 
     true
@@ -327,7 +327,9 @@ async fn handle_app_event(
     use opengoose_types::AppEventKind;
 
     match kind {
-        AppEventKind::MessageReceived { author, content, .. } => {
+        AppEventKind::MessageReceived {
+            author, content, ..
+        } => {
             fire_matching_triggers(db, event_bus, "on_message", |cond| {
                 matches_on_message_event(cond, author, content)
             })


### PR DESCRIPTION
## Summary

- Add `on_message`, `on_session_start`, `on_session_end`, `on_schedule` trigger types to the `TriggerType` enum in `opengoose-teams`
- Add condition structs (`OnMessageCondition`, `OnSessionCondition`, `OnScheduleCondition`) and match functions for each new type
- Add `spawn_event_bus_trigger_watcher` that subscribes to the `EventBus` and fires headless team runs when registered triggers match system events
- Wire the watcher into the `opengoose run` command alongside the existing scheduler
- 11 new unit tests covering condition matching for all new trigger types

## Test plan

- [ ] `cargo test -p opengoose-teams -- triggers` — all 20 tests pass
- [ ] `cargo clippy -p opengoose-teams` — clean
- [ ] `cargo build -p opengoose-teams` — builds cleanly
- [ ] Trigger watcher starts at runtime: `opengoose run` logs "event-bus trigger watcher started"
- [ ] `opengoose trigger add my-trigger --type on_message --team code-review` succeeds
- [ ] Message arriving on any channel fires matching `on_message` triggers

Closes OPE-68

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
