### PR TITLE
feat: Add agent and run detail pages [OPE-149]

### DIFF
--- a/crates/opengoose-web/assets/app.css
+++ b/crates/opengoose-web/assets/app.css
@@ -495,6 +495,15 @@ button:disabled {
   font-weight: 600;
 }
 
+.rail-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.rail-title a:hover {
+  text-decoration: underline;
+}
+
 .rail-meta {
   display: flex;
   justify-content: space-between;

--- a/crates/opengoose-web/src/data/agents.rs
+++ b/crates/opengoose-web/src/data/agents.rs
@@ -1,10 +1,20 @@
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
+use opengoose_persistence::{
+    Database, OrchestrationRun, OrchestrationStore, SessionStore, SessionSummary,
+};
 use opengoose_profiles::{AgentProfile, ProfileStore, all_defaults as default_profiles};
+use opengoose_teams::{TeamDefinition, TeamStore, all_defaults as default_teams};
+use opengoose_types::SessionKey;
 use urlencoding::encode;
 
-use crate::data::utils::{choose_selected_name, preview};
+use super::runs::mock_runs;
+use super::sessions::mock_sessions;
+use crate::data::utils::{choose_selected_name, platform_tone, preview, progress_label, run_tone};
 use crate::data::views::{
-    AgentDetailView, AgentListItem, AgentsPageView, ExtensionRow, SettingRow,
+    AgentDetailView, AgentListItem, AgentRecentRunView, AgentSessionView, AgentsPageView,
+    ExtensionRow, SettingRow,
 };
 
 #[derive(Clone)]
@@ -14,10 +24,17 @@ struct ProfileCatalogEntry {
     is_live: bool,
 }
 
+struct AgentRuntimeCatalog {
+    teams: Vec<TeamDefinition>,
+    runs: Vec<OrchestrationRun>,
+    sessions: Vec<SessionSummary>,
+}
+
 /// Load the agents page view-model, optionally selecting an agent by name.
-pub fn load_agents_page(selected: Option<String>) -> Result<AgentsPageView> {
+pub fn load_agents_page(db: Arc<Database>, selected: Option<String>) -> Result<AgentsPageView> {
     let agents = load_profiles_catalog()?;
     let using_defaults = agents.iter().all(|profile| !profile.is_live);
+    let runtime = load_agent_runtime_catalog(db, using_defaults)?;
     let selected_name = choose_selected_name(
         agents
             .iter()
@@ -53,13 +70,27 @@ pub fn load_agents_page(selected: Option<String>) -> Result<AgentsPageView> {
                 .iter()
                 .find(|entry| entry.profile.title == selected_name)
                 .context("selected agent missing")?,
+            &runtime,
         )?,
     })
 }
 
 /// Load the detail panel for a single agent profile.
-pub fn load_agent_detail(selected: Option<String>) -> Result<AgentDetailView> {
-    Ok(load_agents_page(selected)?.selected)
+pub fn load_agent_detail(db: Arc<Database>, selected: Option<String>) -> Result<AgentDetailView> {
+    Ok(load_agents_page(db, selected)?.selected)
+}
+
+/// Load an exact agent profile detail for standalone pages and JSON detail endpoints.
+pub fn load_agent_detail_exact(db: Arc<Database>, name: &str) -> Result<Option<AgentDetailView>> {
+    let agents = load_profiles_catalog()?;
+    let using_defaults = agents.iter().all(|profile| !profile.is_live);
+    let runtime = load_agent_runtime_catalog(db, using_defaults)?;
+
+    agents
+        .iter()
+        .find(|entry| entry.profile.title == name)
+        .map(|entry| build_agent_detail(entry, &runtime))
+        .transpose()
 }
 
 fn load_profiles_catalog() -> Result<Vec<ProfileCatalogEntry>> {
@@ -89,7 +120,51 @@ fn load_profiles_catalog() -> Result<Vec<ProfileCatalogEntry>> {
         .collect()
 }
 
-fn build_agent_detail(entry: &ProfileCatalogEntry) -> Result<AgentDetailView> {
+fn load_agent_runtime_catalog(
+    db: Arc<Database>,
+    using_defaults: bool,
+) -> Result<AgentRuntimeCatalog> {
+    let live_teams = load_live_teams()?;
+    let live_runs = OrchestrationStore::new(db.clone()).list_runs(None, 200)?;
+    let live_sessions = SessionStore::new(db).list_sessions(24)?;
+    let runtime_preview =
+        using_defaults && live_teams.is_empty() && live_runs.is_empty() && live_sessions.is_empty();
+
+    Ok(AgentRuntimeCatalog {
+        teams: if runtime_preview {
+            default_teams()
+        } else {
+            live_teams
+        },
+        runs: if runtime_preview {
+            mock_runs()
+        } else {
+            live_runs
+        },
+        sessions: if runtime_preview {
+            mock_sessions()
+                .into_iter()
+                .map(|record| record.summary)
+                .collect()
+        } else {
+            live_sessions
+        },
+    })
+}
+
+fn load_live_teams() -> Result<Vec<TeamDefinition>> {
+    let store = TeamStore::new()?;
+    let names = store.list()?;
+    names
+        .into_iter()
+        .map(|name| store.get(&name).map_err(Into::into))
+        .collect()
+}
+
+fn build_agent_detail(
+    entry: &ProfileCatalogEntry,
+    runtime: &AgentRuntimeCatalog,
+) -> Result<AgentDetailView> {
     let settings = profile_settings(&entry.profile);
     let extensions = entry
         .profile
@@ -106,6 +181,9 @@ fn build_agent_detail(entry: &ProfileCatalogEntry) -> Result<AgentDetailView> {
                 .unwrap_or_else(|| "No runtime configuration".into()),
         })
         .collect();
+    let team_names = team_memberships(&runtime.teams, &entry.profile.title);
+    let recent_runs = recent_runs_for_profile(&runtime.runs, &team_names);
+    let connected_sessions = connected_sessions_for_profile(&runtime.sessions, &team_names);
 
     Ok(AgentDetailView {
         title: entry.profile.title.clone(),
@@ -115,6 +193,7 @@ fn build_agent_detail(entry: &ProfileCatalogEntry) -> Result<AgentDetailView> {
             .clone()
             .unwrap_or_else(|| "No profile description provided.".into()),
         source_label: entry.source_label.clone(),
+        detail_page_url: format!("/agents/{}", encode(&entry.profile.title)),
         instructions_preview: preview(
             entry
                 .profile
@@ -128,8 +207,87 @@ fn build_agent_detail(entry: &ProfileCatalogEntry) -> Result<AgentDetailView> {
         activities: entry.profile.activities.clone().unwrap_or_default(),
         skills: entry.profile.skills.clone(),
         extensions,
+        recent_runs,
+        connected_sessions,
+        runtime_empty_hint:
+            "No related orchestration runs or active sessions have been recorded for this profile yet."
+                .into(),
         yaml: entry.profile.to_yaml()?,
     })
+}
+
+fn team_memberships(teams: &[TeamDefinition], profile_title: &str) -> Vec<String> {
+    teams
+        .iter()
+        .filter(|team| {
+            team.agents
+                .iter()
+                .any(|agent| agent.profile == profile_title)
+        })
+        .map(|team| team.title.clone())
+        .collect()
+}
+
+fn recent_runs_for_profile(
+    runs: &[OrchestrationRun],
+    team_names: &[String],
+) -> Vec<AgentRecentRunView> {
+    runs.iter()
+        .filter(|run| {
+            team_names
+                .iter()
+                .any(|team_name| team_name == &run.team_name)
+        })
+        .take(6)
+        .map(|run| AgentRecentRunView {
+            title: run.team_name.clone(),
+            detail: format!(
+                "Run {} · {} workflow · {}",
+                run.team_run_id,
+                run.workflow,
+                progress_label(run)
+            ),
+            updated_at: run.updated_at.clone(),
+            status_label: run.status.as_str().to_uppercase(),
+            status_tone: run_tone(&run.status),
+            page_url: format!("/runs/{}", encode(&run.team_run_id)),
+        })
+        .collect()
+}
+
+fn connected_sessions_for_profile(
+    sessions: &[SessionSummary],
+    team_names: &[String],
+) -> Vec<AgentSessionView> {
+    sessions
+        .iter()
+        .filter(|session| {
+            session
+                .active_team
+                .as_ref()
+                .map(|team_name| team_names.iter().any(|candidate| candidate == team_name))
+                .unwrap_or(false)
+        })
+        .take(6)
+        .map(|session| {
+            let parsed = SessionKey::from_stable_id(&session.session_key);
+            AgentSessionView {
+                title: match &parsed.namespace {
+                    Some(namespace) => format!("{namespace} / {}", parsed.channel_id),
+                    None => parsed.channel_id.clone(),
+                },
+                detail: session
+                    .active_team
+                    .clone()
+                    .map(|team| format!("{team} active"))
+                    .unwrap_or_else(|| "No active team".into()),
+                updated_at: session.updated_at.clone(),
+                badge: parsed.platform.as_str().to_uppercase(),
+                badge_tone: platform_tone(parsed.platform.as_str()),
+                page_url: format!("/sessions?session={}", encode(&session.session_key)),
+            }
+        })
+        .collect()
 }
 
 fn capability_line(profile: &AgentProfile) -> String {

--- a/crates/opengoose-web/src/data/mod.rs
+++ b/crates/opengoose-web/src/data/mod.rs
@@ -10,10 +10,10 @@ mod utils;
 mod views;
 mod workflows;
 
-pub use agents::{load_agent_detail, load_agents_page};
+pub use agents::{load_agent_detail, load_agent_detail_exact, load_agents_page};
 pub use dashboard::load_dashboard;
 pub use queue::{load_queue_detail, load_queue_page};
-pub use runs::{load_run_detail, load_runs_page};
+pub use runs::{load_run_detail, load_run_detail_exact, load_runs_page};
 pub use schedules::{
     ScheduleSaveInput, delete_schedule, load_schedules_page, save_schedule, toggle_schedule,
 };

--- a/crates/opengoose-web/src/data/runs.rs
+++ b/crates/opengoose-web/src/data/runs.rs
@@ -7,7 +7,9 @@ use opengoose_persistence::{
 };
 use urlencoding::encode;
 
-use crate::data::utils::{choose_selected_run, progress_label, run_tone, work_tone};
+use crate::data::utils::{
+    choose_selected_run, format_duration, progress_label, run_duration_seconds, run_tone, work_tone,
+};
 use crate::data::views::{
     BroadcastView, MetaRow, RunDetailView, RunListItem, RunsPageView, WorkItemView,
 };
@@ -47,6 +49,31 @@ pub fn load_runs_page(db: Arc<Database>, selected: Option<String>) -> Result<Run
 /// Load the detail panel for a single orchestration run.
 pub fn load_run_detail(db: Arc<Database>, selected: Option<String>) -> Result<RunDetailView> {
     Ok(load_runs_page(db, selected)?.selected)
+}
+
+/// Load an exact run detail by ID for standalone pages and JSON detail endpoints.
+pub fn load_run_detail_exact(db: Arc<Database>, run_id: &str) -> Result<Option<RunDetailView>> {
+    let run_store = OrchestrationStore::new(db.clone());
+    if let Some(run) = run_store.get_run(run_id)? {
+        let work_items = WorkItemStore::new(db.clone()).list_for_run(run_id, None)?;
+        let broadcasts = MessageQueue::new(db).read_broadcasts(run_id, None)?;
+        return Ok(Some(build_run_detail(
+            &run,
+            &work_items,
+            &broadcasts,
+            "Live runtime",
+        )));
+    }
+
+    let has_live_runs = !run_store.list_runs(None, 1)?.is_empty();
+    if has_live_runs {
+        return Ok(None);
+    }
+
+    Ok(mock_runs()
+        .into_iter()
+        .find(|run| run.team_run_id == run_id)
+        .map(|run| build_mock_run_detail(&run.team_run_id)))
 }
 
 pub(super) fn mock_runs() -> Vec<OrchestrationRun> {
@@ -144,10 +171,19 @@ fn build_run_detail(
     broadcasts: &[QueueMessage],
     source_label: &str,
 ) -> RunDetailView {
+    let updated_label = match run.status {
+        RunStatus::Completed => "Completed",
+        RunStatus::Failed => "Failed",
+        RunStatus::Suspended => "Suspended",
+        RunStatus::Running => "Last update",
+    };
+
     RunDetailView {
         title: format!("Run {}", run.team_run_id),
         subtitle: format!("{} / {}", run.team_name, run.workflow),
         source_label: source_label.into(),
+        detail_page_url: format!("/runs/{}", encode(&run.team_run_id)),
+        queue_page_url: format!("/queue?run={}", encode(&run.team_run_id)),
         meta: vec![
             MetaRow {
                 label: "Status".into(),
@@ -162,8 +198,18 @@ fn build_run_detail(
                 value: run.session_key.clone(),
             },
             MetaRow {
-                label: "Updated".into(),
+                label: "Started".into(),
+                value: run.created_at.clone(),
+            },
+            MetaRow {
+                label: updated_label.into(),
                 value: run.updated_at.clone(),
+            },
+            MetaRow {
+                label: "Duration".into(),
+                value: run_duration_seconds(run)
+                    .map(format_duration)
+                    .unwrap_or_else(|| "Unavailable".into()),
             },
         ],
         work_items: work_items
@@ -186,6 +232,8 @@ fn build_run_detail(
                 } else {
                     "is-root"
                 },
+                output: item.output.clone().filter(|value| !value.is_empty()),
+                error: item.error.clone().filter(|value| !value.is_empty()),
             })
             .collect(),
         broadcasts: broadcasts
@@ -422,7 +470,38 @@ mod tests {
         assert!(labels.contains(&"Status"));
         assert!(labels.contains(&"Session"));
         assert!(labels.contains(&"Progress"));
-        assert!(labels.contains(&"Updated"));
+        assert!(labels.contains(&"Started"));
+        assert!(labels.contains(&"Last update"));
+        assert!(labels.contains(&"Duration"));
+    }
+
+    #[test]
+    fn build_run_detail_includes_queue_link_and_work_item_output() {
+        let run = sample_run("queue-run", RunStatus::Completed);
+        let work_items = vec![WorkItem {
+            id: 1,
+            session_key: run.session_key.clone(),
+            team_run_id: run.team_run_id.clone(),
+            parent_id: None,
+            title: "Ship".into(),
+            description: None,
+            status: WorkStatus::Completed,
+            assigned_to: Some("reviewer".into()),
+            workflow_step: Some(1),
+            input: None,
+            output: Some("All checks passed".into()),
+            error: None,
+            created_at: run.created_at.clone(),
+            updated_at: run.updated_at.clone(),
+        }];
+
+        let detail = build_run_detail(&run, &work_items, &[], "Live");
+
+        assert!(detail.queue_page_url.ends_with("queue-run"));
+        assert_eq!(
+            detail.work_items[0].output.as_deref(),
+            Some("All checks passed")
+        );
     }
 }
 

--- a/crates/opengoose-web/src/data/views.rs
+++ b/crates/opengoose-web/src/data/views.rs
@@ -122,6 +122,8 @@ pub struct WorkItemView {
     pub status_tone: &'static str,
     pub step_label: String,
     pub indent_class: &'static str,
+    pub output: Option<String>,
+    pub error: Option<String>,
 }
 
 /// A broadcast message shown in the run detail panel.
@@ -138,6 +140,8 @@ pub struct RunDetailView {
     pub title: String,
     pub subtitle: String,
     pub source_label: String,
+    pub detail_page_url: String,
+    pub queue_page_url: String,
     pub meta: Vec<MetaRow>,
     pub work_items: Vec<WorkItemView>,
     pub broadcasts: Vec<BroadcastView>,
@@ -216,17 +220,43 @@ pub struct AgentListItem {
     pub active: bool,
 }
 
+/// A recent orchestration run related to an agent profile.
+#[derive(Clone)]
+pub struct AgentRecentRunView {
+    pub title: String,
+    pub detail: String,
+    pub updated_at: String,
+    pub status_label: String,
+    pub status_tone: &'static str,
+    pub page_url: String,
+}
+
+/// An active session routed through a workflow that uses an agent profile.
+#[derive(Clone)]
+pub struct AgentSessionView {
+    pub title: String,
+    pub detail: String,
+    pub updated_at: String,
+    pub badge: String,
+    pub badge_tone: &'static str,
+    pub page_url: String,
+}
+
 /// Full detail panel for a selected agent profile.
 #[derive(Clone)]
 pub struct AgentDetailView {
     pub title: String,
     pub subtitle: String,
     pub source_label: String,
+    pub detail_page_url: String,
     pub instructions_preview: String,
     pub settings: Vec<SettingRow>,
     pub activities: Vec<String>,
     pub skills: Vec<String>,
     pub extensions: Vec<ExtensionRow>,
+    pub recent_runs: Vec<AgentRecentRunView>,
+    pub connected_sessions: Vec<AgentSessionView>,
+    pub runtime_empty_hint: String,
     pub yaml: String,
 }
 

--- a/crates/opengoose-web/src/handlers/agents.rs
+++ b/crates/opengoose-web/src/handlers/agents.rs
@@ -1,8 +1,9 @@
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use serde::Serialize;
 
 use super::AppError;
+use crate::data::load_agent_detail_exact;
 use crate::state::AppState;
 
 /// JSON response item representing an agent profile name.
@@ -12,12 +13,122 @@ pub struct AgentItem {
     pub name: String,
 }
 
+#[derive(Serialize)]
+pub struct AgentSetting {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Serialize)]
+pub struct AgentExtension {
+    pub name: String,
+    pub kind: String,
+    pub summary: String,
+}
+
+#[derive(Serialize)]
+pub struct AgentRecentRun {
+    pub title: String,
+    pub detail: String,
+    pub updated_at: String,
+    pub status_label: String,
+    pub status_tone: String,
+    pub page_url: String,
+}
+
+#[derive(Serialize)]
+pub struct AgentSession {
+    pub title: String,
+    pub detail: String,
+    pub updated_at: String,
+    pub badge: String,
+    pub badge_tone: String,
+    pub page_url: String,
+}
+
+#[derive(Serialize)]
+pub struct AgentDetail {
+    pub title: String,
+    pub subtitle: String,
+    pub source_label: String,
+    pub instructions_preview: String,
+    pub settings: Vec<AgentSetting>,
+    pub activities: Vec<String>,
+    pub skills: Vec<String>,
+    pub extensions: Vec<AgentExtension>,
+    pub recent_runs: Vec<AgentRecentRun>,
+    pub connected_sessions: Vec<AgentSession>,
+    pub runtime_empty_hint: String,
+    pub yaml: String,
+}
+
 /// GET /api/agents — list all installed agent profiles.
 pub async fn list_agents(State(state): State<AppState>) -> Result<Json<Vec<AgentItem>>, AppError> {
     let names = state.profile_store.list()?;
     Ok(Json(
         names.into_iter().map(|name| AgentItem { name }).collect(),
     ))
+}
+
+/// GET /api/agents/:name — return detail for a single agent profile.
+pub async fn get_agent(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<AgentDetail>, AppError> {
+    let detail = load_agent_detail_exact(state.db, &name)?
+        .ok_or_else(|| AppError::NotFound(format!("agent `{name}`")))?;
+
+    Ok(Json(AgentDetail {
+        title: detail.title,
+        subtitle: detail.subtitle,
+        source_label: detail.source_label,
+        instructions_preview: detail.instructions_preview,
+        settings: detail
+            .settings
+            .into_iter()
+            .map(|row| AgentSetting {
+                label: row.label,
+                value: row.value,
+            })
+            .collect(),
+        activities: detail.activities,
+        skills: detail.skills,
+        extensions: detail
+            .extensions
+            .into_iter()
+            .map(|row| AgentExtension {
+                name: row.name,
+                kind: row.kind,
+                summary: row.summary,
+            })
+            .collect(),
+        recent_runs: detail
+            .recent_runs
+            .into_iter()
+            .map(|run| AgentRecentRun {
+                title: run.title,
+                detail: run.detail,
+                updated_at: run.updated_at,
+                status_label: run.status_label,
+                status_tone: run.status_tone.into(),
+                page_url: run.page_url,
+            })
+            .collect(),
+        connected_sessions: detail
+            .connected_sessions
+            .into_iter()
+            .map(|session| AgentSession {
+                title: session.title,
+                detail: session.detail,
+                updated_at: session.updated_at,
+                badge: session.badge,
+                badge_tone: session.badge_tone.into(),
+                page_url: session.page_url,
+            })
+            .collect(),
+        runtime_empty_hint: detail.runtime_empty_hint,
+        yaml: detail.yaml,
+    }))
 }
 
 #[cfg(test)]

--- a/crates/opengoose-web/src/handlers/runs.rs
+++ b/crates/opengoose-web/src/handlers/runs.rs
@@ -1,8 +1,9 @@
 use axum::Json;
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use serde::{Deserialize, Serialize};
 
 use super::AppError;
+use crate::data::load_run_detail_exact;
 use crate::state::AppState;
 
 /// JSON response item for a single orchestration run.
@@ -18,6 +19,45 @@ pub struct RunItem {
     pub result: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+}
+
+#[derive(Serialize)]
+pub struct RunMetaItem {
+    pub label: String,
+    pub value: String,
+}
+
+#[derive(Serialize)]
+pub struct RunWorkItem {
+    pub title: String,
+    pub detail: String,
+    pub status_label: String,
+    pub status_tone: String,
+    pub step_label: String,
+    pub indent_class: String,
+    pub output: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RunBroadcastItem {
+    pub sender: String,
+    pub created_at: String,
+    pub content: String,
+}
+
+#[derive(Serialize)]
+pub struct RunDetail {
+    pub title: String,
+    pub subtitle: String,
+    pub source_label: String,
+    pub queue_page_url: String,
+    pub meta: Vec<RunMetaItem>,
+    pub work_items: Vec<RunWorkItem>,
+    pub broadcasts: Vec<RunBroadcastItem>,
+    pub input: String,
+    pub result: String,
+    pub empty_hint: String,
 }
 
 /// Query parameters for `GET /api/runs`.
@@ -74,6 +114,56 @@ pub async fn list_runs(
             })
             .collect(),
     ))
+}
+
+/// GET /api/runs/:run_id — return detail for a single orchestration run.
+pub async fn get_run(
+    State(state): State<AppState>,
+    Path(run_id): Path<String>,
+) -> Result<Json<RunDetail>, AppError> {
+    let detail = load_run_detail_exact(state.db, &run_id)?
+        .ok_or_else(|| AppError::NotFound(format!("run `{run_id}`")))?;
+
+    Ok(Json(RunDetail {
+        title: detail.title,
+        subtitle: detail.subtitle,
+        source_label: detail.source_label,
+        queue_page_url: detail.queue_page_url,
+        meta: detail
+            .meta
+            .into_iter()
+            .map(|row| RunMetaItem {
+                label: row.label,
+                value: row.value,
+            })
+            .collect(),
+        work_items: detail
+            .work_items
+            .into_iter()
+            .map(|item| RunWorkItem {
+                title: item.title,
+                detail: item.detail,
+                status_label: item.status_label,
+                status_tone: item.status_tone.into(),
+                step_label: item.step_label,
+                indent_class: item.indent_class.into(),
+                output: item.output,
+                error: item.error,
+            })
+            .collect(),
+        broadcasts: detail
+            .broadcasts
+            .into_iter()
+            .map(|message| RunBroadcastItem {
+                sender: message.sender,
+                created_at: message.created_at,
+                content: message.content,
+            })
+            .collect(),
+        input: detail.input,
+        result: detail.result,
+        empty_hint: detail.empty_hint,
+    }))
 }
 
 #[cfg(test)]

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -206,7 +206,9 @@ pub async fn serve(options: WebOptions) -> Result<()> {
             get(handlers::sessions::get_messages),
         )
         .route("/api/runs", get(handlers::runs::list_runs))
+        .route("/api/runs/{run_id}", get(handlers::runs::get_run))
         .route("/api/agents", get(handlers::agents::list_agents))
+        .route("/api/agents/{name}", get(handlers::agents::get_agent))
         .route("/api/teams", get(handlers::teams::list_teams))
         .route("/api/workflows", get(handlers::workflows::list_workflows))
         .route(
@@ -272,7 +274,9 @@ pub async fn serve(options: WebOptions) -> Result<()> {
         .route("/dashboard/events", get(routes::dashboard_events))
         .route("/sessions", get(routes::sessions))
         .route("/runs", get(routes::runs))
+        .route("/runs/{run_id}", get(routes::run_detail))
         .route("/agents", get(routes::agents))
+        .route("/agents/{agent_name}", get(routes::agent_detail))
         .route("/workflows", get(routes::workflows))
         .route(
             "/schedules",
@@ -713,7 +717,9 @@ mod tests {
                 get(handlers::sessions::get_messages),
             )
             .route("/api/runs", get(handlers::runs::list_runs))
+            .route("/api/runs/{run_id}", get(handlers::runs::get_run))
             .route("/api/agents", get(handlers::agents::list_agents))
+            .route("/api/agents/{name}", get(handlers::agents::get_agent))
             .route("/api/teams", get(handlers::teams::list_teams))
             .route("/api/workflows", get(handlers::workflows::list_workflows))
             .route(
@@ -876,6 +882,51 @@ mod tests {
         assert!(body.is_array());
     }
 
+    #[tokio::test]
+    async fn api_run_detail_returns_preview_payload() {
+        let app = api_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(Uri::from_static("/api/runs/run-preview-01"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("run detail request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = read_json(response).await;
+        assert_eq!(body["title"], "Run run-preview-01");
+        assert!(
+            body["queue_page_url"]
+                .as_str()
+                .unwrap()
+                .contains("run-preview-01")
+        );
+    }
+
+    #[tokio::test]
+    async fn api_agent_detail_returns_default_profile_payload() {
+        let app = api_router();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri(Uri::from_static("/api/agents/developer"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("agent detail request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = read_json(response).await;
+        assert_eq!(body["title"], "developer");
+        assert!(body["settings"].is_array());
+    }
+
     // ── Full API router (includes alerts + fallback) ──────────────────────
 
     fn full_api_router() -> Router {
@@ -889,7 +940,9 @@ mod tests {
                 get(handlers::sessions::get_messages),
             )
             .route("/api/runs", get(handlers::runs::list_runs))
+            .route("/api/runs/{run_id}", get(handlers::runs::get_run))
             .route("/api/agents", get(handlers::agents::list_agents))
+            .route("/api/agents/{name}", get(handlers::agents::get_agent))
             .route("/api/teams", get(handlers::teams::list_teams))
             .route("/api/workflows", get(handlers::workflows::list_workflows))
             .route(

--- a/crates/opengoose-web/src/routes.rs
+++ b/crates/opengoose-web/src/routes.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use askama::Template;
 use async_stream::stream;
 use axum::Json;
-use axum::extract::{Form, Query, State};
+use axum::extract::{Form, Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::Html;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -18,9 +18,10 @@ use crate::data::{
     AgentDetailView, AgentsPageView, DashboardView, QueueDetailView, QueuePageView, RunDetailView,
     RunsPageView, ScheduleEditorView, ScheduleSaveInput, SchedulesPageView, SessionDetailView,
     SessionsPageView, TeamEditorView, TeamsPageView, TriggerDetailView, TriggersPageView,
-    WorkflowDetailView, WorkflowsPageView, delete_schedule, load_agents_page, load_dashboard,
-    load_queue_page, load_runs_page, load_schedules_page, load_sessions_page, load_teams_page,
-    load_triggers_page, load_workflows_page, save_schedule, save_team_yaml, toggle_schedule,
+    WorkflowDetailView, WorkflowsPageView, delete_schedule, load_agent_detail_exact,
+    load_agents_page, load_dashboard, load_queue_page, load_run_detail_exact, load_runs_page,
+    load_schedules_page, load_sessions_page, load_teams_page, load_triggers_page,
+    load_workflows_page, save_schedule, save_team_yaml, toggle_schedule,
 };
 
 // --- Result types ---
@@ -162,8 +163,28 @@ pub(crate) async fn runs(
     })
 }
 
-pub(crate) async fn agents(Query(query): Query<AgentQuery>) -> WebResult {
-    let page = load_agents_page(query.agent).map_err(internal_error)?;
+pub(crate) async fn run_detail(
+    State(state): State<PageState>,
+    Path(run_id): Path<String>,
+) -> WebResult {
+    match load_run_detail_exact(state.db, &run_id).map_err(internal_error)? {
+        Some(detail) => render_template(&RunDetailPageTemplate {
+            page_title: "Run Detail",
+            current_nav: "runs",
+            detail,
+        }),
+        None => Err(not_found_error(
+            &format!("/runs/{run_id}"),
+            format!("Run `{run_id}` was not found."),
+        )),
+    }
+}
+
+pub(crate) async fn agents(
+    State(state): State<PageState>,
+    Query(query): Query<AgentQuery>,
+) -> WebResult {
+    let page = load_agents_page(state.db, query.agent).map_err(internal_error)?;
     let detail_html = render_partial(&AgentDetailTemplate {
         detail: page.selected.clone(),
     })?;
@@ -174,6 +195,23 @@ pub(crate) async fn agents(Query(query): Query<AgentQuery>) -> WebResult {
         page,
         detail_html,
     })
+}
+
+pub(crate) async fn agent_detail(
+    State(state): State<PageState>,
+    Path(agent_name): Path<String>,
+) -> WebResult {
+    match load_agent_detail_exact(state.db, &agent_name).map_err(internal_error)? {
+        Some(detail) => render_template(&AgentDetailPageTemplate {
+            page_title: "Agent Detail",
+            current_nav: "agents",
+            detail,
+        }),
+        None => Err(not_found_error(
+            &format!("/agents/{agent_name}"),
+            format!("Agent profile `{agent_name}` was not found."),
+        )),
+    }
 }
 
 pub(crate) async fn workflows(
@@ -435,6 +473,14 @@ fn internal_error(error: anyhow::Error) -> (StatusCode, Html<String>) {
     (StatusCode::INTERNAL_SERVER_ERROR, Html(html))
 }
 
+fn not_found_error(path: &str, detail: String) -> (StatusCode, Html<String>) {
+    let page = crate::pages::ErrorPage::not_found(path);
+    let html = page
+        .render()
+        .unwrap_or_else(|_| format!("<p>Not Found: {detail}</p>"));
+    (StatusCode::NOT_FOUND, Html(html))
+}
+
 fn render_html<T: Template>(template: &T) -> PartialResult {
     template
         .render()
@@ -550,6 +596,14 @@ struct RunDetailTemplate {
 }
 
 #[derive(Template)]
+#[template(path = "run_detail.html")]
+struct RunDetailPageTemplate {
+    page_title: &'static str,
+    current_nav: &'static str,
+    detail: RunDetailView,
+}
+
+#[derive(Template)]
 #[template(path = "agents.html")]
 struct AgentsTemplate {
     page_title: &'static str,
@@ -561,6 +615,14 @@ struct AgentsTemplate {
 #[derive(Template)]
 #[template(path = "partials/agent_detail.html")]
 struct AgentDetailTemplate {
+    detail: AgentDetailView,
+}
+
+#[derive(Template)]
+#[template(path = "agent_detail.html")]
+struct AgentDetailPageTemplate {
+    page_title: &'static str,
+    current_nav: &'static str,
     detail: AgentDetailView,
 }
 

--- a/crates/opengoose-web/templates/agent_detail.html
+++ b/crates/opengoose-web/templates/agent_detail.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="page-intro">
+  <div>
+    <p class="eyebrow">Agents</p>
+    <h1>{{ detail.title }}</h1>
+    <p>{{ detail.subtitle }}</p>
+  </div>
+  <div class="live-chip-row">
+    <a class="secondary-button" href="/agents">All agents</a>
+    <a class="secondary-button" href="/workflows">Workflow map</a>
+  </div>
+</section>
+
+{% include "partials/agent_detail.html" %}
+{% endblock %}

--- a/crates/opengoose-web/templates/partials/agent_detail.html
+++ b/crates/opengoose-web/templates/partials/agent_detail.html
@@ -5,7 +5,10 @@
       <h2>{{ detail.title }}</h2>
       <p>{{ detail.subtitle }}</p>
     </div>
-    <span class="chip tone-neutral">{{ detail.source_label }}</span>
+    <div class="live-chip-row">
+      <span class="chip tone-neutral">{{ detail.source_label }}</span>
+      <a class="secondary-button" href="{{ detail.detail_page_url }}">Full page</a>
+    </div>
   </div>
 
   <div class="content-grid">
@@ -42,8 +45,51 @@
   </div>
   {% endif %}
 
+  {% if detail.recent_runs.len() > 0 %}
+  <div class="timeline">
+    <h3>Recent runs</h3>
+    {% for run in detail.recent_runs %}
+    <article class="timeline-item">
+      <div>
+        <p class="rail-title"><a href="{{ run.page_url }}">{{ run.title }}</a></p>
+        <p class="rail-preview">{{ run.detail }}</p>
+      </div>
+      <div class="rail-meta">
+        <span class="chip tone-{{ run.status_tone }}">{{ run.status_label }}</span>
+        <small>{{ run.updated_at }}</small>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if detail.connected_sessions.len() > 0 %}
+  <div class="timeline">
+    <h3>Connected sessions</h3>
+    {% for session in detail.connected_sessions %}
+    <article class="timeline-item">
+      <div>
+        <p class="rail-title"><a href="{{ session.page_url }}">{{ session.title }}</a></p>
+        <p class="rail-preview">{{ session.detail }}</p>
+      </div>
+      <div class="rail-meta">
+        <span class="chip tone-{{ session.badge_tone }}">{{ session.badge }}</span>
+        <small>{{ session.updated_at }}</small>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if detail.recent_runs.len() == 0 && detail.connected_sessions.len() == 0 %}
+  <p class="empty-hint">{{ detail.runtime_empty_hint }}</p>
+  {% endif %}
+
   <div class="timeline">
     <h3>Extensions</h3>
+    {% if detail.extensions.len() == 0 %}
+    <p class="empty-hint">No extensions are configured for this profile.</p>
+    {% endif %}
     {% for extension in detail.extensions %}
     <article class="timeline-item">
       <div>

--- a/crates/opengoose-web/templates/partials/run_detail.html
+++ b/crates/opengoose-web/templates/partials/run_detail.html
@@ -5,7 +5,11 @@
       <h2>{{ detail.title }}</h2>
       <p>{{ detail.subtitle }}</p>
     </div>
-    <span class="chip tone-neutral">{{ detail.source_label }}</span>
+    <div class="live-chip-row">
+      <span class="chip tone-neutral">{{ detail.source_label }}</span>
+      <a class="secondary-button" href="{{ detail.detail_page_url }}">Full page</a>
+      <a class="secondary-button" href="{{ detail.queue_page_url }}">Queue view</a>
+    </div>
   </div>
 
   <dl class="meta-grid">
@@ -36,6 +40,12 @@
       <div>
         <p class="rail-title">{{ item.title }}</p>
         <p class="rail-subtitle">{{ item.detail }}</p>
+        {% if let Some(output) = item.output %}
+        <p class="rail-preview">{{ output }}</p>
+        {% endif %}
+        {% if let Some(error) = item.error %}
+        <p class="rail-preview">{{ error }}</p>
+        {% endif %}
       </div>
       <div class="rail-meta">
         <span class="chip tone-{{ item.status_tone }}">{{ item.status_label }}</span>

--- a/crates/opengoose-web/templates/run_detail.html
+++ b/crates/opengoose-web/templates/run_detail.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="page-intro">
+  <div>
+    <p class="eyebrow">Runs</p>
+    <h1>{{ detail.title }}</h1>
+    <p>{{ detail.subtitle }}</p>
+  </div>
+  <div class="live-chip-row">
+    <a class="secondary-button" href="/runs">All runs</a>
+    <a class="primary-button" href="{{ detail.queue_page_url }}">Queue view</a>
+  </div>
+</section>
+
+{% include "partials/run_detail.html" %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add standalone `/agents/{name}` and `/runs/{id}` dashboard pages backed by richer detail data
- add matching `/api/agents/{name}` and `/api/runs/{id}` detail endpoints
- expand agent/run detail panels with runtime context, queue links, timestamps, duration, and work item output

## Verification
- cargo fmt --all
- cargo clippy --all-targets
- cargo test

## Paperclip
- Source issue: OPE-149

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
