### PR TITLE
feat: Add session detail page [OPE-131]

### DIFF
--- a/crates/opengoose-matrix/src/gateway.rs
+++ b/crates/opengoose-matrix/src/gateway.rs
@@ -1032,9 +1032,9 @@ mod tests {
     #[test]
     fn test_reconnect_delay_cap_at_attempt_5_and_beyond() {
         // At attempt 5 and 6 both produce the same 32s delay (capped at .min(5))
-        let delay_at_5 = 2u64.pow(5u32.min(5));
-        let delay_at_6 = 2u64.pow(6u32.min(5));
-        let delay_at_10 = 2u64.pow(10u32.min(5));
+        let delay_at_5 = 2u64.pow(5);
+        let delay_at_6 = 2u64.pow(5);
+        let delay_at_10 = 2u64.pow(5);
         assert_eq!(delay_at_5, 32);
         assert_eq!(delay_at_6, 32);
         assert_eq!(delay_at_10, 32);
@@ -1043,10 +1043,10 @@ mod tests {
     #[test]
     fn test_reconnect_delay_before_cap() {
         // Attempts 1–4 each double the previous delay
-        let delay_1 = 2u64.pow(1u32.min(5));
-        let delay_2 = 2u64.pow(2u32.min(5));
-        let delay_3 = 2u64.pow(3u32.min(5));
-        let delay_4 = 2u64.pow(4u32.min(5));
+        let delay_1 = 2u64.pow(1);
+        let delay_2 = 2u64.pow(2);
+        let delay_3 = 2u64.pow(3);
+        let delay_4 = 2u64.pow(4);
         assert_eq!(delay_1, 2);
         assert_eq!(delay_2, 4);
         assert_eq!(delay_3, 8);

--- a/crates/opengoose-persistence/src/session_store.rs
+++ b/crates/opengoose-persistence/src/session_store.rs
@@ -172,6 +172,32 @@ impl SessionStore {
         })
     }
 
+    /// Load a single session summary by key.
+    pub fn get_session(&self, key: &SessionKey) -> PersistenceResult<Option<SessionItem>> {
+        self.db.with(|conn| {
+            let key_str = key.to_stable_id();
+            let row = sessions::table
+                .filter(sessions::session_key.eq(&key_str))
+                .select((
+                    sessions::session_key,
+                    sessions::active_team,
+                    sessions::created_at,
+                    sessions::updated_at,
+                ))
+                .first::<(String, Option<String>, String, String)>(conn)
+                .optional()?;
+
+            Ok(row.map(
+                |(session_key, active_team, created_at, updated_at)| SessionItem {
+                    session_key,
+                    active_team,
+                    created_at,
+                    updated_at,
+                },
+            ))
+        })
+    }
+
     /// Load all sessions that have an active team set.
     pub fn load_all_active_teams(&self) -> PersistenceResult<HashMap<SessionKey, String>> {
         self.db.with(|conn| {
@@ -320,6 +346,24 @@ mod tests {
 
         store.set_active_team(&key, None).unwrap();
         assert_eq!(store.get_active_team(&key).unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_session_returns_summary_when_present() {
+        let store = SessionStore::new(test_db());
+        let key = test_key();
+
+        store
+            .append_user_message(&key, "hello", Some("alice"))
+            .unwrap();
+        store.set_active_team(&key, Some("code-review")).unwrap();
+
+        let session = store
+            .get_session(&key)
+            .unwrap()
+            .expect("session summary should exist");
+        assert_eq!(session.session_key, key.to_stable_id());
+        assert_eq!(session.active_team.as_deref(), Some("code-review"));
     }
 
     #[test]

--- a/crates/opengoose-web/src/data.rs
+++ b/crates/opengoose-web/src/data.rs
@@ -632,6 +632,32 @@ pub fn load_session_detail(
     Ok(load_sessions_page(db, selected)?.selected)
 }
 
+/// Load a specific session detail view by stable session key.
+pub fn load_exact_session_detail(
+    db: Arc<Database>,
+    session_key: &str,
+) -> Result<Option<SessionDetailView>> {
+    let store = SessionStore::new(db.clone());
+    let key = SessionKey::from_stable_id(session_key);
+
+    if let Some(summary) = store.get_session(&key)? {
+        let messages = store.load_history(&key, 40)?;
+        return Ok(Some(build_session_detail(
+            &SessionRecord { summary, messages },
+            "Live runtime",
+        )));
+    }
+
+    if store.list_sessions(1)?.is_empty() {
+        return Ok(mock_sessions()
+            .into_iter()
+            .find(|session| session.summary.session_key == session_key)
+            .map(|session| build_session_detail(&session, "Mock preview")));
+    }
+
+    Ok(None)
+}
+
 /// Load the runs page view-model, optionally selecting a run by ID.
 pub fn load_runs_page(db: Arc<Database>, selected: Option<String>) -> Result<RunsPageView> {
     let run_store = OrchestrationStore::new(db.clone());
@@ -1333,7 +1359,7 @@ fn build_session_list_items(
                 updated_at: session.summary.updated_at.clone(),
                 badge: parsed.platform.as_str().to_uppercase(),
                 badge_tone: platform_tone(parsed.platform.as_str()),
-                page_url: format!("/sessions?session={encoded}"),
+                page_url: format!("/sessions/{encoded}"),
                 active: selected_key
                     .as_ref()
                     .map(|key| key == &session.summary.session_key)
@@ -1345,6 +1371,7 @@ fn build_session_list_items(
 
 fn build_session_detail(session: &SessionRecord, source_label: &str) -> SessionDetailView {
     let parsed = SessionKey::from_stable_id(&session.summary.session_key);
+    let status_label = session_status(session);
     SessionDetailView {
         title: format!("Session {}", parsed.channel_id),
         subtitle: match &parsed.namespace {
@@ -1358,12 +1385,20 @@ fn build_session_detail(session: &SessionRecord, source_label: &str) -> SessionD
                 value: session.summary.session_key.clone(),
             },
             MetaRow {
+                label: "Platform".into(),
+                value: parsed.platform.as_str().to_uppercase(),
+            },
+            MetaRow {
                 label: "Active team".into(),
                 value: session
                     .summary
                     .active_team
                     .clone()
                     .unwrap_or_else(|| "None".into()),
+            },
+            MetaRow {
+                label: "Status".into(),
+                value: status_label.to_string(),
             },
             MetaRow {
                 label: "Created".into(),
@@ -1399,6 +1434,14 @@ fn build_session_detail(session: &SessionRecord, source_label: &str) -> SessionD
             })
             .collect(),
         empty_hint: "This session has no persisted messages yet.".into(),
+    }
+}
+
+fn session_status(session: &SessionRecord) -> &'static str {
+    if session.summary.active_team.is_some() {
+        "Active"
+    } else {
+        "Disconnected"
     }
 }
 
@@ -2735,6 +2778,7 @@ mod tests {
         let items = build_session_list_items(&sessions, None, "Live runtime");
         assert!(items[0].subtitle.contains("feature-dev"));
         assert!(items[0].subtitle.contains("Live runtime"));
+        assert_eq!(items[0].page_url, "/sessions/discord%3Ans%3Achan-a");
     }
 
     #[test]
@@ -2792,6 +2836,18 @@ mod tests {
             .find(|row| row.label == "Active team")
             .unwrap();
         assert_eq!(active_team_row.value, "feature-dev");
+        let status_row = detail
+            .meta
+            .iter()
+            .find(|row| row.label == "Status")
+            .unwrap();
+        assert_eq!(status_row.value, "Active");
+        let platform_row = detail
+            .meta
+            .iter()
+            .find(|row| row.label == "Platform")
+            .unwrap();
+        assert_eq!(platform_row.value, "DISCORD");
     }
 
     #[test]
@@ -2804,6 +2860,60 @@ mod tests {
             .find(|row| row.label == "Active team")
             .unwrap();
         assert_eq!(active_team_row.value, "None");
+        let status_row = detail
+            .meta
+            .iter()
+            .find(|row| row.label == "Status")
+            .unwrap();
+        assert_eq!(status_row.value, "Disconnected");
+    }
+
+    #[test]
+    fn load_exact_session_detail_returns_live_session_when_present() {
+        let db = Arc::new(Database::open_in_memory().expect("in-memory db should open"));
+        let store = SessionStore::new(db.clone());
+        let key = SessionKey::from_stable_id("discord:ns:studio-a:ops-bridge");
+
+        store
+            .append_user_message(&key, "hello", Some("alice"))
+            .expect("append should succeed");
+        store
+            .set_active_team(&key, Some("feature-dev"))
+            .expect("active team should persist");
+
+        let detail = load_exact_session_detail(db, &key.to_stable_id())
+            .expect("detail lookup should succeed")
+            .expect("detail should be found");
+        assert_eq!(detail.title, "Session ops-bridge");
+        assert!(
+            detail
+                .messages
+                .iter()
+                .any(|message| message.content == "hello")
+        );
+    }
+
+    #[test]
+    fn load_exact_session_detail_returns_none_for_missing_live_session() {
+        let db = Arc::new(Database::open_in_memory().expect("in-memory db should open"));
+        let store = SessionStore::new(db.clone());
+        let existing = SessionKey::from_stable_id("discord:ns:studio-a:ops-bridge");
+        store
+            .append_user_message(&existing, "hello", Some("alice"))
+            .expect("append should succeed");
+        let detail = load_exact_session_detail(db, "discord:ns:missing")
+            .expect("detail lookup should succeed");
+        assert!(detail.is_none());
+    }
+
+    #[test]
+    fn load_exact_session_detail_falls_back_to_mock_preview() {
+        let db = Arc::new(Database::open_in_memory().expect("in-memory db should open"));
+        let detail = load_exact_session_detail(db, "discord:ns:studio-a:ops-bridge")
+            .expect("detail lookup should succeed")
+            .expect("mock detail should be found");
+        assert_eq!(detail.source_label, "Mock preview");
+        assert!(detail.meta.iter().any(|row| row.label == "Status"));
     }
 
     // --- build_run_list_items ---

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -24,7 +24,7 @@ use askama::Template;
 use async_stream::stream;
 use axum::Json;
 use axum::Router;
-use axum::extract::{Form, Query, State};
+use axum::extract::{Form, Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::Html;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -43,8 +43,9 @@ use crate::pages::not_found_handler;
 use crate::data::{
     AgentDetailView, AgentsPageView, DashboardView, QueueDetailView, QueuePageView, RunDetailView,
     RunsPageView, SessionDetailView, SessionsPageView, TeamEditorView, TeamsPageView,
-    WorkflowDetailView, WorkflowsPageView, load_agents_page, load_dashboard, load_queue_page,
-    load_runs_page, load_sessions_page, load_teams_page, load_workflows_page, save_team_yaml,
+    WorkflowDetailView, WorkflowsPageView, load_agents_page, load_dashboard,
+    load_exact_session_detail, load_queue_page, load_runs_page, load_sessions_page,
+    load_teams_page, load_workflows_page, save_team_yaml,
 };
 
 /// Configuration for the web dashboard server.
@@ -265,6 +266,7 @@ pub async fn serve(options: WebOptions) -> Result<()> {
         .route("/", get(dashboard))
         .route("/dashboard/events", get(dashboard_events))
         .route("/sessions", get(sessions))
+        .route("/sessions/{session_key}", get(session_detail))
         .route("/runs", get(runs))
         .route("/agents", get(agents))
         .route("/workflows", get(workflows))
@@ -378,6 +380,25 @@ async fn sessions(State(state): State<PageState>, Query(query): Query<SessionQue
     })
 }
 
+async fn session_detail(
+    State(state): State<PageState>,
+    Path(session_key): Path<String>,
+) -> WebResult {
+    let detail = load_exact_session_detail(state.db, &session_key)
+        .map_err(internal_error)?
+        .ok_or_else(|| not_found_page(&format!("/sessions/{session_key}")))?;
+    let detail_html = render_partial(&SessionDetailTemplate {
+        detail: detail.clone(),
+    })?;
+
+    render_template(&SessionDetailPageTemplate {
+        page_title: "Session detail",
+        current_nav: "sessions",
+        detail,
+        detail_html,
+    })
+}
+
 async fn runs(State(state): State<PageState>, Query(query): Query<RunQuery>) -> WebResult {
     let page = load_runs_page(state.db, query.run).map_err(internal_error)?;
     let detail_html = render_partial(&RunDetailTemplate {
@@ -477,6 +498,14 @@ fn internal_error(error: anyhow::Error) -> (StatusCode, Html<String>) {
         .render()
         .unwrap_or_else(|_| format!("<p>Internal Server Error: {error}</p>"));
     (StatusCode::INTERNAL_SERVER_ERROR, Html(html))
+}
+
+fn not_found_page(path: &str) -> (StatusCode, Html<String>) {
+    let page = crate::pages::ErrorPage::not_found(path);
+    let html = page
+        .render()
+        .unwrap_or_else(|_| "<p>Page not found.</p>".to_string());
+    (StatusCode::NOT_FOUND, Html(html))
 }
 
 fn render_html<T: Template>(template: &T) -> PartialResult {
@@ -670,6 +699,15 @@ struct SessionsTemplate {
 }
 
 #[derive(Template)]
+#[template(path = "session_detail.html")]
+struct SessionDetailPageTemplate {
+    page_title: &'static str,
+    current_nav: &'static str,
+    detail: SessionDetailView,
+    detail_html: String,
+}
+
+#[derive(Template)]
 #[template(path = "partials/session_detail.html")]
 struct SessionDetailTemplate {
     detail: SessionDetailView,
@@ -815,7 +853,7 @@ mod tests {
                 updated_at: "2026-03-10 12:34".into(),
                 badge: "DISCORD".into(),
                 badge_tone: "cyan",
-                page_url: "/sessions?session=ops".into(),
+                page_url: "/sessions/ops".into(),
                 active: false,
             }],
             runs: vec![RunListItem {
@@ -953,7 +991,7 @@ mod tests {
                     updated_at: "2026-03-10 12:34".into(),
                     badge: "DISCORD".into(),
                     badge_tone: "cyan",
-                    page_url: "/sessions?session=ops".into(),
+                    page_url: "/sessions/ops".into(),
                     active: true,
                 }],
                 selected: detail,
@@ -967,6 +1005,26 @@ mod tests {
         assert!(html.contains("data-list-item"));
         assert!(html.contains("data-detail-panel"));
         assert!(!html.contains("hx-get"));
+    }
+
+    #[test]
+    fn session_detail_page_template_renders_back_navigation() {
+        let detail = sample_session_detail();
+        let detail_html = render_partial(&SessionDetailTemplate {
+            detail: detail.clone(),
+        })
+        .expect("detail renders");
+        let html = render_partial(&SessionDetailPageTemplate {
+            page_title: "Session detail",
+            current_nav: "sessions",
+            detail,
+            detail_html,
+        })
+        .expect("session detail page renders");
+
+        assert!(html.contains("Back to sessions"));
+        assert!(html.contains("Session detail"));
+        assert!(html.contains("Session ops"));
     }
 
     #[test]
@@ -1111,11 +1169,25 @@ mod tests {
             .with_state(state)
     }
 
+    fn page_router(db: Arc<Database>) -> Router {
+        Router::new()
+            .route("/sessions", get(sessions))
+            .route("/sessions/{session_key}", get(session_detail))
+            .with_state(PageState { db })
+    }
+
     async fn read_json(response: axum::response::Response) -> Value {
         let body = to_bytes(response.into_body(), 1024 * 1024)
             .await
             .expect("response body should be readable");
         serde_json::from_slice(&body).expect("response body should be json")
+    }
+
+    async fn read_html(response: axum::response::Response) -> String {
+        let body = to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("response body should be readable");
+        String::from_utf8(body.to_vec()).expect("response body should be utf-8")
     }
 
     #[tokio::test]
@@ -1256,6 +1328,64 @@ mod tests {
         assert_eq!(messages.status(), StatusCode::OK);
         let body = read_json(messages).await;
         assert!(body.is_array());
+    }
+
+    #[tokio::test]
+    async fn session_detail_route_renders_session_metadata_and_messages() {
+        let db = Arc::new(Database::open_in_memory().expect("in-memory db should open"));
+        let store = SessionStore::new(db.clone());
+        let key = SessionKey::from_stable_id("discord:ns:studio-a:ops-bridge");
+
+        store
+            .append_user_message(&key, "Need a deploy checklist.", Some("alice"))
+            .expect("user message should persist");
+        store
+            .append_assistant_message(&key, "Checklist drafted.")
+            .expect("assistant message should persist");
+        store
+            .set_active_team(&key, Some("feature-dev"))
+            .expect("active team should persist");
+
+        let response = page_router(db)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(Uri::from_static(
+                        "/sessions/discord%3Ans%3Astudio-a%3Aops-bridge",
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("session detail request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = read_html(response).await;
+        assert!(body.contains("discord:ns:studio-a:ops-bridge"));
+        assert!(body.contains("Platform"));
+        assert!(body.contains("DISCORD"));
+        assert!(body.contains("Status"));
+        assert!(body.contains("Active"));
+        assert!(body.contains("feature-dev"));
+        assert!(body.contains("Checklist drafted."));
+    }
+
+    #[tokio::test]
+    async fn session_detail_route_returns_not_found_for_missing_session() {
+        let response = page_router(Arc::new(Database::open_in_memory().unwrap()))
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(Uri::from_static("/sessions/discord%3Ans%3Amissing"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("session detail request should be handled");
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = read_html(response).await;
+        assert!(body.contains("Page not found"));
     }
 
     // ── Full API router (includes alerts + fallback) ──────────────────────

--- a/crates/opengoose-web/templates/session_detail.html
+++ b/crates/opengoose-web/templates/session_detail.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="page-intro">
+  <div>
+    <p class="eyebrow">Session detail</p>
+    <h1>{{ detail.title }}</h1>
+    <p>{{ detail.subtitle }}</p>
+  </div>
+  <a class="secondary-button" href="/sessions">Back to sessions</a>
+</section>
+
+<section class="detail-frame">
+  <div class="detail-panel">{{ detail_html|safe }}</div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated `/sessions/{session_key}` page that renders a full session detail view and returns 404 for unknown sessions
- point session list links at the new detail route and make platform/status explicit in the session metadata
- add persistence/data/page tests for exact session loading and include the small matrix test lint cleanup required for workspace clippy

## Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test

## Issue
- OPE-131
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
