### PR TITLE
feat(OPE-66): add structured tracing spans to opengoose-core

### DIFF
--- a/crates/opengoose-core/src/bridge.rs
+++ b/crates/opengoose-core/src/bridge.rs
@@ -222,19 +222,17 @@ impl GatewayBridge {
     ///
     /// Returns the decoded `SessionKey` so callers can reuse it for platform-specific
     /// sending without re-parsing the stable ID.
+    #[tracing::instrument(
+        name = "outgoing_message",
+        skip(self, body),
+        fields(gateway_type = %gateway_type, message_type = "outgoing")
+    )]
     pub async fn on_outgoing_message(
         &self,
         user_id: &str,
         body: &str,
         gateway_type: &str,
     ) -> SessionKey {
-        let _span = info_span!(
-            "outgoing_message",
-            gateway_type = %gateway_type,
-            message_type = "outgoing",
-        )
-        .entered();
-
         let session_key = SessionKey::from_stable_id(user_id);
 
         // Persist assistant message (from single-agent path)

--- a/crates/opengoose-core/src/engine.rs
+++ b/crates/opengoose-core/src/engine.rs
@@ -253,19 +253,17 @@ impl Engine {
     /// Always returns `Some(receiver)` — the Goose single-agent fallback is
     /// bypassed so that every conversation goes through the profile + workspace
     /// system.
+    #[tracing::instrument(
+        name = "process_message",
+        skip(self, text),
+        fields(session_id = %session_key.to_stable_id(), author = author.unwrap_or("unknown"))
+    )]
     pub async fn process_message_streaming(
         &self,
         session_key: &SessionKey,
         author: Option<&str>,
         text: &str,
     ) -> anyhow::Result<Option<tokio::sync::broadcast::Receiver<StreamChunk>>> {
-        let span = info_span!(
-            "process_message",
-            session_id = %session_key.to_stable_id(),
-            author = author.unwrap_or("unknown"),
-        );
-        let _enter = span.enter();
-
         let team_name = self.accept_message(session_key, author, text);
 
         let stream_id = Uuid::new_v4().to_string();

--- a/crates/opengoose-core/src/stream_orchestrator.rs
+++ b/crates/opengoose-core/src/stream_orchestrator.rs
@@ -1,5 +1,5 @@
 use tokio::sync::broadcast;
-use tracing::{debug_span, warn};
+use tracing::warn;
 
 use opengoose_types::StreamChunk;
 
@@ -18,6 +18,11 @@ use crate::throttle::ThrottlePolicy;
 /// * `rx` — receiver of [`StreamChunk`] events from the LLM/engine
 /// * `throttle` — platform-appropriate rate limiting policy
 /// * `max_display_len` — platform message size limit for intermediate updates
+#[tracing::instrument(
+    name = "drive_stream",
+    skip(responder, rx, throttle),
+    fields(channel_id = %channel_id, max_display_len = max_display_len)
+)]
 pub async fn drive_stream(
     responder: &dyn StreamResponder,
     channel_id: &str,
@@ -25,13 +30,6 @@ pub async fn drive_stream(
     mut throttle: ThrottlePolicy,
     max_display_len: usize,
 ) -> anyhow::Result<String> {
-    let _span = debug_span!(
-        "drive_stream",
-        channel_id = %channel_id,
-        max_display_len = max_display_len,
-    )
-    .entered();
-
     let handle = responder.create_draft(channel_id).await?;
     let mut buffer = String::new();
 


### PR DESCRIPTION
## Summary

- Adds `info_span!` / `debug_span!` tracing instrumentation to critical paths in opengoose-core
- **engine.rs**: `process_message`, `handle_team_command`, `team_orchestration` spans with `session_id`, `team_name`, `author`, `command` fields
- **bridge.rs**: `relay_message`, `outgoing_message` spans with `gateway_type`, `session_id`, `message_type` fields
- **stream_orchestrator.rs**: `drive_stream` span with `channel_id`, `max_display_len` fields

## Test plan

- [x] All 54 opengoose-core tests pass
- [x] Clippy clean
- [x] rustfmt clean
- [x] Only touches files within `crates/opengoose-core/src/` — no API changes, no new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
