### PR TITLE
feat(OPE-67): add input validation and structured error responses to web API

### DIFF
--- a/crates/opengoose-web/src/error.rs
+++ b/crates/opengoose-web/src/error.rs
@@ -17,6 +17,10 @@ pub enum WebError {
     #[error("bad request: {0}")]
     BadRequest(String),
 
+    /// Request body is well-formed but semantically invalid (HTTP 422).
+    #[error("unprocessable entity: {0}")]
+    UnprocessableEntity(String),
+
     /// Unexpected server-side failure (HTTP 500).
     #[error("internal error: {0}")]
     Internal(String),
@@ -53,6 +57,7 @@ impl WebError {
         match self {
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::UnprocessableEntity(_) => StatusCode::UNPROCESSABLE_ENTITY,
             Self::Persistence(e) if e.to_string().contains("NotFound") => StatusCode::NOT_FOUND,
             Self::Team(opengoose_teams::TeamError::NotFound(_)) => StatusCode::NOT_FOUND,
             Self::Team(opengoose_teams::TeamError::AlreadyExists(_)) => StatusCode::CONFLICT,
@@ -94,6 +99,12 @@ mod tests {
     fn bad_request_returns_400() {
         let err = WebError::BadRequest("invalid input".into());
         assert_eq!(err.status_code(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn unprocessable_entity_returns_422() {
+        let err = WebError::UnprocessableEntity("field out of range".into());
+        assert_eq!(err.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[test]

--- a/crates/opengoose-web/src/handlers/alerts.rs
+++ b/crates/opengoose-web/src/handlers/alerts.rs
@@ -94,6 +94,16 @@ pub async fn create_alert(
     State(state): State<AppState>,
     Json(body): Json<CreateAlertRequest>,
 ) -> Result<Json<AlertRuleResponse>, AppError> {
+    if body.name.trim().is_empty() {
+        return Err(AppError::UnprocessableEntity(
+            "`name` must not be empty".into(),
+        ));
+    }
+    if !body.threshold.is_finite() {
+        return Err(AppError::UnprocessableEntity(
+            "`threshold` must be a finite number".into(),
+        ));
+    }
     let metric = AlertMetric::parse(&body.metric).ok_or_else(|| {
         AppError::BadRequest(format!(
             "unknown metric `{}`. Valid: {}",

--- a/crates/opengoose-web/src/handlers/runs.rs
+++ b/crates/opengoose-web/src/handlers/runs.rs
@@ -23,9 +23,9 @@ pub struct RunItem {
 /// Query parameters for `GET /api/runs`.
 #[derive(Deserialize)]
 pub struct ListQuery {
-    /// Optional status filter (e.g. "running", "completed").
+    /// Optional status filter (e.g. "running", "completed", "failed", "suspended").
     pub status: Option<String>,
-    /// Maximum number of runs to return (default 50).
+    /// Maximum number of runs to return (default 50, max 1000).
     #[serde(default = "default_limit")]
     pub limit: i64,
 }
@@ -40,7 +40,21 @@ pub async fn list_runs(
     Query(q): Query<ListQuery>,
 ) -> Result<Json<Vec<RunItem>>, AppError> {
     use opengoose_persistence::RunStatus;
-    let status = q.status.as_deref().and_then(|s| RunStatus::parse(s).ok());
+    if q.limit <= 0 || q.limit > 1000 {
+        return Err(AppError::UnprocessableEntity(format!(
+            "`limit` must be between 1 and 1000, got {}",
+            q.limit
+        )));
+    }
+    let status = if let Some(s) = q.status.as_deref() {
+        Some(RunStatus::parse(s).map_err(|_| {
+            AppError::UnprocessableEntity(format!(
+                "unknown status `{s}`. Valid: running, completed, failed, suspended"
+            ))
+        })?)
+    } else {
+        None
+    };
     let runs = state
         .orchestration_store
         .list_runs(status.as_ref(), q.limit)?;

--- a/crates/opengoose-web/src/handlers/sessions.rs
+++ b/crates/opengoose-web/src/handlers/sessions.rs
@@ -17,7 +17,7 @@ pub struct SessionItem {
 /// Query parameters for `GET /api/sessions`.
 #[derive(Deserialize)]
 pub struct ListQuery {
-    /// Maximum number of sessions to return (default 50).
+    /// Maximum number of sessions to return (default 50, max 1000).
     #[serde(default = "default_limit")]
     pub limit: i64,
 }
@@ -31,6 +31,12 @@ pub async fn list_sessions(
     State(state): State<AppState>,
     Query(q): Query<ListQuery>,
 ) -> Result<Json<Vec<SessionItem>>, AppError> {
+    if q.limit <= 0 || q.limit > 1000 {
+        return Err(AppError::UnprocessableEntity(format!(
+            "`limit` must be between 1 and 1000, got {}",
+            q.limit
+        )));
+    }
     let sessions = state.session_store.list_sessions(q.limit)?;
     Ok(Json(
         sessions
@@ -57,7 +63,7 @@ pub struct MessageItem {
 /// Query parameters for `GET /api/sessions/{session_key}/messages`.
 #[derive(Deserialize)]
 pub struct MessagesQuery {
-    /// Maximum number of messages to return (default 100).
+    /// Maximum number of messages to return (default 100, max 5000).
     #[serde(default = "default_msg_limit")]
     pub limit: usize,
 }
@@ -72,6 +78,17 @@ pub async fn get_messages(
     Path(session_key): Path<String>,
     Query(q): Query<MessagesQuery>,
 ) -> Result<Json<Vec<MessageItem>>, AppError> {
+    if session_key.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "`session_key` must not be empty".into(),
+        ));
+    }
+    if q.limit == 0 || q.limit > 5000 {
+        return Err(AppError::UnprocessableEntity(format!(
+            "`limit` must be between 1 and 5000, got {}",
+            q.limit
+        )));
+    }
     use opengoose_types::SessionKey;
     // Accept raw stable-id strings directly (e.g. "discord:guild:channel")
     let key = SessionKey::from_stable_id(&session_key);


### PR DESCRIPTION
## Summary

- Add `UnprocessableEntity` (HTTP 422) variant to `WebError` with status code mapping and unit test
- `sessions`: validate `limit` range (1–1000); reject blank `session_key` paths
- `runs`: validate `limit` range (1–1000); return 422 for unknown `status` query values with valid-values hint
- `alerts`: validate `name` is non-empty; validate `threshold` is a finite number

## Test plan

- [x] `cargo test -p opengoose-web` — 26 tests pass, 0 failures
- [x] `cargo clippy -p opengoose-web -- -D warnings` — clean
- [x] New `unprocessable_entity_returns_422` unit test in `error.rs`
- [ ] Manual smoke: `GET /api/sessions?limit=0` → 422; `GET /api/runs?status=bogus` → 422 with hint

Closes OPE-67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
