### PR TITLE
feat: Add trigger management dashboard [OPE-137]

### DIFF
--- a/crates/opengoose-matrix/src/gateway.rs
+++ b/crates/opengoose-matrix/src/gateway.rs
@@ -1032,9 +1032,9 @@ mod tests {
     #[test]
     fn test_reconnect_delay_cap_at_attempt_5_and_beyond() {
         // At attempt 5 and 6 both produce the same 32s delay (capped at .min(5))
-        let delay_at_5 = 2u64.pow(5u32.min(5));
-        let delay_at_6 = 2u64.pow(6u32.min(5));
-        let delay_at_10 = 2u64.pow(10u32.min(5));
+        let delay_at_5 = 2u64.pow(5);
+        let delay_at_6 = 2u64.pow(5);
+        let delay_at_10 = 2u64.pow(5);
         assert_eq!(delay_at_5, 32);
         assert_eq!(delay_at_6, 32);
         assert_eq!(delay_at_10, 32);
@@ -1043,10 +1043,10 @@ mod tests {
     #[test]
     fn test_reconnect_delay_before_cap() {
         // Attempts 1–4 each double the previous delay
-        let delay_1 = 2u64.pow(1u32.min(5));
-        let delay_2 = 2u64.pow(2u32.min(5));
-        let delay_3 = 2u64.pow(3u32.min(5));
-        let delay_4 = 2u64.pow(4u32.min(5));
+        let delay_1 = 2u64.pow(1);
+        let delay_2 = 2u64.pow(2);
+        let delay_3 = 2u64.pow(3);
+        let delay_4 = 2u64.pow(4);
         assert_eq!(delay_1, 2);
         assert_eq!(delay_2, 4);
         assert_eq!(delay_3, 8);

--- a/crates/opengoose-web/assets/app.css
+++ b/crates/opengoose-web/assets/app.css
@@ -804,9 +804,37 @@ button:disabled {
   gap: 0.8rem;
 }
 
+.editor-form input,
+.editor-form select {
+  width: 100%;
+  padding: 0.8rem 0.95rem;
+  border-radius: 1rem;
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
+  color: var(--text);
+}
+
 .editor-form textarea {
   min-height: 22rem;
   resize: vertical;
+}
+
+.compact-textarea {
+  min-height: 8rem !important;
+}
+
+.trigger-form-row {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.inline-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.inline-actions form {
+  margin: 0;
 }
 
 .notice {
@@ -924,6 +952,7 @@ tr[data-table-row]:focus-visible {
   }
 
   .control-row,
+  .trigger-form-row,
   .pager {
     grid-template-columns: 1fr;
     flex-direction: column;

--- a/crates/opengoose-web/assets/app.js
+++ b/crates/opengoose-web/assets/app.js
@@ -1,3 +1,4 @@
+import { initConfirmSubmits } from "./modules/confirm-submit.js";
 import { initDashboardStreams } from "./modules/dashboard-stream.js";
 import { initListShells } from "./modules/list-shell.js";
 import { initLiveEvents } from "./modules/live-events.js";
@@ -8,6 +9,7 @@ import { initWorkflowTriggers } from "./modules/workflow-trigger.js";
 initTheme(document);
 initListShells(document);
 initTableShells(document);
+initConfirmSubmits(document);
 initDashboardStreams(document);
 initLiveEvents(document);
 initWorkflowTriggers(document);

--- a/crates/opengoose-web/assets/modules/confirm-submit.js
+++ b/crates/opengoose-web/assets/modules/confirm-submit.js
@@ -1,0 +1,13 @@
+export const initConfirmSubmits = (root = document) => {
+  root.addEventListener("submit", (event) => {
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement)) return;
+
+    const message = form.dataset.confirm;
+    if (!message) return;
+
+    if (!window.confirm(message)) {
+      event.preventDefault();
+    }
+  });
+};

--- a/crates/opengoose-web/src/data.rs
+++ b/crates/opengoose-web/src/data.rs
@@ -9,6 +9,7 @@ use opengoose_persistence::{
     WorkStatus,
 };
 use opengoose_profiles::{AgentProfile, ProfileStore, all_defaults as default_profiles};
+use opengoose_teams::triggers::TriggerType;
 use opengoose_teams::{TeamDefinition, TeamStore, all_defaults as default_teams};
 use opengoose_types::SessionKey;
 use urlencoding::encode;
@@ -352,6 +353,7 @@ pub struct WorkflowDetailView {
     pub recent_runs: Vec<WorkflowRunView>,
     pub yaml: String,
     pub trigger_api_url: String,
+    pub manage_triggers_url: String,
     pub trigger_input: String,
 }
 
@@ -362,6 +364,67 @@ pub struct WorkflowsPageView {
     pub mode_tone: &'static str,
     pub workflows: Vec<WorkflowListItem>,
     pub selected: WorkflowDetailView,
+}
+
+/// One workflow option in the trigger creation form.
+#[derive(Clone)]
+pub struct TriggerWorkflowOptionView {
+    pub value: String,
+    pub label: String,
+    pub detail: String,
+    pub selected: bool,
+}
+
+/// One trigger type option in the trigger creation form.
+#[derive(Clone)]
+pub struct TriggerTypeOptionView {
+    pub value: String,
+    pub label: String,
+    pub selected: bool,
+}
+
+/// Draft values for the trigger creation form.
+#[derive(Clone)]
+pub struct TriggerDraftView {
+    pub name: String,
+    pub trigger_type: String,
+    pub workflow_name: String,
+    pub condition_json: String,
+    pub condition_help: String,
+    pub input: String,
+}
+
+/// One trigger row rendered in the management table.
+#[derive(Clone)]
+pub struct TriggerListItemView {
+    pub name: String,
+    pub trigger_type: String,
+    pub trigger_type_label: String,
+    pub workflow_title: String,
+    pub workflow_page_url: String,
+    pub status_label: String,
+    pub status_tone: &'static str,
+    pub fire_count: i32,
+    pub last_fired_at: String,
+    pub condition_preview: String,
+    pub input_preview: String,
+    pub toggle_label: String,
+    pub toggle_enabled_value: bool,
+    pub search_text: String,
+}
+
+/// View-model for the trigger management page.
+#[derive(Clone)]
+pub struct TriggersPageView {
+    pub mode_label: String,
+    pub mode_tone: &'static str,
+    pub notice: Option<Notice>,
+    pub summary: Vec<MetricCard>,
+    pub form: TriggerDraftView,
+    pub workflows: Vec<TriggerWorkflowOptionView>,
+    pub trigger_types: Vec<TriggerTypeOptionView>,
+    pub triggers: Vec<TriggerListItemView>,
+    pub empty_hint: String,
 }
 
 /// Aggregated view-model for the main dashboard page.
@@ -814,6 +877,109 @@ pub fn load_workflow_detail(
     selected: Option<String>,
 ) -> Result<WorkflowDetailView> {
     Ok(load_workflows_page(db, selected)?.selected)
+}
+
+/// Load the trigger management page view-model.
+pub fn load_triggers_page(
+    db: Arc<Database>,
+    draft: Option<TriggerDraftView>,
+    notice: Option<Notice>,
+) -> Result<TriggersPageView> {
+    let teams = load_teams_catalog()?;
+    let triggers = TriggerStore::new(db).list()?;
+    let default_workflow = teams
+        .first()
+        .map(|entry| entry.name.clone())
+        .unwrap_or_default();
+    let default_trigger_type = TriggerType::all_names()
+        .iter()
+        .find(|name| **name == "on_message")
+        .copied()
+        .unwrap_or("on_message")
+        .to_string();
+
+    let form = draft.unwrap_or_else(|| {
+        build_trigger_draft(
+            String::new(),
+            default_trigger_type.clone(),
+            default_workflow.clone(),
+            trigger_condition_example(&default_trigger_type).into(),
+            "Triggered from the web dashboard".into(),
+        )
+    });
+
+    let workflows: Vec<_> = teams
+        .iter()
+        .map(|entry| TriggerWorkflowOptionView {
+            value: entry.name.clone(),
+            label: entry.team.title.clone(),
+            detail: entry.team.workflow_name(),
+            selected: entry.name == form.workflow_name,
+        })
+        .collect();
+    let trigger_types: Vec<_> = TriggerType::all_names()
+        .iter()
+        .map(|name| TriggerTypeOptionView {
+            value: (*name).into(),
+            label: humanize_trigger_type(name),
+            selected: *name == form.trigger_type,
+        })
+        .collect();
+    let covered_workflows = triggers
+        .iter()
+        .map(|trigger| trigger.team_name.as_str())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+    let enabled_triggers = triggers.iter().filter(|trigger| trigger.enabled).count();
+    let paused_triggers = triggers.len().saturating_sub(enabled_triggers);
+    let trigger_types_count = triggers
+        .iter()
+        .map(|trigger| trigger.trigger_type.as_str())
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+
+    Ok(TriggersPageView {
+        mode_label: if triggers.is_empty() {
+            "Ready for setup".into()
+        } else {
+            "Live registry".into()
+        },
+        mode_tone: if triggers.is_empty() { "neutral" } else { "success" },
+        notice,
+        summary: vec![
+            MetricCard {
+                label: "Configured".into(),
+                value: triggers.len().to_string(),
+                note: "Saved triggers in the registry".into(),
+                tone: "cyan",
+            },
+            MetricCard {
+                label: "Enabled".into(),
+                value: enabled_triggers.to_string(),
+                note: format!("{paused_triggers} paused"),
+                tone: "sage",
+            },
+            MetricCard {
+                label: "Workflow coverage".into(),
+                value: covered_workflows.to_string(),
+                note: "Workflows with at least one trigger".into(),
+                tone: "amber",
+            },
+            MetricCard {
+                label: "Trigger kinds".into(),
+                value: trigger_types_count.to_string(),
+                note: "Distinct trigger types configured".into(),
+                tone: "neutral",
+            },
+        ],
+        form,
+        workflows,
+        trigger_types,
+        triggers: build_trigger_list_items(&teams, &triggers),
+        empty_hint:
+            "No triggers are configured yet. Create one to launch workflows from events or webhooks."
+                .into(),
+    })
 }
 
 /// Save edited team YAML and return the refreshed editor view.
@@ -2046,6 +2212,7 @@ fn build_workflow_detail(entry: &WorkflowCatalogEntry) -> Result<WorkflowDetailV
             .collect(),
         yaml: entry.team.to_yaml()?,
         trigger_api_url: format!("/api/workflows/{}/trigger", encode(&entry.name)),
+        manage_triggers_url: "/triggers".into(),
         trigger_input: format!(
             "Manual run requested from the web dashboard for {}",
             entry.name
@@ -2101,6 +2268,117 @@ fn build_workflow_automations(entry: &WorkflowCatalogEntry) -> Vec<WorkflowAutom
     });
 
     schedules.chain(triggers).collect()
+}
+
+pub fn build_trigger_draft(
+    name: String,
+    trigger_type: String,
+    workflow_name: String,
+    condition_json: String,
+    input: String,
+) -> TriggerDraftView {
+    let selected_type = if TriggerType::parse(&trigger_type).is_some() {
+        trigger_type
+    } else {
+        "on_message".into()
+    };
+    let normalized_condition = if condition_json.trim().is_empty() {
+        trigger_condition_example(&selected_type).into()
+    } else {
+        condition_json
+    };
+
+    TriggerDraftView {
+        name,
+        trigger_type: selected_type.clone(),
+        workflow_name,
+        condition_json: normalized_condition,
+        condition_help: format!(
+            "Provide a JSON object. Example: {}",
+            trigger_condition_example(&selected_type)
+        ),
+        input,
+    }
+}
+
+fn build_trigger_list_items(
+    teams: &[TeamCatalogEntry],
+    triggers: &[Trigger],
+) -> Vec<TriggerListItemView> {
+    triggers
+        .iter()
+        .map(|trigger| {
+            let workflow_title = teams
+                .iter()
+                .find(|entry| entry.name == trigger.team_name)
+                .map(|entry| entry.team.title.clone())
+                .unwrap_or_else(|| trigger.team_name.clone());
+            TriggerListItemView {
+                name: trigger.name.clone(),
+                trigger_type: trigger.trigger_type.clone(),
+                trigger_type_label: humanize_trigger_type(&trigger.trigger_type),
+                workflow_title,
+                workflow_page_url: format!("/workflows?workflow={}", encode(&trigger.team_name)),
+                status_label: if trigger.enabled {
+                    "Enabled".into()
+                } else {
+                    "Paused".into()
+                },
+                status_tone: if trigger.enabled { "sage" } else { "neutral" },
+                fire_count: trigger.fire_count,
+                last_fired_at: trigger
+                    .last_fired_at
+                    .clone()
+                    .unwrap_or_else(|| "Never".into()),
+                condition_preview: preview(&trigger.condition_json, 120),
+                input_preview: if trigger.input.trim().is_empty() {
+                    "No custom workflow input.".into()
+                } else {
+                    preview(&trigger.input, 120)
+                },
+                toggle_label: if trigger.enabled {
+                    "Pause".into()
+                } else {
+                    "Enable".into()
+                },
+                toggle_enabled_value: !trigger.enabled,
+                search_text: format!(
+                    "{} {} {} {} {}",
+                    trigger.name,
+                    trigger.trigger_type,
+                    trigger.team_name,
+                    trigger.condition_json,
+                    trigger.input
+                ),
+            }
+        })
+        .collect()
+}
+
+fn trigger_condition_example(trigger_type: &str) -> &'static str {
+    match trigger_type {
+        "file_watch" => r#"{"pattern":"src/**/*.rs"}"#,
+        "message_received" => r#"{"from_agent":"planner","payload_contains":"ship it"}"#,
+        "schedule_complete" => r#"{"schedule_name":"nightly-review"}"#,
+        "webhook_received" => r#"{"path":"/github/pr"}"#,
+        "on_message" => r#"{"content_contains":"deploy"}"#,
+        "on_session_start" | "on_session_end" => r#"{"platform":"discord"}"#,
+        "on_schedule" => r#"{"team":"feature-dev"}"#,
+        _ => "{}",
+    }
+}
+
+fn humanize_trigger_type(raw: &str) -> String {
+    raw.split('_')
+        .map(|segment| {
+            let mut chars = segment.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn choose_selected_name(options: Vec<String>, selected: Option<String>) -> String {

--- a/crates/opengoose-web/src/handlers/mod.rs
+++ b/crates/opengoose-web/src/handlers/mod.rs
@@ -16,6 +16,8 @@ pub mod runs;
 pub mod sessions;
 /// JSON API handlers for team definitions.
 pub mod teams;
+/// JSON API handlers for trigger CRUD and toggle management.
+pub mod triggers;
 /// HTTP endpoint for receiving inbound webhooks and firing matching triggers.
 pub mod webhooks;
 /// JSON API handlers for workflow definitions and manual triggers.

--- a/crates/opengoose-web/src/handlers/triggers.rs
+++ b/crates/opengoose-web/src/handlers/triggers.rs
@@ -1,0 +1,358 @@
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use opengoose_persistence::Trigger;
+use opengoose_teams::triggers::TriggerType;
+
+use super::AppError;
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateTriggerInput {
+    pub name: String,
+    pub trigger_type: String,
+    #[serde(default)]
+    pub condition_json: String,
+    pub team_name: String,
+    #[serde(default)]
+    pub input: String,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ToggleTriggerRequest {
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TriggerItem {
+    pub name: String,
+    pub trigger_type: String,
+    pub condition_json: String,
+    pub team_name: String,
+    pub workflow_title: String,
+    pub input: String,
+    pub enabled: bool,
+    pub last_fired_at: Option<String>,
+    pub fire_count: i32,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// GET /api/triggers — list all workflow triggers.
+pub async fn list_triggers(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<TriggerItem>>, AppError> {
+    Ok(Json(list_trigger_items(&state)?))
+}
+
+/// POST /api/triggers — create a new workflow trigger.
+pub async fn create_trigger(
+    State(state): State<AppState>,
+    Json(payload): Json<CreateTriggerInput>,
+) -> Result<(StatusCode, Json<TriggerItem>), AppError> {
+    let trigger = create_trigger_record(&state, payload)?;
+    Ok((StatusCode::CREATED, Json(trigger)))
+}
+
+/// POST /api/triggers/:name/toggle — enable or disable a trigger.
+pub async fn toggle_trigger(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(payload): Json<ToggleTriggerRequest>,
+) -> Result<Json<TriggerItem>, AppError> {
+    Ok(Json(set_trigger_enabled_record(
+        &state,
+        &name,
+        payload.enabled,
+    )?))
+}
+
+/// DELETE /api/triggers/:name — remove a trigger.
+pub async fn delete_trigger(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<StatusCode, AppError> {
+    delete_trigger_record(&state, &name)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub(crate) fn list_trigger_items(state: &AppState) -> Result<Vec<TriggerItem>, AppError> {
+    state
+        .trigger_store
+        .list()?
+        .into_iter()
+        .map(|trigger| trigger_item(state, trigger))
+        .collect()
+}
+
+pub(crate) fn create_trigger_record(
+    state: &AppState,
+    payload: CreateTriggerInput,
+) -> Result<TriggerItem, AppError> {
+    let name = required_field(payload.name, "name")?;
+    let trigger_type = normalize_trigger_type(&payload.trigger_type)?;
+    let team_name = required_field(payload.team_name, "team_name")?;
+    let condition_json = normalize_condition_json(&payload.condition_json)?;
+    let input = payload.input.trim().to_string();
+    let enabled = payload.enabled.unwrap_or(true);
+
+    state.team_store.get(&team_name)?;
+    if state.trigger_store.get_by_name(&name)?.is_some() {
+        return Err(AppError::BadRequest(format!(
+            "trigger {name} already exists"
+        )));
+    }
+
+    state
+        .trigger_store
+        .create(&name, &trigger_type, &condition_json, &team_name, &input)?;
+
+    if !enabled {
+        state.trigger_store.set_enabled(&name, false)?;
+    }
+
+    let saved = state
+        .trigger_store
+        .get_by_name(&name)?
+        .ok_or_else(|| AppError::NotFound(format!("trigger {name}")))?;
+
+    trigger_item(state, saved)
+}
+
+pub(crate) fn set_trigger_enabled_record(
+    state: &AppState,
+    name: &str,
+    enabled: bool,
+) -> Result<TriggerItem, AppError> {
+    let name = required_field(name.to_string(), "name")?;
+    if !state.trigger_store.set_enabled(&name, enabled)? {
+        return Err(AppError::NotFound(format!("trigger {name}")));
+    }
+
+    let trigger = state
+        .trigger_store
+        .get_by_name(&name)?
+        .ok_or_else(|| AppError::NotFound(format!("trigger {name}")))?;
+
+    trigger_item(state, trigger)
+}
+
+pub(crate) fn delete_trigger_record(state: &AppState, name: &str) -> Result<(), AppError> {
+    let name = required_field(name.to_string(), "name")?;
+    if !state.trigger_store.remove(&name)? {
+        return Err(AppError::NotFound(format!("trigger {name}")));
+    }
+    Ok(())
+}
+
+fn trigger_item(state: &AppState, trigger: Trigger) -> Result<TriggerItem, AppError> {
+    let workflow_title = state
+        .team_store
+        .get(&trigger.team_name)
+        .map(|team| team.title)
+        .unwrap_or_else(|_| trigger.team_name.clone());
+
+    Ok(TriggerItem {
+        name: trigger.name,
+        trigger_type: trigger.trigger_type,
+        condition_json: trigger.condition_json,
+        team_name: trigger.team_name,
+        workflow_title,
+        input: trigger.input,
+        enabled: trigger.enabled,
+        last_fired_at: trigger.last_fired_at,
+        fire_count: trigger.fire_count,
+        created_at: trigger.created_at,
+        updated_at: trigger.updated_at,
+    })
+}
+
+fn required_field(value: String, field: &str) -> Result<String, AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::BadRequest(format!("{field} is required")));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn normalize_trigger_type(raw: &str) -> Result<String, AppError> {
+    let normalized = required_field(raw.to_string(), "trigger_type")?;
+    if TriggerType::parse(&normalized).is_none() {
+        return Err(AppError::BadRequest(format!(
+            "unknown trigger_type {normalized}"
+        )));
+    }
+    Ok(normalized)
+}
+
+fn normalize_condition_json(raw: &str) -> Result<String, AppError> {
+    let candidate = if raw.trim().is_empty() {
+        "{}"
+    } else {
+        raw.trim()
+    };
+    let value: serde_json::Value = serde_json::from_str(candidate).map_err(|error| {
+        AppError::BadRequest(format!("condition_json must be valid JSON: {error}"))
+    })?;
+
+    if !value.is_object() {
+        return Err(AppError::BadRequest(
+            "condition_json must be a JSON object".into(),
+        ));
+    }
+
+    serde_json::to_string_pretty(&value)
+        .map_err(|error| AppError::Internal(format!("failed to format condition_json: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::Json;
+    use axum::extract::State;
+
+    use super::{
+        CreateTriggerInput, create_trigger_record, delete_trigger_record, list_triggers,
+        set_trigger_enabled_record,
+    };
+    use crate::handlers::test_support::{make_state, sample_team};
+
+    #[tokio::test]
+    async fn list_triggers_returns_workflow_titles() {
+        let state = make_state();
+        state
+            .team_store
+            .save(&sample_team("feature-dev", "planner"), false)
+            .expect("team should be saved");
+        create_trigger_record(
+            &state,
+            CreateTriggerInput {
+                name: "github-pr".into(),
+                trigger_type: "webhook_received".into(),
+                condition_json: r#"{"path":"/github/pr"}"#.into(),
+                team_name: "feature-dev".into(),
+                input: "review the PR".into(),
+                enabled: None,
+            },
+        )
+        .expect("trigger should be created");
+
+        let Json(items) = list_triggers(State(state))
+            .await
+            .expect("list_triggers should succeed");
+
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].workflow_title, "feature-dev");
+        assert_eq!(items[0].trigger_type, "webhook_received");
+    }
+
+    #[test]
+    fn create_trigger_record_rejects_unknown_type() {
+        let state = make_state();
+        state
+            .team_store
+            .save(&sample_team("feature-dev", "planner"), false)
+            .expect("team should be saved");
+
+        let err = create_trigger_record(
+            &state,
+            CreateTriggerInput {
+                name: "bad".into(),
+                trigger_type: "wat".into(),
+                condition_json: "{}".into(),
+                team_name: "feature-dev".into(),
+                input: String::new(),
+                enabled: None,
+            },
+        )
+        .expect_err("unknown trigger type should fail");
+
+        assert!(err.to_string().contains("unknown trigger_type"));
+    }
+
+    #[test]
+    fn create_trigger_record_rejects_non_object_json() {
+        let state = make_state();
+        state
+            .team_store
+            .save(&sample_team("feature-dev", "planner"), false)
+            .expect("team should be saved");
+
+        let err = create_trigger_record(
+            &state,
+            CreateTriggerInput {
+                name: "bad-json".into(),
+                trigger_type: "on_message".into(),
+                condition_json: "[]".into(),
+                team_name: "feature-dev".into(),
+                input: String::new(),
+                enabled: None,
+            },
+        )
+        .expect_err("array condition should fail");
+
+        assert!(err.to_string().contains("JSON object"));
+    }
+
+    #[test]
+    fn create_trigger_record_can_start_disabled() {
+        let state = make_state();
+        state
+            .team_store
+            .save(&sample_team("feature-dev", "planner"), false)
+            .expect("team should be saved");
+
+        let trigger = create_trigger_record(
+            &state,
+            CreateTriggerInput {
+                name: "nightly".into(),
+                trigger_type: "schedule_complete".into(),
+                condition_json: r#"{"schedule_name":"nightly"}"#.into(),
+                team_name: "feature-dev".into(),
+                input: String::new(),
+                enabled: Some(false),
+            },
+        )
+        .expect("trigger should be created");
+
+        assert!(!trigger.enabled);
+    }
+
+    #[test]
+    fn set_trigger_enabled_record_updates_state() {
+        let state = make_state();
+        state
+            .team_store
+            .save(&sample_team("feature-dev", "planner"), false)
+            .expect("team should be saved");
+        create_trigger_record(
+            &state,
+            CreateTriggerInput {
+                name: "watch-src".into(),
+                trigger_type: "file_watch".into(),
+                condition_json: r#"{"pattern":"src/**/*.rs"}"#.into(),
+                team_name: "feature-dev".into(),
+                input: String::new(),
+                enabled: None,
+            },
+        )
+        .expect("trigger should be created");
+
+        let updated =
+            set_trigger_enabled_record(&state, "watch-src", false).expect("toggle should succeed");
+
+        assert!(!updated.enabled);
+    }
+
+    #[test]
+    fn delete_trigger_record_returns_not_found_for_missing_trigger() {
+        let state = make_state();
+
+        let err = delete_trigger_record(&state, "nope").expect_err("missing trigger should fail");
+
+        assert!(err.to_string().contains("not found"));
+    }
+}

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -9,11 +9,11 @@ mod state;
 
 /// Re-exported error type for web API and page handlers.
 pub use error::WebError;
+pub use routes::render_dashboard_live_partial;
 /// Re-exported shared application state for all handlers.
 pub use state::AppState;
 /// Alias kept for backward compatibility.
 pub use state::AppState as SharedAppState;
-pub use routes::render_dashboard_live_partial;
 
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -31,7 +31,6 @@ use tracing::{info, warn};
 
 use crate::handlers::remote_agents::{self, RemoteGatewayState};
 use crate::pages::not_found_handler;
-
 /// Configuration for the web dashboard server.
 #[derive(Debug, Clone, Copy)]
 pub struct WebOptions {
@@ -208,6 +207,18 @@ pub async fn serve(options: WebOptions) -> Result<()> {
         .route("/api/runs", get(handlers::runs::list_runs))
         .route("/api/agents", get(handlers::agents::list_agents))
         .route("/api/teams", get(handlers::teams::list_teams))
+        .route(
+            "/api/triggers",
+            get(handlers::triggers::list_triggers).post(handlers::triggers::create_trigger),
+        )
+        .route(
+            "/api/triggers/{name}/toggle",
+            post(handlers::triggers::toggle_trigger),
+        )
+        .route(
+            "/api/triggers/{name}",
+            delete(handlers::triggers::delete_trigger),
+        )
         .route("/api/workflows", get(handlers::workflows::list_workflows))
         .route(
             "/api/workflows/{name}",
@@ -250,6 +261,12 @@ pub async fn serve(options: WebOptions) -> Result<()> {
         .route("/runs", get(routes::runs))
         .route("/agents", get(routes::agents))
         .route("/workflows", get(routes::workflows))
+        .route(
+            "/triggers",
+            get(routes::triggers).post(routes::trigger_create),
+        )
+        .route("/triggers/toggle", post(routes::trigger_toggle))
+        .route("/triggers/delete", post(routes::trigger_delete))
         .route("/teams", get(routes::teams).post(routes::team_save))
         .route("/queue", get(routes::queue))
         .route("/api/health", get(routes::health))
@@ -272,14 +289,14 @@ pub async fn serve(options: WebOptions) -> Result<()> {
     .await?;
     Ok(())
 }
-
 #[cfg(test)]
 mod tests {
     use crate::data::{
         ActivityItem, AlertCard, DashboardView, MessageBubble, MetaRow, MetricCard,
         QueueDetailView, QueueMessageView, RunListItem, SessionDetailView, SessionListItem,
-        SessionsPageView, StatusSegment, TrendBar, WorkflowAutomationView, WorkflowDetailView,
-        WorkflowListItem, WorkflowRunView, WorkflowStepView, WorkflowsPageView,
+        SessionsPageView, StatusSegment, TrendBar, TriggerDraftView, TriggersPageView,
+        WorkflowAutomationView, WorkflowDetailView, WorkflowListItem, WorkflowRunView,
+        WorkflowStepView, WorkflowsPageView,
     };
     use crate::routes;
 
@@ -440,7 +457,61 @@ mod tests {
             }],
             yaml: "title: feature-dev".into(),
             trigger_api_url: "/api/workflows/feature-dev/trigger".into(),
+            manage_triggers_url: "/triggers".into(),
             trigger_input: "Manual run requested".into(),
+        }
+    }
+
+    fn sample_triggers_page() -> TriggersPageView {
+        TriggersPageView {
+            mode_label: "Live registry".into(),
+            mode_tone: "success",
+            notice: Some(crate::data::Notice {
+                text: "Trigger created.".into(),
+                tone: "success",
+            }),
+            summary: vec![MetricCard {
+                label: "Configured".into(),
+                value: "2".into(),
+                note: "Saved triggers in the registry".into(),
+                tone: "cyan",
+            }],
+            form: TriggerDraftView {
+                name: "github-pr".into(),
+                trigger_type: "webhook_received".into(),
+                workflow_name: "feature-dev".into(),
+                condition_json: r#"{"path":"/github/pr"}"#.into(),
+                condition_help: r#"Provide a JSON object. Example: {"path":"/github/pr"}"#.into(),
+                input: "review the PR".into(),
+            },
+            workflows: vec![crate::data::TriggerWorkflowOptionView {
+                value: "feature-dev".into(),
+                label: "feature-dev".into(),
+                detail: "Chain".into(),
+                selected: true,
+            }],
+            trigger_types: vec![crate::data::TriggerTypeOptionView {
+                value: "webhook_received".into(),
+                label: "Webhook Received".into(),
+                selected: true,
+            }],
+            triggers: vec![crate::data::TriggerListItemView {
+                name: "github-pr".into(),
+                trigger_type: "webhook_received".into(),
+                trigger_type_label: "Webhook Received".into(),
+                workflow_title: "feature-dev".into(),
+                workflow_page_url: "/workflows?workflow=feature-dev".into(),
+                status_label: "Enabled".into(),
+                status_tone: "sage",
+                fire_count: 3,
+                last_fired_at: "2026-03-10 12:35".into(),
+                condition_preview: r#"{"path":"/github/pr"}"#.into(),
+                input_preview: "review the PR".into(),
+                toggle_label: "Pause".into(),
+                toggle_enabled_value: false,
+                search_text: "github-pr webhook_received feature-dev".into(),
+            }],
+            empty_hint: "No triggers are configured yet.".into(),
         }
     }
 
@@ -459,8 +530,8 @@ mod tests {
     #[test]
     fn sessions_template_renders_accessible_list_controls() {
         let detail = sample_session_detail();
-        let detail_html = routes::test_support::render_session_detail(detail.clone())
-            .expect("detail renders");
+        let detail_html =
+            routes::test_support::render_session_detail(detail.clone()).expect("detail renders");
         let html = routes::test_support::render_sessions_page(
             SessionsPageView {
                 mode_label: "Live runtime".into(),
@@ -527,7 +598,21 @@ mod tests {
         assert!(html.contains("Search workflows"));
         assert!(html.contains("data-workflow-trigger"));
         assert!(html.contains("/api/workflows/feature-dev/trigger"));
+        assert!(html.contains("/triggers"));
         assert!(html.contains("Recent runs"));
+    }
+
+    #[test]
+    fn triggers_template_renders_management_controls() {
+        let html = routes::test_support::render_triggers_page(sample_triggers_page())
+            .expect("triggers template renders");
+
+        assert!(html.contains("Create trigger"));
+        assert!(html.contains("workflow_name"));
+        assert!(html.contains("data-table-shell"));
+        assert!(html.contains("/triggers/toggle"));
+        assert!(html.contains("/triggers/delete"));
+        assert!(html.contains("github-pr"));
     }
 
     use crate::handlers;
@@ -539,7 +624,7 @@ mod tests {
         body::to_bytes,
         extract::State,
         http::{Method, Request, StatusCode, Uri},
-        routing::{get, post},
+        routing::{delete, get, post},
     };
     use opengoose_persistence::{Database, RunStatus};
     use serde_json::Value;
@@ -610,6 +695,18 @@ mod tests {
             .route("/api/runs", get(handlers::runs::list_runs))
             .route("/api/agents", get(handlers::agents::list_agents))
             .route("/api/teams", get(handlers::teams::list_teams))
+            .route(
+                "/api/triggers",
+                get(handlers::triggers::list_triggers).post(handlers::triggers::create_trigger),
+            )
+            .route(
+                "/api/triggers/{name}/toggle",
+                post(handlers::triggers::toggle_trigger),
+            )
+            .route(
+                "/api/triggers/{name}",
+                delete(handlers::triggers::delete_trigger),
+            )
             .route("/api/workflows", get(handlers::workflows::list_workflows))
             .route(
                 "/api/workflows/{name}",
@@ -735,6 +832,21 @@ mod tests {
         let teams_body = read_json(teams).await;
         assert!(teams_body.is_array());
 
+        let triggers = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(Uri::from_static("/api/triggers"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("triggers request should succeed");
+        assert_eq!(triggers.status(), StatusCode::OK);
+        let triggers_body = read_json(triggers).await;
+        assert!(triggers_body.is_array());
+
         let workflows = app
             .oneshot(
                 Request::builder()
@@ -786,6 +898,18 @@ mod tests {
             .route("/api/runs", get(handlers::runs::list_runs))
             .route("/api/agents", get(handlers::agents::list_agents))
             .route("/api/teams", get(handlers::teams::list_teams))
+            .route(
+                "/api/triggers",
+                get(handlers::triggers::list_triggers).post(handlers::triggers::create_trigger),
+            )
+            .route(
+                "/api/triggers/{name}/toggle",
+                post(handlers::triggers::toggle_trigger),
+            )
+            .route(
+                "/api/triggers/{name}",
+                delete(handlers::triggers::delete_trigger),
+            )
             .route("/api/workflows", get(handlers::workflows::list_workflows))
             .route(
                 "/api/workflows/{name}",

--- a/crates/opengoose-web/src/routes.rs
+++ b/crates/opengoose-web/src/routes.rs
@@ -13,13 +13,15 @@ use futures_core::Stream;
 use opengoose_persistence::{Database, MessageQueue, OrchestrationStore, RunStatus, SessionStore};
 use serde::{Deserialize, Serialize};
 
-use crate::PageState;
 use crate::data::{
     AgentDetailView, AgentsPageView, DashboardView, QueueDetailView, QueuePageView, RunDetailView,
     RunsPageView, SessionDetailView, SessionsPageView, TeamEditorView, TeamsPageView,
-    WorkflowDetailView, WorkflowsPageView, load_agents_page, load_dashboard, load_queue_page,
-    load_runs_page, load_sessions_page, load_teams_page, load_workflows_page, save_team_yaml,
+    TriggerDraftView, TriggersPageView, WorkflowDetailView, WorkflowsPageView, build_trigger_draft,
+    load_agents_page, load_dashboard, load_queue_page, load_runs_page, load_sessions_page,
+    load_teams_page, load_triggers_page, load_workflows_page, save_team_yaml,
 };
+use crate::handlers::triggers as trigger_handlers;
+use crate::{AppState, PageState};
 
 // --- Result types ---
 
@@ -58,6 +60,26 @@ pub(crate) struct WorkflowQuery {
 pub(crate) struct TeamSaveForm {
     original_name: String,
     yaml: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct TriggerCreateForm {
+    name: String,
+    trigger_type: String,
+    workflow_name: String,
+    condition_json: String,
+    input: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct TriggerToggleForm {
+    name: String,
+    enabled: bool,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct TriggerDeleteForm {
+    name: String,
 }
 
 // --- Page handlers ---
@@ -167,6 +189,112 @@ pub(crate) async fn workflows(
         page,
         detail_html,
     })
+}
+
+pub(crate) async fn triggers(State(state): State<PageState>) -> WebResult {
+    render_triggers_page(state.db, None, None)
+}
+
+pub(crate) async fn trigger_create(
+    State(state): State<PageState>,
+    Form(form): Form<TriggerCreateForm>,
+) -> WebResult {
+    let draft = build_trigger_draft(
+        form.name.clone(),
+        form.trigger_type.clone(),
+        form.workflow_name.clone(),
+        form.condition_json.clone(),
+        form.input.clone(),
+    );
+    let app_state = AppState::new(state.db.clone()).map_err(internal_error)?;
+
+    match trigger_handlers::create_trigger_record(
+        &app_state,
+        trigger_handlers::CreateTriggerInput {
+            name: form.name,
+            trigger_type: form.trigger_type,
+            condition_json: form.condition_json,
+            team_name: form.workflow_name,
+            input: form.input,
+            enabled: None,
+        },
+    ) {
+        Ok(trigger) => render_triggers_page(
+            state.db,
+            None,
+            Some(crate::data::Notice {
+                text: format!(
+                    "Trigger {} created for {}.",
+                    trigger.name, trigger.workflow_title
+                ),
+                tone: "success",
+            }),
+        ),
+        Err(error) => render_triggers_page(
+            state.db,
+            Some(draft),
+            Some(crate::data::Notice {
+                text: error.to_string(),
+                tone: "danger",
+            }),
+        ),
+    }
+}
+
+pub(crate) async fn trigger_toggle(
+    State(state): State<PageState>,
+    Form(form): Form<TriggerToggleForm>,
+) -> WebResult {
+    let app_state = AppState::new(state.db.clone()).map_err(internal_error)?;
+
+    match trigger_handlers::set_trigger_enabled_record(&app_state, &form.name, form.enabled) {
+        Ok(trigger) => render_triggers_page(
+            state.db,
+            None,
+            Some(crate::data::Notice {
+                text: format!(
+                    "Trigger {} is now {}.",
+                    trigger.name,
+                    if trigger.enabled { "enabled" } else { "paused" }
+                ),
+                tone: "success",
+            }),
+        ),
+        Err(error) => render_triggers_page(
+            state.db,
+            None,
+            Some(crate::data::Notice {
+                text: error.to_string(),
+                tone: "danger",
+            }),
+        ),
+    }
+}
+
+pub(crate) async fn trigger_delete(
+    State(state): State<PageState>,
+    Form(form): Form<TriggerDeleteForm>,
+) -> WebResult {
+    let app_state = AppState::new(state.db.clone()).map_err(internal_error)?;
+
+    match trigger_handlers::delete_trigger_record(&app_state, &form.name) {
+        Ok(()) => render_triggers_page(
+            state.db,
+            None,
+            Some(crate::data::Notice {
+                text: format!("Trigger {} deleted.", form.name),
+                tone: "success",
+            }),
+        ),
+        Err(error) => render_triggers_page(
+            state.db,
+            None,
+            Some(crate::data::Notice {
+                text: error.to_string(),
+                tone: "danger",
+            }),
+        ),
+    }
 }
 
 pub(crate) async fn teams(Query(query): Query<TeamQuery>) -> WebResult {
@@ -348,6 +476,19 @@ fn render_dashboard_live_html(db: Arc<Database>) -> PartialResult {
     render_partial(&DashboardLiveTemplate { dashboard })
 }
 
+fn render_triggers_page(
+    db: Arc<Database>,
+    draft: Option<TriggerDraftView>,
+    notice: Option<crate::data::Notice>,
+) -> WebResult {
+    let page = load_triggers_page(db, draft, notice).map_err(internal_error)?;
+    render_template(&TriggersTemplate {
+        page_title: "Triggers",
+        current_nav: "triggers",
+        page,
+    })
+}
+
 pub(crate) fn api_error(
     status: StatusCode,
     message: impl std::fmt::Display,
@@ -388,7 +529,9 @@ fn dashboard_stream_error_html() -> &'static str {
 /// Render the dashboard live partial from a pre-built `DashboardView`.
 ///
 /// Exposed for benchmarking. Returns the rendered HTML string or an error message.
-pub fn render_dashboard_live_partial(dashboard: crate::data::DashboardView) -> Result<String, String> {
+pub fn render_dashboard_live_partial(
+    dashboard: crate::data::DashboardView,
+) -> Result<String, String> {
     DashboardLiveTemplate { dashboard }
         .render()
         .map_err(|e| e.to_string())
@@ -472,6 +615,14 @@ struct WorkflowDetailTemplate {
 }
 
 #[derive(Template)]
+#[template(path = "triggers.html")]
+struct TriggersTemplate {
+    page_title: &'static str,
+    current_nav: &'static str,
+    page: TriggersPageView,
+}
+
+#[derive(Template)]
 #[template(path = "teams.html")]
 struct TeamsTemplate {
     page_title: &'static str,
@@ -505,8 +656,8 @@ struct QueueDetailTemplate {
 pub(crate) mod test_support {
     use super::*;
     use crate::data::{
-        DashboardView, QueueDetailView, SessionDetailView, SessionsPageView, WorkflowDetailView,
-        WorkflowsPageView,
+        DashboardView, QueueDetailView, SessionDetailView, SessionsPageView, TriggersPageView,
+        WorkflowDetailView, WorkflowsPageView,
     };
 
     pub(crate) fn render_dashboard_live(dashboard: DashboardView) -> PartialResult {
@@ -546,6 +697,14 @@ pub(crate) mod test_support {
             current_nav: "workflows",
             page,
             detail_html,
+        })
+    }
+
+    pub(crate) fn render_triggers_page(page: TriggersPageView) -> PartialResult {
+        render_partial(&TriggersTemplate {
+            page_title: "Triggers",
+            current_nav: "triggers",
+            page,
         })
     }
 }

--- a/crates/opengoose-web/templates/base.html
+++ b/crates/opengoose-web/templates/base.html
@@ -34,6 +34,7 @@
         <a href="/runs" class="nav-link{% if current_nav == "runs" %} is-active{% endif %}" {% if current_nav == "runs" %}aria-current="page"{% endif %}>Runs</a>
         <a href="/agents" class="nav-link{% if current_nav == "agents" %} is-active{% endif %}" {% if current_nav == "agents" %}aria-current="page"{% endif %}>Agents</a>
         <a href="/workflows" class="nav-link{% if current_nav == "workflows" %} is-active{% endif %}" {% if current_nav == "workflows" %}aria-current="page"{% endif %}>Workflows</a>
+        <a href="/triggers" class="nav-link{% if current_nav == "triggers" %} is-active{% endif %}" {% if current_nav == "triggers" %}aria-current="page"{% endif %}>Triggers</a>
         <a href="/teams" class="nav-link{% if current_nav == "teams" %} is-active{% endif %}" {% if current_nav == "teams" %}aria-current="page"{% endif %}>Teams</a>
         <a href="/queue" class="nav-link{% if current_nav == "queue" %} is-active{% endif %}" {% if current_nav == "queue" %}aria-current="page"{% endif %}>Queue</a>
       </nav>

--- a/crates/opengoose-web/templates/partials/workflow_detail.html
+++ b/crates/opengoose-web/templates/partials/workflow_detail.html
@@ -25,6 +25,7 @@
     <textarea id="workflow-trigger-input" name="input" spellcheck="false">{{ detail.trigger_input }}</textarea>
     <div class="live-chip-row">
       <button class="primary-button" type="submit" data-trigger-submit>Run workflow now</button>
+      <a class="secondary-button" href="{{ detail.manage_triggers_url }}">Manage triggers</a>
       <p class="detail-status" data-trigger-status role="status" aria-live="polite"></p>
     </div>
   </form>
@@ -46,7 +47,7 @@
 
   {% if detail.automations.len() > 0 %}
   <div class="timeline">
-    <h3>Automation</h3>
+    <h3>Schedules and triggers</h3>
     {% for automation in detail.automations %}
     <article class="timeline-item">
       <div>

--- a/crates/opengoose-web/templates/triggers.html
+++ b/crates/opengoose-web/templates/triggers.html
@@ -1,0 +1,219 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="page-intro">
+  <div>
+    <p class="eyebrow">Triggers</p>
+    <h1>Manage event hooks that launch workflows without dropping to the CLI.</h1>
+  </div>
+  <span class="chip tone-{{ page.mode_tone }}">{{ page.mode_label }}</span>
+</section>
+
+{% match page.notice %}
+{% when Some with (notice) %}
+<div class="notice tone-{{ notice.tone }}">{{ notice.text }}</div>
+{% when None %}
+{% endmatch %}
+
+<section class="metric-grid compact-grid">
+  {% for metric in page.summary %}
+  <article class="metric-card tone-{{ metric.tone }}">
+    <p class="metric-label">{{ metric.label }}</p>
+    <strong class="metric-value">{{ metric.value }}</strong>
+    <p class="metric-note">{{ metric.note }}</p>
+  </article>
+  {% endfor %}
+</section>
+
+<section class="split-grid">
+  <article class="detail-card">
+    <div class="detail-head">
+      <div>
+        <p class="eyebrow">Create Trigger</p>
+        <h2>Attach a workflow to an event</h2>
+        <p>New triggers are enabled immediately and can be paused later from the table.</p>
+      </div>
+      <span class="chip tone-cyan">Server rendered</span>
+    </div>
+
+    {% if page.workflows.len() > 0 %}
+    <form class="editor-form" method="post" action="/triggers">
+      <div class="control-row trigger-form-row">
+        <label class="control-field">
+          <span>Name</span>
+          <input type="text" name="name" placeholder="github-pr" value="{{ page.form.name }}" autocomplete="off">
+        </label>
+        <label class="control-field">
+          <span>Type</span>
+          <select name="trigger_type">
+            {% for trigger_type in page.trigger_types %}
+            <option value="{{ trigger_type.value }}" {% if trigger_type.selected %}selected{% endif %}>{{ trigger_type.label }}</option>
+            {% endfor %}
+          </select>
+        </label>
+        <label class="control-field">
+          <span>Workflow</span>
+          <select name="workflow_name">
+            {% for workflow in page.workflows %}
+            <option value="{{ workflow.value }}" {% if workflow.selected %}selected{% endif %}>{{ workflow.label }} · {{ workflow.detail }}</option>
+            {% endfor %}
+          </select>
+        </label>
+      </div>
+      <label class="control-field">
+        <span>Condition JSON</span>
+        <textarea class="compact-textarea" name="condition_json" spellcheck="false">{{ page.form.condition_json }}</textarea>
+      </label>
+      <p class="detail-status">{{ page.form.condition_help }}</p>
+      <label class="control-field">
+        <span>Workflow Input</span>
+        <textarea class="compact-textarea" name="input" spellcheck="false">{{ page.form.input }}</textarea>
+      </label>
+      <div class="live-chip-row">
+        <button class="primary-button" type="submit">Create trigger</button>
+        <p class="detail-status">Input is optional and passed through when the trigger fires.</p>
+      </div>
+    </form>
+    {% else %}
+    <p class="empty-hint">No workflows are available yet. Add a workflow first, then return here to connect triggers.</p>
+    {% endif %}
+  </article>
+
+  <article class="detail-card">
+    <div class="detail-head">
+      <div>
+        <p class="eyebrow">Supported Types</p>
+        <h2>Event sources in the current runtime</h2>
+        <p>Condition JSON should always be an object. Pick the trigger type, then shape the condition to match that event source.</p>
+      </div>
+      <span class="chip tone-neutral">{{ page.trigger_types.len() }} kinds</span>
+    </div>
+
+    <div class="timeline">
+      {% for trigger_type in page.trigger_types %}
+      <article class="timeline-item">
+        <div>
+          <p class="rail-title">{{ trigger_type.label }}</p>
+          <p class="rail-subtitle">{{ trigger_type.value }}</p>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </article>
+</section>
+
+<section class="detail-card">
+  <div class="panel-head">
+    <div>
+      <p class="eyebrow">Trigger List</p>
+      <h2>Pause, resume, and prune automation hooks</h2>
+      <small>Each row shows the target workflow, activity history, and quick actions.</small>
+    </div>
+  </div>
+
+  {% if page.triggers.len() > 0 %}
+  <section class="table-shell" data-table-shell data-table-label="triggers">
+    <div class="list-toolbar" role="search" aria-label="Filter triggers">
+      <div class="control-row">
+        <label class="control-field control-field-search">
+          <span>Search triggers</span>
+          <input type="search" placeholder="Name, type, workflow, payload" autocomplete="off" data-table-search>
+        </label>
+        <label class="control-field control-field-compact">
+          <span>Status</span>
+          <select data-table-filter>
+            <option value="all" selected>All</option>
+            <option value="enabled">Enabled</option>
+            <option value="paused">Paused</option>
+          </select>
+        </label>
+        <label class="control-field control-field-compact">
+          <span>Sort</span>
+          <select data-table-sort>
+            <option value="newest" selected>Latest activity</option>
+            <option value="sender">Name A-Z</option>
+            <option value="recipient">Workflow A-Z</option>
+            <option value="retries">Fire count high-low</option>
+          </select>
+        </label>
+        <label class="control-field control-field-compact">
+          <span>Page size</span>
+          <select data-table-page-size>
+            <option value="4">4</option>
+            <option value="6" selected>6</option>
+            <option value="10">10</option>
+          </select>
+        </label>
+      </div>
+      <p class="list-status" data-table-status role="status" aria-live="polite"></p>
+    </div>
+
+    <div class="table-wrap">
+      <table>
+        <caption class="visually-hidden">Configured workflow triggers</caption>
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Type</th>
+            <th scope="col">Workflow</th>
+            <th scope="col">Status</th>
+            <th scope="col">Fire count</th>
+            <th scope="col">Last fired</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody data-table-body>
+          {% for trigger in page.triggers %}
+          <tr
+            data-table-row
+            data-search="{{ trigger.search_text }}"
+            data-status="{{ trigger.status_label }}"
+            data-sort-created="{{ trigger.last_fired_at }}"
+            data-sort-sender="{{ trigger.name }}"
+            data-sort-recipient="{{ trigger.workflow_title }}"
+            data-sort-retries="{{ trigger.fire_count }}"
+            tabindex="0"
+          >
+            <td><strong>{{ trigger.name }}</strong></td>
+            <td>{{ trigger.trigger_type_label }}</td>
+            <td><a href="{{ trigger.workflow_page_url }}">{{ trigger.workflow_title }}</a></td>
+            <td><span class="chip tone-{{ trigger.status_tone }}">{{ trigger.status_label }}</span></td>
+            <td>{{ trigger.fire_count }}</td>
+            <td>{{ trigger.last_fired_at }}</td>
+            <td>
+              <div class="inline-actions">
+                <form method="post" action="/triggers/toggle">
+                  <input type="hidden" name="name" value="{{ trigger.name }}">
+                  <input type="hidden" name="enabled" value="{{ trigger.toggle_enabled_value }}">
+                  <button class="secondary-button" type="submit">{{ trigger.toggle_label }}</button>
+                </form>
+                <form method="post" action="/triggers/delete" data-confirm="Delete trigger {{ trigger.name }}?">
+                  <input type="hidden" name="name" value="{{ trigger.name }}">
+                  <button class="secondary-button" type="submit">Delete</button>
+                </form>
+              </div>
+            </td>
+          </tr>
+          <tr class="table-detail" data-table-detail>
+            <td colspan="7">
+              <strong>Condition:</strong> {{ trigger.condition_preview }}
+              <br><strong>Workflow input:</strong> {{ trigger.input_preview }}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <p class="empty-hint empty-hint-inline" data-table-empty hidden>No triggers match the current filters.</p>
+    <div class="pager" data-table-pagination>
+      <button class="secondary-button" type="button" data-table-prev>Previous</button>
+      <p class="pager-label" data-table-page>Page 1 of 1</p>
+      <button class="secondary-button" type="button" data-table-next>Next</button>
+    </div>
+  </section>
+  {% else %}
+  <p class="empty-hint">{{ page.empty_hint }}</p>
+  {% endif %}
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a server-rendered triggers dashboard for creating, pausing, resuming, and deleting workflow triggers
- expose trigger CRUD and toggle routes in both the HTML dashboard and `/api/triggers` JSON API
- port the page wiring onto the post-OPE-135 `routes.rs` structure and keep the workspace clippy-clean, including the small matrix cleanup needed for `-D warnings`

## Verification
- cargo fmt --all
- cargo build
- cargo clippy --all-targets -- -D warnings
- cargo test

Paperclip issue: OPE-137
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
