### PR TITLE
test: Expand CLI auth and run coverage [OPE-111]

### DIFF
--- a/crates/opengoose-cli/src/cmd/auth.rs
+++ b/crates/opengoose-cli/src/cmd/auth.rs
@@ -523,14 +523,55 @@ fn provider_status(
 mod tests {
     use super::*;
 
-    use std::sync::Once;
+    use std::sync::{Mutex, Once};
 
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
     static RUSTLS_INIT: Once = Once::new();
 
     fn ensure_rustls_provider() {
         RUSTLS_INIT.call_once(|| {
             let _ = rustls::crypto::ring::default_provider().install_default();
         });
+    }
+
+    struct EnvVarGuard {
+        name: String,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &str, value: Option<&str>) -> Self {
+            let original = std::env::var(name).ok();
+            // Safety: test-only helper guarded by ENV_LOCK.
+            unsafe {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+            Self {
+                name: name.to_string(),
+                original,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // Safety: test-only helper guarded by ENV_LOCK.
+            unsafe {
+                match &self.original {
+                    Some(value) => std::env::set_var(&self.name, value),
+                    None => std::env::remove_var(&self.name),
+                }
+            }
+        }
+    }
+
+    fn with_env_var<T>(name: &str, value: Option<&str>, test: impl FnOnce() -> T) -> T {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvVarGuard::set(name, value);
+        test()
     }
 
     #[test]
@@ -559,10 +600,46 @@ mod tests {
             default: None,
             primary: false,
         };
+        let profile = ConfigKeySummary {
+            name: "AWS_PROFILE".into(),
+            required: false,
+            secret: false,
+            oauth_flow: false,
+            default: None,
+            primary: false,
+        };
+        let project = ConfigKeySummary {
+            name: "GOOGLE_PROJECT".into(),
+            required: false,
+            secret: false,
+            oauth_flow: false,
+            default: None,
+            primary: false,
+        };
+        let deployment = ConfigKeySummary {
+            name: "AZURE_DEPLOYMENT".into(),
+            required: false,
+            secret: false,
+            oauth_flow: false,
+            default: None,
+            primary: false,
+        };
+        let fallback = ConfigKeySummary {
+            name: "CUSTOM_SETTING".into(),
+            required: false,
+            secret: false,
+            oauth_flow: false,
+            default: None,
+            primary: false,
+        };
 
         assert_eq!(key_label(&api_key), "API Key");
         assert_eq!(key_label(&token), "Token");
         assert_eq!(key_label(&location), "Location");
+        assert_eq!(key_label(&profile), "Profile");
+        assert_eq!(key_label(&project), "Project ID");
+        assert_eq!(key_label(&deployment), "Deployment");
+        assert_eq!(key_label(&fallback), "Value");
     }
 
     #[tokio::test]
@@ -614,15 +691,24 @@ mod tests {
         );
     }
 
-    fn make_key(name: &str, required: bool, oauth_flow: bool) -> ConfigKeySummary {
+    fn make_key_with_primary(
+        name: &str,
+        required: bool,
+        oauth_flow: bool,
+        primary: bool,
+    ) -> ConfigKeySummary {
         ConfigKeySummary {
             name: name.into(),
             required,
             secret: true,
             oauth_flow,
             default: None,
-            primary: true,
+            primary,
         }
+    }
+
+    fn make_key(name: &str, required: bool, oauth_flow: bool) -> ConfigKeySummary {
+        make_key_with_primary(name, required, oauth_flow, true)
     }
 
     fn make_provider(name: &str, keys: Vec<ConfigKeySummary>) -> ProviderSummary {
@@ -634,6 +720,17 @@ mod tests {
             known_models: vec![],
             config_keys: keys,
         }
+    }
+
+    fn config_with_provider_keys(provider_name: &str, keys_in_keyring: &[&str]) -> ConfigFile {
+        let mut config = ConfigFile::default();
+        config.providers.insert(
+            provider_name.to_string(),
+            opengoose_secrets::ProviderMeta {
+                keys_in_keyring: keys_in_keyring.iter().map(|key| key.to_string()).collect(),
+            },
+        );
+        config
     }
 
     #[test]
@@ -655,6 +752,18 @@ mod tests {
     }
 
     #[test]
+    fn provider_auth_type_prefers_primary_key_over_first_key() {
+        let provider = make_provider(
+            "mixed",
+            vec![
+                make_key_with_primary("MIXED_API_KEY", true, false, false),
+                make_key_with_primary("MIXED_TOKEN", true, true, true),
+            ],
+        );
+        assert_eq!(provider_auth_type(&provider), "oauth");
+    }
+
+    #[test]
     fn provider_status_ready_when_no_required_keys() {
         let provider = make_provider("local", vec![]);
         let config = opengoose_secrets::ConfigFile::default();
@@ -665,14 +774,16 @@ mod tests {
 
     #[test]
     fn provider_status_not_configured_when_key_missing() {
-        let provider = make_provider("openai", vec![make_key("OPENAI_API_KEY", true, false)]);
-        // Ensure the env var is not set
-        // Safety: test-only, single-threaded test runner for this module
-        unsafe { std::env::remove_var("OPENAI_API_KEY") };
-        let config = opengoose_secrets::ConfigFile::default();
-        let (status, via) = provider_status(&provider, &config);
-        assert_eq!(status, "not configured");
-        assert!(via.is_none());
+        let provider = make_provider(
+            "test-provider-missing",
+            vec![make_key("OPENGOOSE_TEST_MISSING_KEY_12345", true, false)],
+        );
+        with_env_var("OPENGOOSE_TEST_MISSING_KEY_12345", None, || {
+            let config = opengoose_secrets::ConfigFile::default();
+            let (status, via) = provider_status(&provider, &config);
+            assert_eq!(status, "not configured");
+            assert!(via.is_none());
+        });
     }
 
     #[test]
@@ -681,12 +792,77 @@ mod tests {
             "test-provider-env",
             vec![make_key("OPENGOOSE_TEST_ENV_KEY_12345", true, false)],
         );
-        // Safety: test-only, single-threaded test runner for this module
-        unsafe { std::env::set_var("OPENGOOSE_TEST_ENV_KEY_12345", "test-value") };
-        let config = opengoose_secrets::ConfigFile::default();
+        with_env_var("OPENGOOSE_TEST_ENV_KEY_12345", Some("test-value"), || {
+            let config = opengoose_secrets::ConfigFile::default();
+            let (status, via) = provider_status(&provider, &config);
+            assert_eq!(status, "configured");
+            assert_eq!(via, Some("env"));
+        });
+    }
+
+    #[test]
+    fn provider_status_not_configured_when_env_value_is_empty() {
+        let provider = make_provider(
+            "test-provider-empty",
+            vec![make_key("OPENGOOSE_TEST_EMPTY_KEY_12345", true, false)],
+        );
+        with_env_var("OPENGOOSE_TEST_EMPTY_KEY_12345", Some(""), || {
+            let config = opengoose_secrets::ConfigFile::default();
+            let (status, via) = provider_status(&provider, &config);
+            assert_eq!(status, "not configured");
+            assert!(via.is_none());
+        });
+    }
+
+    #[test]
+    fn provider_status_configured_via_keyring_when_all_required_keys_exist() {
+        let provider = make_provider(
+            "keyring-provider",
+            vec![
+                make_key("KEYRING_API_KEY", true, false),
+                make_key_with_primary("KEYRING_ORG_ID", true, false, false),
+            ],
+        );
+        let config =
+            config_with_provider_keys("keyring-provider", &["keyring_api_key", "keyring_org_id"]);
         let (status, via) = provider_status(&provider, &config);
-        unsafe { std::env::remove_var("OPENGOOSE_TEST_ENV_KEY_12345") };
         assert_eq!(status, "configured");
-        assert_eq!(via, Some("env"));
+        assert_eq!(via, Some("keyring"));
+    }
+
+    #[test]
+    fn provider_status_not_configured_when_keyring_is_missing_required_key() {
+        let provider = make_provider(
+            "partial-keyring-provider",
+            vec![
+                make_key("PARTIAL_API_KEY", true, false),
+                make_key_with_primary("PARTIAL_ORG_ID", true, false, false),
+            ],
+        );
+        let config = config_with_provider_keys("partial-keyring-provider", &["partial_api_key"]);
+        let (status, via) = provider_status(&provider, &config);
+        assert_eq!(status, "not configured");
+        assert!(via.is_none());
+    }
+
+    #[test]
+    fn provider_status_prefers_env_when_env_and_keyring_are_both_available() {
+        let provider = make_provider(
+            "env-precedence-provider",
+            vec![make_key("OPENGOOSE_TEST_PRECEDENCE_KEY_12345", true, false)],
+        );
+        with_env_var(
+            "OPENGOOSE_TEST_PRECEDENCE_KEY_12345",
+            Some("present"),
+            || {
+                let config = config_with_provider_keys(
+                    "env-precedence-provider",
+                    &["opengoose_test_precedence_key_12345"],
+                );
+                let (status, via) = provider_status(&provider, &config);
+                assert_eq!(status, "configured");
+                assert_eq!(via, Some("env"));
+            },
+        );
     }
 }

--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -361,7 +361,7 @@ mod tests {
     use opengoose_secrets::{
         ConfigFile, CredentialResolver, SecretResult, SecretStore, SecretValue,
     };
-    use opengoose_types::AppEventKind;
+    use opengoose_types::{AppEventKind, EventBus, Platform, SessionKey};
 
     static RUSTLS_INIT: Once = Once::new();
     static GOOSE_PATH_ROOT: OnceLock<std::path::PathBuf> = OnceLock::new();
@@ -442,6 +442,27 @@ mod tests {
             ConfigFile::default(),
             Arc::new(MockStore::new(entries)),
         )
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn register_pushes_gateway_and_bridge_into_their_respective_vectors() {
+        let event_bus = EventBus::new(16);
+        let engine = test_engine(event_bus.clone());
+        let bridge = Arc::new(GatewayBridge::new(engine));
+        let gateway: Arc<dyn Gateway> = Arc::new(DiscordGateway::new(
+            "discord-token",
+            bridge.clone(),
+            event_bus,
+        ));
+        let mut gateways = Vec::new();
+        let mut bridges = Vec::new();
+
+        register(&mut gateways, &mut bridges, gateway.clone(), bridge.clone());
+
+        assert_eq!(gateways.len(), 1);
+        assert_eq!(gateways[0].gateway_type(), "discord");
+        assert_eq!(bridges.len(), 1);
+        assert!(Arc::ptr_eq(&bridges[0], &bridge));
     }
 
     #[tokio::test]
@@ -558,6 +579,103 @@ mod tests {
             store.consume_pending_code(&code).await.unwrap(),
             Some("discord".into())
         );
+
+        cancel.cancel();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn spawn_pairing_handler_generates_codes_for_each_registered_bridge() {
+        ensure_goose_test_root();
+
+        let event_bus = EventBus::new(16);
+        let mut events = event_bus.subscribe();
+
+        let first_bridge = Arc::new(GatewayBridge::new(test_engine(event_bus.clone())));
+        let first_store = Arc::new(PairingStore::new().unwrap());
+        first_bridge.set_pairing_store(first_store.clone()).await;
+
+        let second_bridge = Arc::new(GatewayBridge::new(test_engine(event_bus.clone())));
+        let second_store = Arc::new(PairingStore::new().unwrap());
+        second_bridge.set_pairing_store(second_store.clone()).await;
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        spawn_pairing_handler(
+            vec![first_bridge, second_bridge],
+            vec!["discord".to_string(), "slack".to_string()],
+            rx,
+            cancel.clone(),
+        );
+
+        tx.send(()).unwrap();
+
+        let mut codes = Vec::new();
+        for _ in 0..2 {
+            let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            let code = match event.kind {
+                AppEventKind::PairingCodeGenerated { code } => code,
+                other => unreachable!("expected pairing code event, got {}", other),
+            };
+            codes.push(code);
+        }
+
+        let mut platforms = Vec::new();
+        for code in codes {
+            if let Some(platform) = first_store.consume_pending_code(&code).await.unwrap() {
+                platforms.push(platform);
+                continue;
+            }
+            if let Some(platform) = second_store.consume_pending_code(&code).await.unwrap() {
+                platforms.push(platform);
+                continue;
+            }
+            panic!("pairing code was not stored on any bridge");
+        }
+
+        platforms.sort();
+        assert_eq!(platforms, vec!["discord".to_string(), "slack".to_string()]);
+
+        cancel.cancel();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn spawn_tui_composer_handler_emits_error_event_when_engine_processing_fails() {
+        let event_bus = EventBus::new(16);
+        let mut events = event_bus.subscribe();
+        let engine = Arc::new(Engine::new_with_team_store(
+            event_bus.clone(),
+            Database::open_in_memory().unwrap(),
+            None,
+        ));
+        let session_key = SessionKey::dm(Platform::Discord, "operator");
+        engine.set_active_team(&session_key, "code-review".to_string());
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        spawn_tui_composer_handler(engine, event_bus.clone(), rx, cancel.clone());
+
+        tx.send(ComposerRequest {
+            session_key,
+            content: "hello world".to_string(),
+        })
+        .unwrap();
+
+        let (context, message) = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let event = events.recv().await.unwrap();
+                if let AppEventKind::Error { context, message } = event.kind {
+                    return (context, message);
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(context, "tui_compose");
+        assert!(message.contains("team store not available"));
 
         cancel.cancel();
     }

--- a/crates/opengoose-cli/src/cmd/skill.rs
+++ b/crates/opengoose-cli/src/cmd/skill.rs
@@ -124,9 +124,7 @@ mod tests {
     }
 
     fn minimal_skill_yaml(name: &str) -> String {
-        format!(
-            "name: {name}\nversion: \"1.0.0\"\ndescription: A test skill\nextensions: []\n"
-        )
+        format!("name: {name}\nversion: \"1.0.0\"\ndescription: A test skill\nextensions: []\n")
     }
 
     fn write_skill_file(dir: &TempDir, name: &str) -> PathBuf {
@@ -253,7 +251,10 @@ mod tests {
         let (_tmp, store) = temp_store();
         store.install_defaults(false).unwrap();
         let second = store.install_defaults(false).unwrap();
-        assert_eq!(second, 0, "re-installing without force should install nothing");
+        assert_eq!(
+            second, 0,
+            "re-installing without force should install nothing"
+        );
     }
 
     #[test]

--- a/crates/opengoose-persistence/src/db.rs
+++ b/crates/opengoose-persistence/src/db.rs
@@ -68,7 +68,10 @@ impl Database {
     where
         F: FnOnce(&mut SqliteConnection) -> PersistenceResult<T>,
     {
-        let mut conn = self.conn.lock().map_err(|_| PersistenceError::LockPoisoned)?;
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|_| PersistenceError::LockPoisoned)?;
         f(&mut conn)
     }
 
@@ -418,8 +421,9 @@ mod tests {
     fn test_wal_journal_mode() {
         #[derive(diesel::QueryableByName)]
         struct JournalRow {
+            #[diesel(column_name = journal_mode)]
             #[diesel(sql_type = diesel::sql_types::Text)]
-            journal_mode: String,
+            _journal_mode: String,
         }
         let db = Database::open_in_memory().unwrap();
         db.with(|conn| {

--- a/crates/opengoose-secrets/src/resolver.rs
+++ b/crates/opengoose-secrets/src/resolver.rs
@@ -371,9 +371,7 @@ mod tests {
             // so we only assert on the error case when the env var is absent).
             if std::env::var(key_info.env_var).is_err() {
                 let secret_key = SecretKey::Custom(key_info.env_var.to_lowercase());
-                let result = resolver.resolve(&SecretKey::Custom(
-                    key_info.env_var.to_lowercase(),
-                ));
+                let result = resolver.resolve(&SecretKey::Custom(key_info.env_var.to_lowercase()));
                 match result {
                     Err(SecretError::NotFound { .. }) => {}
                     Ok(_) => {
@@ -402,9 +400,7 @@ mod tests {
             ConfigFile::default(),
             Arc::new(MockStore::new()),
         );
-        let result = resolver.resolve(&SecretKey::Custom(
-            key_info.env_var.to_lowercase(),
-        ));
+        let result = resolver.resolve(&SecretKey::Custom(key_info.env_var.to_lowercase()));
 
         unsafe { std::env::remove_var(key_info.env_var) };
 
@@ -433,7 +429,10 @@ mod tests {
 
         let err_msg = err.to_string();
         // Error message should reference the key/env var for actionability, not a secret value.
-        assert!(err_msg.contains("sensitive_key") || err_msg.contains("OPENGOOSE_DEFINITELY_NOT_SET_SENSITIVE"));
+        assert!(
+            err_msg.contains("sensitive_key")
+                || err_msg.contains("OPENGOOSE_DEFINITELY_NOT_SET_SENSITIVE")
+        );
         // Confirm SecretValue Debug stays redacted.
         let val = crate::SecretValue::new("hunter2".into());
         let debug = format!("{:?}", val);
@@ -556,8 +555,7 @@ mod tests {
         }
 
         let store = Arc::new(MockStore::new());
-        let resolver =
-            CredentialResolver::with_config_and_store(ConfigFile::default(), store);
+        let resolver = CredentialResolver::with_config_and_store(ConfigFile::default(), store);
 
         for (key, _) in &well_known {
             let result = resolver.resolve(key);

--- a/crates/opengoose-web/src/handlers/sessions.rs
+++ b/crates/opengoose-web/src/handlers/sessions.rs
@@ -157,12 +157,9 @@ mod tests {
     #[tokio::test]
     async fn list_sessions_returns_empty_initially() {
         let state = make_state();
-        let Json(sessions) = list_sessions(
-            State(state),
-            Query(ListQuery { limit: 50 }),
-        )
-        .await
-        .expect("list_sessions should succeed");
+        let Json(sessions) = list_sessions(State(state), Query(ListQuery { limit: 50 }))
+            .await
+            .expect("list_sessions should succeed");
         assert!(sessions.is_empty());
     }
 
@@ -175,12 +172,9 @@ mod tests {
             .append_user_message(&key, "hello world", Some("alice"))
             .expect("append should succeed");
 
-        let Json(sessions) = list_sessions(
-            State(state),
-            Query(ListQuery { limit: 50 }),
-        )
-        .await
-        .expect("list_sessions should succeed");
+        let Json(sessions) = list_sessions(State(state), Query(ListQuery { limit: 50 }))
+            .await
+            .expect("list_sessions should succeed");
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_key, "discord:ns:guild123:chan456");
@@ -197,12 +191,9 @@ mod tests {
                 .expect("append should succeed");
         }
 
-        let Json(sessions) = list_sessions(
-            State(state),
-            Query(ListQuery { limit: 3 }),
-        )
-        .await
-        .expect("list_sessions should succeed");
+        let Json(sessions) = list_sessions(State(state), Query(ListQuery { limit: 3 }))
+            .await
+            .expect("list_sessions should succeed");
 
         assert_eq!(sessions.len(), 3);
     }


### PR DESCRIPTION
## Summary
- expand `auth.rs` coverage around key labeling, auth type selection, env/keyring precedence, and missing-value paths
- expand `run.rs` coverage around gateway registration, multi-bridge pairing generation, and composer error propagation
- clear a pre-existing persistence test warning so strict clippy passes cleanly

## Verification
- `cargo fmt --all`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Paperclip issue: [OPE-111](http://localhost:3131/OPE/issues/OPE-111)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
