### PR TITLE
test: Add web handler unit coverage [OPE-109]

### DIFF
--- a/crates/opengoose-cli/src/cmd/skill.rs
+++ b/crates/opengoose-cli/src/cmd/skill.rs
@@ -124,9 +124,7 @@ mod tests {
     }
 
     fn minimal_skill_yaml(name: &str) -> String {
-        format!(
-            "name: {name}\nversion: \"1.0.0\"\ndescription: A test skill\nextensions: []\n"
-        )
+        format!("name: {name}\nversion: \"1.0.0\"\ndescription: A test skill\nextensions: []\n")
     }
 
     fn write_skill_file(dir: &TempDir, name: &str) -> PathBuf {
@@ -253,7 +251,10 @@ mod tests {
         let (_tmp, store) = temp_store();
         store.install_defaults(false).unwrap();
         let second = store.install_defaults(false).unwrap();
-        assert_eq!(second, 0, "re-installing without force should install nothing");
+        assert_eq!(
+            second, 0,
+            "re-installing without force should install nothing"
+        );
     }
 
     #[test]

--- a/crates/opengoose-persistence/src/db.rs
+++ b/crates/opengoose-persistence/src/db.rs
@@ -68,7 +68,10 @@ impl Database {
     where
         F: FnOnce(&mut SqliteConnection) -> PersistenceResult<T>,
     {
-        let mut conn = self.conn.lock().map_err(|_| PersistenceError::LockPoisoned)?;
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|_| PersistenceError::LockPoisoned)?;
         f(&mut conn)
     }
 
@@ -424,9 +427,14 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         db.with(|conn| {
             // In-memory databases always report "memory" mode even when WAL is requested;
-            // for file databases the pragma returns "wal". We just verify the pragma runs
-            // without error.
-            let _: Vec<JournalRow> = diesel::sql_query("PRAGMA journal_mode").load(conn)?;
+            // for file databases the pragma returns "wal".
+            let rows: Vec<JournalRow> = diesel::sql_query("PRAGMA journal_mode").load(conn)?;
+            let mode = rows
+                .into_iter()
+                .next()
+                .expect("journal_mode pragma should return one row")
+                .journal_mode;
+            assert!(mode == "memory" || mode == "wal");
             Ok(())
         })
         .unwrap();

--- a/crates/opengoose-secrets/src/resolver.rs
+++ b/crates/opengoose-secrets/src/resolver.rs
@@ -371,9 +371,7 @@ mod tests {
             // so we only assert on the error case when the env var is absent).
             if std::env::var(key_info.env_var).is_err() {
                 let secret_key = SecretKey::Custom(key_info.env_var.to_lowercase());
-                let result = resolver.resolve(&SecretKey::Custom(
-                    key_info.env_var.to_lowercase(),
-                ));
+                let result = resolver.resolve(&SecretKey::Custom(key_info.env_var.to_lowercase()));
                 match result {
                     Err(SecretError::NotFound { .. }) => {}
                     Ok(_) => {
@@ -402,9 +400,7 @@ mod tests {
             ConfigFile::default(),
             Arc::new(MockStore::new()),
         );
-        let result = resolver.resolve(&SecretKey::Custom(
-            key_info.env_var.to_lowercase(),
-        ));
+        let result = resolver.resolve(&SecretKey::Custom(key_info.env_var.to_lowercase()));
 
         unsafe { std::env::remove_var(key_info.env_var) };
 
@@ -433,7 +429,10 @@ mod tests {
 
         let err_msg = err.to_string();
         // Error message should reference the key/env var for actionability, not a secret value.
-        assert!(err_msg.contains("sensitive_key") || err_msg.contains("OPENGOOSE_DEFINITELY_NOT_SET_SENSITIVE"));
+        assert!(
+            err_msg.contains("sensitive_key")
+                || err_msg.contains("OPENGOOSE_DEFINITELY_NOT_SET_SENSITIVE")
+        );
         // Confirm SecretValue Debug stays redacted.
         let val = crate::SecretValue::new("hunter2".into());
         let debug = format!("{:?}", val);
@@ -556,8 +555,7 @@ mod tests {
         }
 
         let store = Arc::new(MockStore::new());
-        let resolver =
-            CredentialResolver::with_config_and_store(ConfigFile::default(), store);
+        let resolver = CredentialResolver::with_config_and_store(ConfigFile::default(), store);
 
         for (key, _) in &well_known {
             let result = resolver.resolve(key);

--- a/crates/opengoose-web/src/handlers/agents.rs
+++ b/crates/opengoose-web/src/handlers/agents.rs
@@ -19,3 +19,59 @@ pub async fn list_agents(State(state): State<AppState>) -> Result<Json<Vec<Agent
         names.into_iter().map(|name| AgentItem { name }).collect(),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::Json;
+    use axum::extract::State;
+
+    use super::list_agents;
+    use crate::error::WebError;
+    use crate::handlers::test_support::{
+        make_state, make_state_with_dirs, sample_profile, unique_temp_dir, unique_temp_path,
+    };
+
+    #[tokio::test]
+    async fn list_agents_returns_empty_initially() {
+        let Json(agents) = list_agents(State(make_state()))
+            .await
+            .expect("list_agents should succeed");
+
+        assert!(agents.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_agents_returns_sorted_names() {
+        let state = make_state();
+        state
+            .profile_store
+            .save(&sample_profile("zeta"), false)
+            .expect("first profile should be saved");
+        state
+            .profile_store
+            .save(&sample_profile("alpha"), false)
+            .expect("second profile should be saved");
+
+        let Json(agents) = list_agents(State(state))
+            .await
+            .expect("list_agents should succeed");
+
+        let names: Vec<String> = agents.into_iter().map(|agent| agent.name).collect();
+        assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    #[tokio::test]
+    async fn list_agents_propagates_store_errors() {
+        let invalid_profile_path = unique_temp_path("profiles-file");
+        std::fs::write(&invalid_profile_path, "not a directory")
+            .expect("profile file should be created");
+        let state = make_state_with_dirs(invalid_profile_path, unique_temp_dir("teams"));
+
+        let err = list_agents(State(state))
+            .await
+            .err()
+            .expect("invalid profile store path should fail");
+
+        assert!(matches!(err, WebError::Profile(_)));
+    }
+}

--- a/crates/opengoose-web/src/handlers/dashboard.rs
+++ b/crates/opengoose-web/src/handlers/dashboard.rs
@@ -37,3 +37,117 @@ pub async fn get_dashboard(
         team_count,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::Json;
+    use axum::extract::State;
+    use opengoose_types::SessionKey;
+
+    use super::get_dashboard;
+    use crate::handlers::test_support::{
+        make_state, make_state_with_dirs, sample_profile, sample_team, unique_temp_path,
+    };
+
+    #[tokio::test]
+    async fn get_dashboard_returns_zero_counts_initially() {
+        let Json(stats) = get_dashboard(State(make_state()))
+            .await
+            .expect("dashboard should succeed");
+
+        assert_eq!(stats.session_count, 0);
+        assert_eq!(stats.message_count, 0);
+        assert_eq!(stats.run_count, 0);
+        assert_eq!(stats.agent_count, 0);
+        assert_eq!(stats.team_count, 0);
+    }
+
+    #[tokio::test]
+    async fn get_dashboard_aggregates_counts_from_stores() {
+        let state = make_state();
+        let key = SessionKey::from_stable_id("discord:ns:guild:channel");
+        state
+            .session_store
+            .append_user_message(&key, "hello", Some("alice"))
+            .expect("user message should be stored");
+        state
+            .session_store
+            .append_assistant_message(&key, "hi there")
+            .expect("assistant message should be stored");
+
+        state
+            .orchestration_store
+            .create_run(
+                "run-1",
+                "discord:ns:guild:channel",
+                "code-review",
+                "chain",
+                "input",
+                2,
+            )
+            .expect("first run should be created");
+        state
+            .orchestration_store
+            .create_run(
+                "run-2",
+                "discord:ns:guild:channel",
+                "feature-dev",
+                "fan_out",
+                "input",
+                3,
+            )
+            .expect("second run should be created");
+
+        state
+            .profile_store
+            .save(&sample_profile("alpha"), false)
+            .expect("first profile should be saved");
+        state
+            .profile_store
+            .save(&sample_profile("beta"), false)
+            .expect("second profile should be saved");
+        state
+            .team_store
+            .save(&sample_team("frontend-team", "alpha"), false)
+            .expect("team should be saved");
+
+        let Json(stats) = get_dashboard(State(state))
+            .await
+            .expect("dashboard should succeed");
+
+        assert_eq!(stats.session_count, 1);
+        assert_eq!(stats.message_count, 2);
+        assert_eq!(stats.run_count, 2);
+        assert_eq!(stats.agent_count, 2);
+        assert_eq!(stats.team_count, 1);
+    }
+
+    #[tokio::test]
+    async fn get_dashboard_defaults_agent_and_team_counts_to_zero_on_list_errors() {
+        let profile_path = unique_temp_path("profiles-file");
+        let team_path = unique_temp_path("teams-file");
+        std::fs::write(&profile_path, "not a directory").expect("profile file should be created");
+        std::fs::write(&team_path, "not a directory").expect("team file should be created");
+
+        let state = make_state_with_dirs(profile_path, team_path);
+        let key = SessionKey::from_stable_id("slack:ns:team:channel");
+        state
+            .session_store
+            .append_user_message(&key, "hello", None)
+            .expect("message should be stored");
+        state
+            .orchestration_store
+            .create_run("run-1", "slack:ns:team:channel", "ops", "chain", "input", 1)
+            .expect("run should be created");
+
+        let Json(stats) = get_dashboard(State(state))
+            .await
+            .expect("dashboard should succeed");
+
+        assert_eq!(stats.session_count, 1);
+        assert_eq!(stats.message_count, 1);
+        assert_eq!(stats.run_count, 1);
+        assert_eq!(stats.agent_count, 0);
+        assert_eq!(stats.team_count, 0);
+    }
+}

--- a/crates/opengoose-web/src/handlers/mod.rs
+++ b/crates/opengoose-web/src/handlers/mod.rs
@@ -17,6 +17,9 @@ pub mod teams;
 /// JSON API handlers for workflow definitions and manual triggers.
 pub mod workflows;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 /// Handler-level error type.
 ///
 /// This is a type alias for [`crate::error::WebError`], which provides

--- a/crates/opengoose-web/src/handlers/runs.rs
+++ b/crates/opengoose-web/src/handlers/runs.rs
@@ -75,3 +75,202 @@ pub async fn list_runs(
             .collect(),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::Json;
+    use axum::extract::{Query, State};
+    use opengoose_persistence::RunStatus;
+
+    use super::{ListQuery, list_runs};
+    use crate::error::WebError;
+    use crate::handlers::test_support::make_state;
+
+    #[tokio::test]
+    async fn list_runs_returns_empty_initially() {
+        let state = make_state();
+
+        let Json(runs) = list_runs(
+            State(state),
+            Query(ListQuery {
+                status: None,
+                limit: 50,
+            }),
+        )
+        .await
+        .expect("list_runs should succeed");
+
+        assert!(runs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_runs_maps_run_fields_from_store() {
+        let state = make_state();
+        state
+            .orchestration_store
+            .create_run(
+                "run-1",
+                "session-1",
+                "code-review",
+                "chain",
+                "review this",
+                3,
+            )
+            .expect("run should be created");
+        state
+            .orchestration_store
+            .advance_step("run-1", 2)
+            .expect("step should advance");
+        state
+            .orchestration_store
+            .complete_run("run-1", "approved")
+            .expect("run should complete");
+
+        let Json(runs) = list_runs(
+            State(state),
+            Query(ListQuery {
+                status: Some("completed".into()),
+                limit: 50,
+            }),
+        )
+        .await
+        .expect("list_runs should succeed");
+
+        assert_eq!(runs.len(), 1);
+        let run = &runs[0];
+        assert_eq!(run.team_run_id, "run-1");
+        assert_eq!(run.session_key, "session-1");
+        assert_eq!(run.team_name, "code-review");
+        assert_eq!(run.workflow, "chain");
+        assert_eq!(run.status, RunStatus::Completed.as_str());
+        assert_eq!(run.current_step, 2);
+        assert_eq!(run.total_steps, 3);
+        assert_eq!(run.result.as_deref(), Some("approved"));
+        assert!(!run.created_at.is_empty());
+        assert!(!run.updated_at.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_runs_filters_by_status() {
+        let state = make_state();
+        state
+            .orchestration_store
+            .create_run(
+                "run-running",
+                "session-1",
+                "frontend",
+                "chain",
+                "build ui",
+                2,
+            )
+            .expect("running run should be created");
+        state
+            .orchestration_store
+            .create_run(
+                "run-completed",
+                "session-2",
+                "backend",
+                "fan_out",
+                "ship api",
+                4,
+            )
+            .expect("completed run should be created");
+        state
+            .orchestration_store
+            .complete_run("run-completed", "done")
+            .expect("run should complete");
+
+        let Json(runs) = list_runs(
+            State(state),
+            Query(ListQuery {
+                status: Some("running".into()),
+                limit: 50,
+            }),
+        )
+        .await
+        .expect("list_runs should succeed");
+
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].team_run_id, "run-running");
+        assert_eq!(runs[0].status, RunStatus::Running.as_str());
+    }
+
+    #[tokio::test]
+    async fn list_runs_respects_limit() {
+        let state = make_state();
+        for i in 0..5 {
+            state
+                .orchestration_store
+                .create_run(
+                    &format!("run-{i}"),
+                    &format!("session-{i}"),
+                    "ops",
+                    "chain",
+                    "input",
+                    1,
+                )
+                .expect("run should be created");
+        }
+
+        let Json(runs) = list_runs(
+            State(state),
+            Query(ListQuery {
+                status: None,
+                limit: 3,
+            }),
+        )
+        .await
+        .expect("list_runs should succeed");
+
+        assert_eq!(runs.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn list_runs_rejects_out_of_range_limits() {
+        let zero_limit = list_runs(
+            State(make_state()),
+            Query(ListQuery {
+                status: None,
+                limit: 0,
+            }),
+        )
+        .await
+        .err()
+        .expect("zero limit should be rejected");
+        assert!(
+            matches!(zero_limit, WebError::UnprocessableEntity(message) if message.contains("between 1 and 1000"))
+        );
+
+        let too_large_limit = list_runs(
+            State(make_state()),
+            Query(ListQuery {
+                status: None,
+                limit: 1001,
+            }),
+        )
+        .await
+        .err()
+        .expect("too-large limit should be rejected");
+        assert!(
+            matches!(too_large_limit, WebError::UnprocessableEntity(message) if message.contains("between 1 and 1000"))
+        );
+    }
+
+    #[tokio::test]
+    async fn list_runs_rejects_unknown_status() {
+        let err = list_runs(
+            State(make_state()),
+            Query(ListQuery {
+                status: Some("bogus".into()),
+                limit: 50,
+            }),
+        )
+        .await
+        .err()
+        .expect("unknown status should be rejected");
+
+        assert!(
+            matches!(err, WebError::UnprocessableEntity(message) if message.contains("unknown status"))
+        );
+    }
+}

--- a/crates/opengoose-web/src/handlers/sessions.rs
+++ b/crates/opengoose-web/src/handlers/sessions.rs
@@ -157,12 +157,9 @@ mod tests {
     #[tokio::test]
     async fn list_sessions_returns_empty_initially() {
         let state = make_state();
-        let Json(sessions) = list_sessions(
-            State(state),
-            Query(ListQuery { limit: 50 }),
-        )
-        .await
-        .expect("list_sessions should succeed");
+        let Json(sessions) = list_sessions(State(state), Query(ListQuery { limit: 50 }))
+            .await
+            .expect("list_sessions should succeed");
         assert!(sessions.is_empty());
     }
 
@@ -175,12 +172,9 @@ mod tests {
             .append_user_message(&key, "hello world", Some("alice"))
             .expect("append should succeed");
 
-        let Json(sessions) = list_sessions(
-            State(state),
-            Query(ListQuery { limit: 50 }),
-        )
-        .await
-        .expect("list_sessions should succeed");
+        let Json(sessions) = list_sessions(State(state), Query(ListQuery { limit: 50 }))
+            .await
+            .expect("list_sessions should succeed");
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_key, "discord:ns:guild123:chan456");
@@ -197,12 +191,9 @@ mod tests {
                 .expect("append should succeed");
         }
 
-        let Json(sessions) = list_sessions(
-            State(state),
-            Query(ListQuery { limit: 3 }),
-        )
-        .await
-        .expect("list_sessions should succeed");
+        let Json(sessions) = list_sessions(State(state), Query(ListQuery { limit: 3 }))
+            .await
+            .expect("list_sessions should succeed");
 
         assert_eq!(sessions.len(), 3);
     }

--- a/crates/opengoose-web/src/handlers/teams.rs
+++ b/crates/opengoose-web/src/handlers/teams.rs
@@ -19,3 +19,58 @@ pub async fn list_teams(State(state): State<AppState>) -> Result<Json<Vec<TeamIt
         names.into_iter().map(|name| TeamItem { name }).collect(),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::Json;
+    use axum::extract::State;
+
+    use super::list_teams;
+    use crate::error::WebError;
+    use crate::handlers::test_support::{
+        make_state, make_state_with_dirs, sample_team, unique_temp_dir, unique_temp_path,
+    };
+
+    #[tokio::test]
+    async fn list_teams_returns_empty_initially() {
+        let Json(teams) = list_teams(State(make_state()))
+            .await
+            .expect("list_teams should succeed");
+
+        assert!(teams.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_teams_returns_sorted_names() {
+        let state = make_state();
+        state
+            .team_store
+            .save(&sample_team("zeta", "developer"), false)
+            .expect("first team should be saved");
+        state
+            .team_store
+            .save(&sample_team("alpha", "developer"), false)
+            .expect("second team should be saved");
+
+        let Json(teams) = list_teams(State(state))
+            .await
+            .expect("list_teams should succeed");
+
+        let names: Vec<String> = teams.into_iter().map(|team| team.name).collect();
+        assert_eq!(names, vec!["alpha", "zeta"]);
+    }
+
+    #[tokio::test]
+    async fn list_teams_propagates_store_errors() {
+        let invalid_team_path = unique_temp_path("teams-file");
+        std::fs::write(&invalid_team_path, "not a directory").expect("team file should be created");
+        let state = make_state_with_dirs(unique_temp_dir("profiles"), invalid_team_path);
+
+        let err = list_teams(State(state))
+            .await
+            .err()
+            .expect("invalid team store path should fail");
+
+        assert!(matches!(err, WebError::Team(_)));
+    }
+}

--- a/crates/opengoose-web/src/handlers/test_support.rs
+++ b/crates/opengoose-web/src/handlers/test_support.rs
@@ -1,0 +1,80 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use opengoose_persistence::{
+    AlertStore, Database, OrchestrationStore, ScheduleStore, SessionStore, TriggerStore,
+};
+use opengoose_profiles::{AgentProfile, ProfileStore};
+use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore};
+use opengoose_types::ChannelMetricsStore;
+
+use crate::state::AppState;
+
+pub(crate) fn unique_temp_path(label: &str) -> PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "opengoose-web-{label}-{}-{suffix}",
+        std::process::id()
+    ))
+}
+
+pub(crate) fn unique_temp_dir(label: &str) -> PathBuf {
+    let dir = unique_temp_path(label);
+    std::fs::create_dir_all(&dir).expect("temp test dir should be created");
+    dir
+}
+
+pub(crate) fn make_state() -> AppState {
+    make_state_with_dirs(unique_temp_dir("profiles"), unique_temp_dir("teams"))
+}
+
+pub(crate) fn make_state_with_dirs(profile_dir: PathBuf, team_dir: PathBuf) -> AppState {
+    let db = Arc::new(Database::open_in_memory().expect("in-memory db should open"));
+    AppState {
+        db: db.clone(),
+        session_store: Arc::new(SessionStore::new(db.clone())),
+        orchestration_store: Arc::new(OrchestrationStore::new(db.clone())),
+        profile_store: Arc::new(ProfileStore::with_dir(profile_dir)),
+        team_store: Arc::new(TeamStore::with_dir(team_dir)),
+        schedule_store: Arc::new(ScheduleStore::new(db.clone())),
+        trigger_store: Arc::new(TriggerStore::new(db.clone())),
+        alert_store: Arc::new(AlertStore::new(db)),
+        channel_metrics: ChannelMetricsStore::new(),
+    }
+}
+
+pub(crate) fn sample_profile(title: &str) -> AgentProfile {
+    AgentProfile {
+        version: "1.0".into(),
+        title: title.into(),
+        description: Some(format!("{title} profile")),
+        instructions: None,
+        prompt: None,
+        extensions: vec![],
+        skills: vec![],
+        settings: None,
+        activities: None,
+        response: None,
+        sub_recipes: None,
+        parameters: None,
+    }
+}
+
+pub(crate) fn sample_team(title: &str, profile: &str) -> TeamDefinition {
+    TeamDefinition {
+        version: "1.0".into(),
+        title: title.into(),
+        description: Some(format!("{title} team")),
+        workflow: OrchestrationPattern::Chain,
+        agents: vec![TeamAgent {
+            profile: profile.into(),
+            role: Some("test agent".into()),
+        }],
+        router: None,
+        fan_out: None,
+    }
+}


### PR DESCRIPTION
## Summary
- add handler-level unit tests for `runs`, `dashboard`, `teams`, and `agents`
- add shared web handler test support for in-memory `AppState` setup and fixture creation
- include the small rustfmt/clippy cleanup needed for the workspace quality gates to pass cleanly

## Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

## Paperclip
- Issue: [OPE-109](http://localhost:3131/OPE/issues/OPE-109)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
