### PR TITLE
feat: Add remote agents management page [OPE-158]

### DIFF
--- a/crates/opengoose-web/assets/app.js
+++ b/crates/opengoose-web/assets/app.js
@@ -1,6 +1,7 @@
 import { initDashboardStreams } from "./modules/dashboard-stream.js";
 import { initListShells } from "./modules/list-shell.js";
 import { initLiveEvents } from "./modules/live-events.js";
+import { initRemoteAgentActions } from "./modules/remote-agents.js";
 import { initTableShells } from "./modules/table-shell.js";
 import { initTheme } from "./modules/theme.js";
 import { initWorkflowTriggers } from "./modules/workflow-trigger.js";
@@ -10,4 +11,5 @@ initListShells(document);
 initTableShells(document);
 initDashboardStreams(document);
 initLiveEvents(document);
+initRemoteAgentActions(document);
 initWorkflowTriggers(document);

--- a/crates/opengoose-web/assets/modules/live-events.js
+++ b/crates/opengoose-web/assets/modules/live-events.js
@@ -1,5 +1,6 @@
 import { initDashboardStreams } from "./dashboard-stream.js";
 import { initListShells } from "./list-shell.js";
+import { initRemoteAgentActions } from "./remote-agents.js";
 import { initTableShells } from "./table-shell.js";
 import { initWorkflowTriggers } from "./workflow-trigger.js";
 
@@ -59,6 +60,7 @@ const refreshFragments = async (owner, selectors) => {
   initListShells(document);
   initTableShells(document);
   initDashboardStreams(document);
+  initRemoteAgentActions(document);
   initWorkflowTriggers(document);
   setConnectionStatus(owner, "live");
 };

--- a/crates/opengoose-web/assets/modules/remote-agents.js
+++ b/crates/opengoose-web/assets/modules/remote-agents.js
@@ -1,0 +1,56 @@
+export function initRemoteAgentActions(root = document) {
+  const buttons = root.querySelectorAll("[data-remote-agent-disconnect]");
+  const status =
+    document.querySelector("[data-remote-agents-status]") ||
+    root.querySelector("[data-remote-agents-status]");
+
+  buttons.forEach((button) => {
+    if (button.dataset.remoteAgentBound === "true") {
+      return;
+    }
+    button.dataset.remoteAgentBound = "true";
+
+    button.addEventListener("click", async () => {
+      const agentName = button.dataset.agentName || "agent";
+      const url = button.dataset.disconnectUrl;
+      if (!url) {
+        if (status) {
+          status.textContent = "Disconnect URL missing for the selected agent.";
+        }
+        return;
+      }
+
+      button.disabled = true;
+      if (status) {
+        status.textContent = `Disconnecting ${agentName}…`;
+      }
+
+      try {
+        const response = await fetch(url, {
+          method: "DELETE",
+          headers: {
+            accept: "text/plain",
+          },
+        });
+        const message = await response.text();
+
+        if (!response.ok) {
+          throw new Error(message || `Disconnect failed for ${agentName}.`);
+        }
+
+        if (status) {
+          status.textContent = message || `${agentName} disconnected. Refreshing…`;
+        }
+        window.location.reload();
+      } catch (error) {
+        if (status) {
+          status.textContent =
+            error instanceof Error
+              ? error.message
+              : `Disconnect failed for ${agentName}.`;
+        }
+        button.disabled = false;
+      }
+    });
+  });
+}

--- a/crates/opengoose-web/src/data/mod.rs
+++ b/crates/opengoose-web/src/data/mod.rs
@@ -1,6 +1,7 @@
 mod agents;
 mod dashboard;
 mod queue;
+mod remote_agents;
 mod runs;
 mod schedules;
 mod sessions;
@@ -13,6 +14,7 @@ mod workflows;
 pub use agents::{load_agent_detail, load_agents_page};
 pub use dashboard::load_dashboard;
 pub use queue::{load_queue_detail, load_queue_page};
+pub use remote_agents::load_remote_agents_page;
 pub use runs::{load_run_detail, load_runs_page};
 pub use schedules::{
     ScheduleSaveInput, delete_schedule, load_schedules_page, save_schedule, toggle_schedule,

--- a/crates/opengoose-web/src/data/remote_agents.rs
+++ b/crates/opengoose-web/src/data/remote_agents.rs
@@ -1,0 +1,147 @@
+use anyhow::Result;
+use chrono::Utc;
+use opengoose_teams::remote::RemoteAgentRegistry;
+use urlencoding::encode;
+
+use crate::data::views::{MetricCard, RemoteAgentRowView, RemoteAgentsPageView};
+
+/// Load the remote agents page view-model from the shared registry.
+pub async fn load_remote_agents_page(
+    registry: &RemoteAgentRegistry,
+    websocket_url: String,
+) -> Result<RemoteAgentsPageView> {
+    let mut connected = registry.list().await;
+    connected.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let interval_secs = registry.heartbeat_interval().as_secs();
+    let timeout_secs = registry.heartbeat_timeout().as_secs();
+    let mut healthy_count = 0usize;
+    let mut late_count = 0usize;
+    let mut stale_count = 0usize;
+
+    let agents = connected
+        .into_iter()
+        .map(|agent| {
+            let connected_secs = agent.connected_at.elapsed().as_secs();
+            let heartbeat_secs = agent.last_heartbeat.elapsed().as_secs();
+            let (status_label, status_tone) = if heartbeat_secs > timeout_secs {
+                stale_count += 1;
+                ("Stale", "danger")
+            } else if heartbeat_secs > interval_secs {
+                late_count += 1;
+                ("Late", "amber")
+            } else {
+                healthy_count += 1;
+                ("Healthy", "success")
+            };
+            let capabilities_text = if agent.capabilities.is_empty() {
+                "No capabilities advertised".into()
+            } else {
+                agent.capabilities.join(", ")
+            };
+
+            RemoteAgentRowView {
+                name: agent.name.clone(),
+                capabilities: agent.capabilities,
+                capabilities_text,
+                endpoint: agent.endpoint,
+                connected_for: format_elapsed(connected_secs),
+                connected_sort: connected_secs.to_string(),
+                heartbeat_age: format_elapsed(heartbeat_secs),
+                heartbeat_sort: heartbeat_secs.to_string(),
+                status_label: status_label.into(),
+                status_tone,
+                disconnect_path: format!("/api/agents/remote/{}", encode(&agent.name)),
+            }
+        })
+        .collect();
+
+    let total = healthy_count + late_count + stale_count;
+    let (mode_label, mode_tone) = if total == 0 {
+        ("Idle registry".into(), "neutral")
+    } else if stale_count > 0 {
+        ("Attention needed".into(), "danger")
+    } else if late_count > 0 {
+        ("Heartbeat drift".into(), "amber")
+    } else {
+        ("Live registry".into(), "success")
+    };
+
+    Ok(RemoteAgentsPageView {
+        mode_label,
+        mode_tone,
+        stream_summary:
+            "The registry snapshot is server-rendered, then refreshed every four seconds through the existing SSE transport."
+                .into(),
+        snapshot_label: format!("Snapshot {}", Utc::now().format("%H:%M:%S UTC")),
+        metrics: vec![
+            MetricCard {
+                label: "Connected".into(),
+                value: total.to_string(),
+                note: "Currently registered remote agents".into(),
+                tone: "cyan",
+            },
+            MetricCard {
+                label: "Healthy".into(),
+                value: healthy_count.to_string(),
+                note: format!("Heartbeat within {}", format_elapsed(interval_secs)),
+                tone: "sage",
+            },
+            MetricCard {
+                label: "Late".into(),
+                value: late_count.to_string(),
+                note: "Past the nominal heartbeat interval".into(),
+                tone: "amber",
+            },
+            MetricCard {
+                label: "Stale".into(),
+                value: stale_count.to_string(),
+                note: format!("Past the {} timeout window", format_elapsed(timeout_secs)),
+                tone: "rose",
+            },
+        ],
+        agents,
+        websocket_url,
+        heartbeat_interval_label: format_elapsed(interval_secs),
+        heartbeat_timeout_label: format_elapsed(timeout_secs),
+        handshake_preview: serde_json::to_string_pretty(&serde_json::json!({
+            "type": "handshake",
+            "agent_name": "remote-builder-1",
+            "api_key": "your-shared-key",
+            "capabilities": ["execute", "relay"]
+        }))?,
+    })
+}
+
+fn format_elapsed(seconds: u64) -> String {
+    let hours = seconds / 3600;
+    let minutes = (seconds % 3600) / 60;
+    let seconds = seconds % 60;
+
+    if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opengoose_teams::remote::RemoteConfig;
+
+    #[tokio::test]
+    async fn load_remote_agents_page_marks_empty_registry_idle() {
+        let page = load_remote_agents_page(
+            &RemoteAgentRegistry::new(RemoteConfig::default()),
+            "ws://localhost:3000/api/agents/connect".into(),
+        )
+        .await
+        .expect("page should load");
+
+        assert_eq!(page.mode_label, "Idle registry");
+        assert!(page.agents.is_empty());
+    }
+}

--- a/crates/opengoose-web/src/data/views.rs
+++ b/crates/opengoose-web/src/data/views.rs
@@ -239,6 +239,37 @@ pub struct AgentsPageView {
     pub selected: AgentDetailView,
 }
 
+/// A single connected remote agent row in the dashboard table.
+#[derive(Clone)]
+pub struct RemoteAgentRowView {
+    pub name: String,
+    pub capabilities: Vec<String>,
+    pub capabilities_text: String,
+    pub endpoint: String,
+    pub connected_for: String,
+    pub connected_sort: String,
+    pub heartbeat_age: String,
+    pub heartbeat_sort: String,
+    pub status_label: String,
+    pub status_tone: &'static str,
+    pub disconnect_path: String,
+}
+
+/// View-model for the remote agents page.
+#[derive(Clone)]
+pub struct RemoteAgentsPageView {
+    pub mode_label: String,
+    pub mode_tone: &'static str,
+    pub stream_summary: String,
+    pub snapshot_label: String,
+    pub metrics: Vec<MetricCard>,
+    pub agents: Vec<RemoteAgentRowView>,
+    pub websocket_url: String,
+    pub heartbeat_interval_label: String,
+    pub heartbeat_timeout_label: String,
+    pub handshake_preview: String,
+}
+
 /// Summary row for the team list sidebar.
 #[derive(Clone)]
 pub struct TeamListItem {

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -50,6 +50,7 @@ impl Default for WebOptions {
 #[derive(Clone)]
 pub(crate) struct PageState {
     db: Arc<Database>,
+    remote_registry: RemoteAgentRegistry,
 }
 
 const LIVE_EVENT_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -190,13 +191,15 @@ fn spawn_live_event_watcher(db: Arc<Database>, event_bus: EventBus) {
 /// REST endpoints under `/api/`, and the remote-agent WebSocket gateway.
 pub async fn serve(options: WebOptions) -> Result<()> {
     let db = Arc::new(Database::open()?);
-    let state = PageState { db: db.clone() };
-    let api_state = AppState::new(db)?;
-    spawn_live_event_watcher(state.db.clone(), api_state.event_bus.clone());
-
     let remote_state = Arc::new(RemoteGatewayState {
         registry: RemoteAgentRegistry::new(RemoteConfig::default()),
     });
+    let state = PageState {
+        db: db.clone(),
+        remote_registry: remote_state.registry.clone(),
+    };
+    let api_state = AppState::new(db)?;
+    spawn_live_event_watcher(state.db.clone(), api_state.event_bus.clone());
 
     let api_routes = Router::new()
         .route("/api/events", get(handlers::events::stream_events))
@@ -273,6 +276,8 @@ pub async fn serve(options: WebOptions) -> Result<()> {
         .route("/sessions", get(routes::sessions))
         .route("/runs", get(routes::runs))
         .route("/agents", get(routes::agents))
+        .route("/remote-agents", get(routes::remote_agents))
+        .route("/remote-agents/events", get(routes::remote_agents_events))
         .route("/workflows", get(routes::workflows))
         .route(
             "/schedules",

--- a/crates/opengoose-web/src/routes.rs
+++ b/crates/opengoose-web/src/routes.rs
@@ -6,7 +6,7 @@ use askama::Template;
 use async_stream::stream;
 use axum::Json;
 use axum::extract::{Form, Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::Html;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use futures_core::Stream;
@@ -15,12 +15,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::PageState;
 use crate::data::{
-    AgentDetailView, AgentsPageView, DashboardView, QueueDetailView, QueuePageView, RunDetailView,
-    RunsPageView, ScheduleEditorView, ScheduleSaveInput, SchedulesPageView, SessionDetailView,
-    SessionsPageView, TeamEditorView, TeamsPageView, TriggerDetailView, TriggersPageView,
-    WorkflowDetailView, WorkflowsPageView, delete_schedule, load_agents_page, load_dashboard,
-    load_queue_page, load_runs_page, load_schedules_page, load_sessions_page, load_teams_page,
-    load_triggers_page, load_workflows_page, save_schedule, save_team_yaml, toggle_schedule,
+    AgentDetailView, AgentsPageView, DashboardView, QueueDetailView, QueuePageView,
+    RemoteAgentsPageView, RunDetailView, RunsPageView, ScheduleEditorView, ScheduleSaveInput,
+    SchedulesPageView, SessionDetailView, SessionsPageView, TeamEditorView, TeamsPageView,
+    TriggerDetailView, TriggersPageView, WorkflowDetailView, WorkflowsPageView, delete_schedule,
+    load_agents_page, load_dashboard, load_queue_page, load_remote_agents_page, load_runs_page,
+    load_schedules_page, load_sessions_page, load_teams_page, load_triggers_page,
+    load_workflows_page, save_schedule, save_team_yaml, toggle_schedule,
 };
 
 // --- Result types ---
@@ -128,6 +129,26 @@ pub(crate) async fn dashboard_events(
     ))
 }
 
+pub(crate) async fn remote_agents_events()
+-> Sse<impl Stream<Item = Result<Event, Infallible>> + Send> {
+    let event_stream = stream! {
+        yield Ok(Event::default().data("remote-agents-ready"));
+
+        let mut ticker = tokio::time::interval(Duration::from_secs(4));
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            yield Ok(Event::default().data("remote-agents-refresh"));
+        }
+    };
+
+    Sse::new(event_stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(15))
+            .text("opengoose-remote-agents"),
+    )
+}
+
 pub(crate) async fn sessions(
     State(state): State<PageState>,
     Query(query): Query<SessionQuery>,
@@ -173,6 +194,20 @@ pub(crate) async fn agents(Query(query): Query<AgentQuery>) -> WebResult {
         current_nav: "agents",
         page,
         detail_html,
+    })
+}
+
+pub(crate) async fn remote_agents(State(state): State<PageState>, headers: HeaderMap) -> WebResult {
+    let page = load_remote_agents_page(&state.remote_registry, websocket_url(&headers))
+        .await
+        .map_err(internal_error)?;
+    let live_html = render_partial(&RemoteAgentsLiveTemplate { page: page.clone() })?;
+
+    render_template(&RemoteAgentsTemplate {
+        page_title: "Remote Agents",
+        current_nav: "remote_agents",
+        page,
+        live_html,
     })
 }
 
@@ -454,6 +489,58 @@ fn render_dashboard_live_html(db: Arc<Database>) -> PartialResult {
     render_partial(&DashboardLiveTemplate { dashboard })
 }
 
+fn websocket_url(headers: &HeaderMap) -> String {
+    let host = forwarded_header(headers, "x-forwarded-host")
+        .or_else(|| forwarded_host(headers))
+        .or_else(|| header_string(headers, "host"))
+        .unwrap_or_else(|| "localhost:3000".into());
+    let scheme = match forwarded_header(headers, "x-forwarded-proto")
+        .or_else(|| forwarded_proto(headers))
+        .as_deref()
+    {
+        Some("https") | Some("wss") => "wss",
+        _ => "ws",
+    };
+
+    format!("{scheme}://{host}/api/agents/connect")
+}
+
+fn header_string(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.split(',').next().unwrap_or(value).trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn forwarded_header(headers: &HeaderMap, name: &str) -> Option<String> {
+    header_string(headers, name)
+}
+
+fn forwarded_proto(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("forwarded")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| {
+            value
+                .split(';')
+                .find_map(|segment| segment.trim().strip_prefix("proto="))
+        })
+        .map(|value| value.trim_matches('"').to_string())
+}
+
+fn forwarded_host(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("forwarded")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| {
+            value
+                .split(';')
+                .find_map(|segment| segment.trim().strip_prefix("host="))
+        })
+        .map(|value| value.trim_matches('"').to_string())
+}
+
 pub(crate) fn api_error(
     status: StatusCode,
     message: impl std::fmt::Display,
@@ -562,6 +649,21 @@ struct AgentsTemplate {
 #[template(path = "partials/agent_detail.html")]
 struct AgentDetailTemplate {
     detail: AgentDetailView,
+}
+
+#[derive(Template)]
+#[template(path = "remote_agents.html")]
+struct RemoteAgentsTemplate {
+    page_title: &'static str,
+    current_nav: &'static str,
+    page: RemoteAgentsPageView,
+    live_html: String,
+}
+
+#[derive(Template)]
+#[template(path = "partials/remote_agents_live.html")]
+struct RemoteAgentsLiveTemplate {
+    page: RemoteAgentsPageView,
 }
 
 #[derive(Template)]
@@ -709,6 +811,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use opengoose_persistence::{Database, ScheduleStore};
+    use opengoose_teams::remote::{RemoteAgentRegistry, RemoteConfig};
     use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore};
 
     use super::*;
@@ -763,6 +866,13 @@ mod tests {
             .expect("team should save");
     }
 
+    fn page_state(db: Arc<Database>) -> PageState {
+        PageState {
+            db,
+            remote_registry: RemoteAgentRegistry::new(RemoteConfig::default()),
+        }
+    }
+
     #[test]
     fn schedules_handler_renders_existing_schedule() {
         with_temp_home(|| {
@@ -784,7 +894,7 @@ mod tests {
                 .expect("runtime should build")
                 .block_on(async {
                     let Html(html) = schedules(
-                        State(PageState { db }),
+                        State(page_state(db)),
                         Query(ScheduleQuery {
                             schedule: Some("nightly-ops".into()),
                         }),
@@ -809,7 +919,7 @@ mod tests {
                 .expect("runtime should build")
                 .block_on(async {
                     let Html(html) = schedule_action(
-                        State(PageState { db: db.clone() }),
+                        State(page_state(db.clone())),
                         Form(ScheduleActionForm {
                             intent: "save".into(),
                             original_name: None,
@@ -833,5 +943,74 @@ mod tests {
                     );
                 });
         });
+    }
+
+    #[tokio::test]
+    async fn remote_agents_handler_renders_empty_registry() {
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "opengoose.test".parse().expect("host header"));
+
+        let Html(html) = remote_agents(
+            State(page_state(Arc::new(
+                Database::open_in_memory().expect("db should open"),
+            ))),
+            headers,
+        )
+        .await
+        .expect("handler should render");
+
+        assert!(html.contains("No remote agents are connected right now."));
+        assert!(html.contains("ws://opengoose.test/api/agents/connect"));
+        assert!(html.contains("data-live-events-url=\"/remote-agents/events\""));
+    }
+
+    #[tokio::test]
+    async fn remote_agents_handler_renders_registered_agents() {
+        let state = page_state(Arc::new(
+            Database::open_in_memory().expect("db should open"),
+        ));
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        state
+            .remote_registry
+            .register(
+                "remote-a".into(),
+                vec!["execute".into(), "relay".into()],
+                "ws://remote-a:9000".into(),
+                tx,
+            )
+            .await
+            .expect("agent should register");
+
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "dashboard.local".parse().expect("host header"));
+
+        let Html(html) = remote_agents(State(state), headers)
+            .await
+            .expect("handler should render");
+
+        assert!(html.contains("remote-a"));
+        assert!(html.contains("execute"));
+        assert!(html.contains("ws://remote-a:9000"));
+        assert!(html.contains("/api/agents/remote/remote-a"));
+        assert!(html.contains("Disconnect"));
+    }
+
+    #[test]
+    fn websocket_url_prefers_forwarded_https_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-host",
+            "goose.example.com".parse().expect("forwarded host"),
+        );
+        headers.insert(
+            "x-forwarded-proto",
+            "https".parse().expect("forwarded proto"),
+        );
+        headers.insert("host", "localhost:3000".parse().expect("host header"));
+
+        assert_eq!(
+            websocket_url(&headers),
+            "wss://goose.example.com/api/agents/connect"
+        );
     }
 }

--- a/crates/opengoose-web/templates/base.html
+++ b/crates/opengoose-web/templates/base.html
@@ -33,6 +33,7 @@
         <a href="/sessions" class="nav-link{% if current_nav == "sessions" %} is-active{% endif %}" {% if current_nav == "sessions" %}aria-current="page"{% endif %}>Sessions</a>
         <a href="/runs" class="nav-link{% if current_nav == "runs" %} is-active{% endif %}" {% if current_nav == "runs" %}aria-current="page"{% endif %}>Runs</a>
         <a href="/agents" class="nav-link{% if current_nav == "agents" %} is-active{% endif %}" {% if current_nav == "agents" %}aria-current="page"{% endif %}>Agents</a>
+        <a href="/remote-agents" class="nav-link{% if current_nav == "remote_agents" %} is-active{% endif %}" {% if current_nav == "remote_agents" %}aria-current="page"{% endif %}>Remote Agents</a>
         <a href="/workflows" class="nav-link{% if current_nav == "workflows" %} is-active{% endif %}" {% if current_nav == "workflows" %}aria-current="page"{% endif %}>Workflows</a>
         <a href="/schedules" class="nav-link{% if current_nav == "schedules" %} is-active{% endif %}" {% if current_nav == "schedules" %}aria-current="page"{% endif %}>Schedules</a>
         <a href="/triggers" class="nav-link{% if current_nav == "triggers" %} is-active{% endif %}" {% if current_nav == "triggers" %}aria-current="page"{% endif %}>Triggers</a>

--- a/crates/opengoose-web/templates/partials/remote_agents_live.html
+++ b/crates/opengoose-web/templates/partials/remote_agents_live.html
@@ -1,0 +1,184 @@
+<section class="monitor-banner panel">
+  <div>
+    <p class="eyebrow">Remote registry</p>
+    <h2>Connected agents, heartbeat drift, and disconnect controls in one live snapshot.</h2>
+    <p>{{ page.stream_summary }}</p>
+  </div>
+  <div class="banner-meta">
+    <span class="chip tone-{{ page.mode_tone }}">{{ page.mode_label }}</span>
+    <span class="chip tone-cyan">SSE / 4s cadence</span>
+    <p>{{ page.snapshot_label }}</p>
+  </div>
+</section>
+
+<section class="metric-grid compact-grid">
+  {% for metric in page.metrics %}
+  <article class="metric-card tone-{{ metric.tone }}">
+    <p class="metric-label">{{ metric.label }}</p>
+    <strong class="metric-value">{{ metric.value }}</strong>
+    <p class="metric-note">{{ metric.note }}</p>
+  </article>
+  {% endfor %}
+</section>
+
+<section class="table-shell panel" data-table-shell data-table-label="remote agents">
+  <div class="panel-head">
+    <div>
+      <h2>Connected agents</h2>
+      <small>Disconnecting an agent sends the protocol disconnect frame, then removes it from the registry.</small>
+    </div>
+  </div>
+
+  {% if page.agents.len() > 0 %}
+  <div class="list-toolbar" role="search" aria-label="Filter remote agents">
+    <div class="control-row">
+      <label class="control-field control-field-search">
+        <span>Search agents</span>
+        <input type="search" placeholder="Agent, capability, endpoint" autocomplete="off" data-table-search>
+      </label>
+      <label class="control-field control-field-compact">
+        <span>Status</span>
+        <select data-table-filter>
+          <option value="all" selected>All</option>
+          <option value="healthy">Healthy</option>
+          <option value="late">Late</option>
+          <option value="stale">Stale</option>
+        </select>
+      </label>
+      <label class="control-field control-field-compact">
+        <span>Sort</span>
+        <select data-table-sort>
+          <option value="newest" selected>Longest connected</option>
+          <option value="oldest">Shortest connected</option>
+          <option value="sender">Agent A-Z</option>
+          <option value="recipient">Endpoint A-Z</option>
+          <option value="retries">Heartbeat oldest</option>
+        </select>
+      </label>
+      <label class="control-field control-field-compact">
+        <span>Page size</span>
+        <select data-table-page-size>
+          <option value="4">4</option>
+          <option value="6" selected>6</option>
+          <option value="10">10</option>
+        </select>
+      </label>
+    </div>
+    <p class="list-status" data-table-status role="status" aria-live="polite"></p>
+  </div>
+
+  <div class="table-wrap">
+    <table>
+      <caption class="visually-hidden">Currently connected remote agents</caption>
+      <thead>
+        <tr>
+          <th scope="col">Agent</th>
+          <th scope="col">Capabilities</th>
+          <th scope="col">Endpoint</th>
+          <th scope="col">Connected</th>
+          <th scope="col">Heartbeat</th>
+          <th scope="col">Status</th>
+          <th scope="col">Action</th>
+        </tr>
+      </thead>
+      <tbody data-table-body>
+        {% for agent in page.agents %}
+        <tr
+          data-table-row
+          data-search="{{ agent.name }} {{ agent.capabilities_text }} {{ agent.endpoint }} {{ agent.status_label }}"
+          data-status="{{ agent.status_label }}"
+          data-sort-created="{{ agent.connected_sort }}"
+          data-sort-sender="{{ agent.name }}"
+          data-sort-recipient="{{ agent.endpoint }}"
+          data-sort-retries="{{ agent.heartbeat_sort }}"
+          tabindex="0"
+        >
+          <td>{{ agent.name }}</td>
+          <td>
+            {% if agent.capabilities.len() > 0 %}
+            <div class="token-row">
+              {% for capability in agent.capabilities %}
+              <span class="token">{{ capability }}</span>
+              {% endfor %}
+            </div>
+            {% else %}
+            <span class="rail-subtitle">No capabilities advertised</span>
+            {% endif %}
+          </td>
+          <td>{{ agent.endpoint }}</td>
+          <td>{{ agent.connected_for }}</td>
+          <td>{{ agent.heartbeat_age }}</td>
+          <td><span class="chip tone-{{ agent.status_tone }}">{{ agent.status_label }}</span></td>
+          <td>
+            <button
+              class="secondary-button"
+              type="button"
+              data-remote-agent-disconnect
+              data-agent-name="{{ agent.name }}"
+              data-disconnect-url="{{ agent.disconnect_path }}"
+            >
+              Disconnect
+            </button>
+          </td>
+        </tr>
+        <tr class="table-detail" data-table-detail>
+          <td colspan="7">
+            <strong>Capabilities:</strong> {{ agent.capabilities_text }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <p class="empty-hint empty-hint-inline" data-table-empty hidden>No remote agents match the current filters.</p>
+  <div class="pager" data-table-pagination>
+    <button class="secondary-button" type="button" data-table-prev>Previous</button>
+    <p class="pager-label" data-table-page>Page 1 of 1</p>
+    <button class="secondary-button" type="button" data-table-next>Next</button>
+  </div>
+  {% else %}
+  <p class="empty-hint">No remote agents are connected right now. Use the connection payload below to attach one.</p>
+  {% endif %}
+</section>
+
+<section class="split-grid">
+  <article class="panel">
+    <div class="panel-head">
+      <div>
+        <h2>Connection endpoint</h2>
+        <small>Share this WebSocket URL with any external agent process.</small>
+      </div>
+    </div>
+    <dl class="stacked-meta">
+      <div class="stacked-meta-row">
+        <dt>WebSocket URL</dt>
+        <dd>{{ page.websocket_url }}</dd>
+      </div>
+      <div class="stacked-meta-row">
+        <dt>Handshake timing</dt>
+        <dd>Send as the first frame immediately after connect.</dd>
+      </div>
+      <div class="stacked-meta-row">
+        <dt>Server heartbeat</dt>
+        <dd>Every {{ page.heartbeat_interval_label }}</dd>
+      </div>
+      <div class="stacked-meta-row">
+        <dt>Stale timeout</dt>
+        <dd>{{ page.heartbeat_timeout_label }}</dd>
+      </div>
+    </dl>
+  </article>
+
+  <article class="panel">
+    <div class="panel-head">
+      <div>
+        <h2>Handshake payload</h2>
+        <small>The first message must identify the agent and include its shared API key.</small>
+      </div>
+    </div>
+    <div class="editor-block">
+      <pre>{{ page.handshake_preview }}</pre>
+    </div>
+  </article>
+</section>

--- a/crates/opengoose-web/templates/remote_agents.html
+++ b/crates/opengoose-web/templates/remote_agents.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section
+  data-live-events
+  data-live-events-url="/remote-agents/events"
+  data-live-events-targets="#remote-agents-live"
+>
+  <section class="hero-panel">
+    <div class="hero-copy">
+      <p class="eyebrow">Remote agents</p>
+      <h1>Monitor connected remote workers and cut stale sockets from the dashboard.</h1>
+      <p class="hero-text">{{ page.stream_summary }}</p>
+    </div>
+    <div class="hero-status">
+      <p class="eyebrow">Registry transport</p>
+      <div class="live-chip-row">
+        <span class="chip tone-{{ page.mode_tone }}">{{ page.mode_label }}</span>
+        <span class="chip tone-amber" data-live-events-connection role="status" aria-live="polite">Connecting</span>
+      </div>
+      <p>Heartbeat freshness and connection state refresh below without a full page reload.</p>
+      <p class="heartbeat" data-remote-agents-status role="status" aria-live="polite">
+        Disconnect actions call the live API and the table refreshes automatically.
+      </p>
+    </div>
+  </section>
+
+  <div class="monitor-stack">
+    <div id="remote-agents-live">{{ live_html|safe }}</div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a Remote Agents dashboard page with a live SSE refresh loop, registry metrics, connection instructions, and disconnect controls
- wire the page into the web router and primary navigation
- cover the page with remote registry route tests for empty and populated states

## Paperclip
- Issue: OPE-158

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
