### PR TITLE
feat: Wire dashboard and runs live SSE refresh [OPE-156]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6619,6 +6619,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "criterion",
  "dashmap 6.1.0",
  "goose 1.27.2",
  "opengoose-persistence",

--- a/crates/opengoose-cli/src/cmd/plugin.rs
+++ b/crates/opengoose-cli/src/cmd/plugin.rs
@@ -454,8 +454,13 @@ mod tests {
     #[test]
     fn dispatch_install_with_full_metadata_succeeds() {
         let db = make_db();
-        let (_dir, plugin_path) =
-            make_plugin_dir_full("rich-plugin", "2.0.0", "Bob", "Does rich things", &["skill"]);
+        let (_dir, plugin_path) = make_plugin_dir_full(
+            "rich-plugin",
+            "2.0.0",
+            "Bob",
+            "Does rich things",
+            &["skill"],
+        );
 
         let result = run(PluginAction::Install { path: plugin_path }, db.clone());
         assert!(result.is_ok(), "install should succeed: {result:?}");
@@ -499,7 +504,12 @@ mod tests {
         // Second install should fail with "already installed"
         let result = run(PluginAction::Install { path: plugin_path }, db);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("already installed"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("already installed")
+        );
     }
 
     #[test]
@@ -528,10 +538,12 @@ mod tests {
         );
         assert!(result.is_ok());
 
-        assert!(PluginStore::new(db)
-            .get_by_name("removable")
-            .unwrap()
-            .is_none());
+        assert!(
+            PluginStore::new(db)
+                .get_by_name("removable")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/opengoose-cli/src/cmd/schedule.rs
+++ b/crates/opengoose-cli/src/cmd/schedule.rs
@@ -559,7 +559,10 @@ mod tests {
         );
         assert!(result.is_ok());
 
-        let s = ScheduleStore::new(db).get_by_name("sched").unwrap().unwrap();
+        let s = ScheduleStore::new(db)
+            .get_by_name("sched")
+            .unwrap()
+            .unwrap();
         assert!(s.enabled);
     }
 
@@ -696,7 +699,10 @@ mod tests {
         )
         .unwrap();
 
-        let s = ScheduleStore::new(db).get_by_name("daily").unwrap().unwrap();
+        let s = ScheduleStore::new(db)
+            .get_by_name("daily")
+            .unwrap()
+            .unwrap();
         assert!(s.enabled);
     }
 

--- a/crates/opengoose-cli/src/cmd/trigger.rs
+++ b/crates/opengoose-cli/src/cmd/trigger.rs
@@ -71,7 +71,15 @@ pub(crate) fn run(
             team,
             condition,
             input,
-        } => cmd_add(&store, team_store, &name, &trigger_type, &team, &condition, &input),
+        } => cmd_add(
+            &store,
+            team_store,
+            &name,
+            &trigger_type,
+            &team,
+            &condition,
+            &input,
+        ),
         TriggerAction::List => cmd_list(&store),
         TriggerAction::Remove { name } => cmd_remove(&store, &name),
         TriggerAction::Enable { name } => cmd_enable(&store, &name),
@@ -483,7 +491,10 @@ mod tests {
         );
         assert!(result.is_err());
         assert!(
-            result.unwrap_err().to_string().contains("invalid condition JSON")
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid condition JSON")
         );
     }
 
@@ -527,10 +538,12 @@ mod tests {
         );
         assert!(result.is_ok());
 
-        assert!(TriggerStore::new(db)
-            .get_by_name("to-remove")
-            .unwrap()
-            .is_none());
+        assert!(
+            TriggerStore::new(db)
+                .get_by_name("to-remove")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -555,9 +568,7 @@ mod tests {
         let (_dir, team_store) = empty_team_store();
 
         let store = TriggerStore::new(db.clone());
-        store
-            .create("t", "file_watch", "{}", "team", "")
-            .unwrap();
+        store.create("t", "file_watch", "{}", "team", "").unwrap();
         store.set_enabled("t", false).unwrap();
 
         let result = run(

--- a/crates/opengoose-core/benches/engine_bench.rs
+++ b/crates/opengoose-core/benches/engine_bench.rs
@@ -49,7 +49,7 @@ fn bench_truncate_for_display(c: &mut Criterion) {
     }
 
     // UTF-8 multibyte content
-    let emoji_text: String = std::iter::repeat("🦆").take(500).collect();
+    let emoji_text = "🦆".repeat(500);
     group.bench_function("utf8_multibyte", |b| {
         b.iter(|| truncate_for_display(black_box(&emoji_text), 500));
     });

--- a/crates/opengoose-core/src/engine/tests.rs
+++ b/crates/opengoose-core/src/engine/tests.rs
@@ -275,7 +275,9 @@ async fn process_message_streaming_team_error_path_emits_stream_started() {
     let mut rx = event_bus.subscribe();
     let engine = Engine::new_with_team_store(event_bus, Database::open_in_memory().unwrap(), None);
     let key = test_key();
-    engine.session_manager.set_active_team(&key, "code-review".into());
+    engine
+        .session_manager
+        .set_active_team(&key, "code-review".into());
 
     let result = engine
         .process_message_streaming(&key, Some("alice"), "hello")

--- a/crates/opengoose-provider-bridge/src/lib.rs
+++ b/crates/opengoose-provider-bridge/src/lib.rs
@@ -142,6 +142,8 @@ impl GooseProviderService {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[tokio::test]
@@ -186,9 +188,14 @@ mod tests {
         // aren't configured in the test environment.  In that case the
         // provider's static known_models list (already verified non-empty
         // above) is the expected fallback, so we just return early.
-        let models = match GooseProviderService::fetch_models(&provider.name).await {
-            Ok(m) => m,
-            Err(_) => return, // unconfigured provider – nothing more to assert
+        let models = match tokio::time::timeout(
+            Duration::from_secs(10),
+            GooseProviderService::fetch_models(&provider.name),
+        )
+        .await
+        {
+            Ok(Ok(models)) => models,
+            Ok(Err(_)) | Err(_) => return,
         };
 
         assert!(!models.is_empty());

--- a/crates/opengoose-slack/src/gateway/envelope.rs
+++ b/crates/opengoose-slack/src/gateway/envelope.rs
@@ -383,7 +383,8 @@ mod tests {
             channel,
             text,
             display_name,
-        } = action else {
+        } = action
+        else {
             return Err("expected Relay action".to_string());
         };
         assert_eq!(session_key.platform, Platform::Slack);

--- a/crates/opengoose-telegram/src/gateway.rs
+++ b/crates/opengoose-telegram/src/gateway.rs
@@ -938,7 +938,10 @@ mod tests {
         // entity.length > text.len() → bot_command_text returns None → is_bot_command returns None
         let msg = TelegramMessage {
             message_id: 1,
-            chat: Chat { id: 1, chat_type: "private".to_string() },
+            chat: Chat {
+                id: 1,
+                chat_type: "private".to_string(),
+            },
             from: None,
             text: Some("/team".to_string()),
             entities: Some(vec![MessageEntity {
@@ -955,7 +958,10 @@ mod tests {
         // "👍" is 4 bytes. length=2 ends mid-emoji → not a char boundary → None
         let msg = TelegramMessage {
             message_id: 1,
-            chat: Chat { id: 1, chat_type: "private".to_string() },
+            chat: Chat {
+                id: 1,
+                chat_type: "private".to_string(),
+            },
             from: None,
             text: Some("👍hello".to_string()),
             entities: Some(vec![MessageEntity {
@@ -995,7 +1001,10 @@ mod tests {
 
     #[test]
     fn test_session_key_private_channel_id_format() {
-        let chat = Chat { id: 99999, chat_type: "private".to_string() };
+        let chat = Chat {
+            id: 99999,
+            chat_type: "private".to_string(),
+        };
         let key = TelegramGateway::session_key(&chat);
         assert_eq!(key.channel_id, "99999");
         assert_eq!(key.namespace, None);
@@ -1003,7 +1012,10 @@ mod tests {
 
     #[test]
     fn test_session_key_group_namespace_equals_channel_id() {
-        let chat = Chat { id: -500, chat_type: "group".to_string() };
+        let chat = Chat {
+            id: -500,
+            chat_type: "group".to_string(),
+        };
         let key = TelegramGateway::session_key(&chat);
         // For non-private chats, namespace == channel_id (both set to chat_id)
         assert_eq!(key.channel_id, "-500");
@@ -1017,12 +1029,23 @@ mod tests {
         // First entity is a mention, second is /team at offset 0 → should match
         let msg = TelegramMessage {
             message_id: 1,
-            chat: Chat { id: 1, chat_type: "group".to_string() },
+            chat: Chat {
+                id: 1,
+                chat_type: "group".to_string(),
+            },
             from: None,
             text: Some("/team list".to_string()),
             entities: Some(vec![
-                MessageEntity { entity_type: "mention".to_string(), offset: 0, length: 3 },
-                MessageEntity { entity_type: "bot_command".to_string(), offset: 0, length: 5 },
+                MessageEntity {
+                    entity_type: "mention".to_string(),
+                    offset: 0,
+                    length: 3,
+                },
+                MessageEntity {
+                    entity_type: "bot_command".to_string(),
+                    offset: 0,
+                    length: 5,
+                },
             ]),
         };
         assert_eq!(TelegramGateway::is_bot_command(&msg), Some("list"));
@@ -1033,7 +1056,10 @@ mod tests {
         // Empty entities vector (not None) → None
         let msg = TelegramMessage {
             message_id: 1,
-            chat: Chat { id: 1, chat_type: "private".to_string() },
+            chat: Chat {
+                id: 1,
+                chat_type: "private".to_string(),
+            },
             from: None,
             text: Some("/team".to_string()),
             entities: Some(vec![]),
@@ -1046,7 +1072,10 @@ mod tests {
         // /team with multi-word argument
         let msg = TelegramMessage {
             message_id: 1,
-            chat: Chat { id: 1, chat_type: "private".to_string() },
+            chat: Chat {
+                id: 1,
+                chat_type: "private".to_string(),
+            },
             from: None,
             text: Some("/team list all active".to_string()),
             entities: Some(vec![MessageEntity {
@@ -1055,7 +1084,10 @@ mod tests {
                 length: 5,
             }]),
         };
-        assert_eq!(TelegramGateway::is_bot_command(&msg), Some("list all active"));
+        assert_eq!(
+            TelegramGateway::is_bot_command(&msg),
+            Some("list all active")
+        );
     }
 
     // --- platform_user: edge cases ---

--- a/crates/opengoose-web/assets/modules/live-events.js
+++ b/crates/opengoose-web/assets/modules/live-events.js
@@ -17,6 +17,10 @@ const connectionLabels = {
   degraded: "Stream degraded",
 };
 
+const REFRESH_DEBOUNCE_MS = 180;
+const INITIAL_RETRY_DELAY_MS = 1000;
+const MAX_RETRY_DELAY_MS = 30000;
+
 const liveEventState = new WeakMap();
 
 const parseCsv = (value) =>
@@ -33,6 +37,18 @@ const setConnectionStatus = (owner, state) => {
 
   chip.textContent = connectionLabels[state] || connectionLabels.connecting;
   chip.className = `chip tone-${connectionTones[state] || connectionTones.connecting}`;
+};
+
+const reconnectDelayMs = (attempt) =>
+  Math.min(INITIAL_RETRY_DELAY_MS * 2 ** attempt, MAX_RETRY_DELAY_MS);
+
+const closeSource = (state) => {
+  if (!state?.source) return;
+
+  state.source.onopen = null;
+  state.source.onerror = null;
+  state.source.close();
+  state.source = null;
 };
 
 const refreshFragments = async (owner, selectors) => {
@@ -59,6 +75,7 @@ const refreshFragments = async (owner, selectors) => {
   initListShells(document);
   initTableShells(document);
   initDashboardStreams(document);
+  initLiveEvents(document);
   initWorkflowTriggers(document);
   setConnectionStatus(owner, "live");
 };
@@ -82,7 +99,61 @@ const scheduleRefresh = (owner) => {
     } finally {
       state.refreshing = false;
     }
-  }, 180);
+  }, REFRESH_DEBOUNCE_MS);
+};
+
+const bindEventTypes = (source, owner, eventTypes) => {
+  if (eventTypes.length === 0) {
+    source.onmessage = () => scheduleRefresh(owner);
+  } else {
+    eventTypes.forEach((type) => {
+      source.addEventListener(type, () => scheduleRefresh(owner));
+    });
+  }
+};
+
+const scheduleReconnect = (owner) => {
+  const state = liveEventState.get(owner);
+  if (!state || state.reconnectTimer) return;
+
+  const attempt = state.retryAttempts;
+  state.retryAttempts += 1;
+  setConnectionStatus(owner, "retrying");
+
+  state.reconnectTimer = window.setTimeout(() => {
+    state.reconnectTimer = null;
+    connectLiveEvents(owner);
+  }, reconnectDelayMs(attempt));
+};
+
+const connectLiveEvents = (owner) => {
+  const state = liveEventState.get(owner);
+  if (!state) return;
+
+  closeSource(state);
+  setConnectionStatus(
+    owner,
+    state.retryAttempts > 0 ? "retrying" : "connecting",
+  );
+
+  const source = new EventSource(state.url);
+  state.source = source;
+
+  source.onopen = () => {
+    if (state.source !== source) return;
+
+    state.retryAttempts = 0;
+    setConnectionStatus(owner, "live");
+  };
+
+  source.onerror = () => {
+    if (state.source !== source) return;
+
+    closeSource(state);
+    scheduleReconnect(owner);
+  };
+
+  bindEventTypes(source, owner, state.eventTypes);
 };
 
 const bindLiveEvents = (owner) => {
@@ -94,40 +165,20 @@ const bindLiveEvents = (owner) => {
 
   owner.dataset.liveEventsBound = "true";
 
-  const state = {
+  liveEventState.set(owner, {
+    eventTypes,
     selectors,
+    url:
+      owner.dataset.liveEventsUrl ||
+      `/api/events${eventTypes.length ? `?types=${eventTypes.join(",")}` : ""}`,
     pendingTimer: null,
+    reconnectTimer: null,
     refreshing: false,
-  };
-  liveEventState.set(owner, state);
+    retryAttempts: 0,
+    source: null,
+  });
 
-  const url =
-    owner.dataset.liveEventsUrl ||
-    `/api/events${eventTypes.length ? `?types=${eventTypes.join(",")}` : ""}`;
-
-  const source = new EventSource(url);
-
-  source.onopen = () => {
-    setConnectionStatus(owner, "live");
-  };
-
-  source.onerror = () => {
-    if (source.readyState === EventSource.CLOSED) {
-      setConnectionStatus(owner, "degraded");
-      return;
-    }
-    setConnectionStatus(owner, "retrying");
-  };
-
-  if (eventTypes.length === 0) {
-    source.onmessage = () => scheduleRefresh(owner);
-  } else {
-    eventTypes.forEach((type) => {
-      source.addEventListener(type, () => scheduleRefresh(owner));
-    });
-  }
-
-  setConnectionStatus(owner, "connecting");
+  connectLiveEvents(owner);
 };
 
 export const initLiveEvents = (root = document) => {

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -305,11 +305,12 @@ pub async fn serve(options: WebOptions) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::data::{
-        ActivityItem, AlertCard, DashboardView, MessageBubble, MetaRow, MetricCard, Notice,
-        QueueDetailView, QueueMessageView, RunListItem, ScheduleEditorView, ScheduleHistoryItem,
-        ScheduleListItem, SchedulesPageView, SelectOption, SessionDetailView, SessionListItem,
-        SessionsPageView, StatusSegment, TrendBar, WorkflowAutomationView, WorkflowDetailView,
-        WorkflowListItem, WorkflowRunView, WorkflowStepView, WorkflowsPageView,
+        ActivityItem, AlertCard, BroadcastView, DashboardView, MessageBubble, MetaRow, MetricCard,
+        Notice, QueueDetailView, QueueMessageView, RunDetailView, RunListItem, RunsPageView,
+        ScheduleEditorView, ScheduleHistoryItem, ScheduleListItem, SchedulesPageView, SelectOption,
+        SessionDetailView, SessionListItem, SessionsPageView, StatusSegment, TrendBar,
+        WorkItemView, WorkflowAutomationView, WorkflowDetailView, WorkflowListItem,
+        WorkflowRunView, WorkflowStepView, WorkflowsPageView,
     };
     use crate::routes;
 
@@ -406,6 +407,34 @@ mod tests {
                 alignment: "right",
             }],
             empty_hint: "No messages yet.".into(),
+        }
+    }
+
+    fn sample_run_detail() -> RunDetailView {
+        RunDetailView {
+            title: "Run run-1".into(),
+            subtitle: "feature-dev / chain".into(),
+            source_label: "Live runtime".into(),
+            meta: vec![MetaRow {
+                label: "Status".into(),
+                value: "running".into(),
+            }],
+            work_items: vec![WorkItemView {
+                title: "Implement live refresh".into(),
+                detail: "frontend-engineer · 2026-03-10 12:35".into(),
+                status_label: "running".into(),
+                status_tone: "cyan",
+                step_label: "Step 2".into(),
+                indent_class: "is-root",
+            }],
+            broadcasts: vec![BroadcastView {
+                sender: "planner".into(),
+                created_at: "2026-03-10 12:35".into(),
+                content: "Push the runs board live.".into(),
+            }],
+            input: "Implement the SSE updates.".into(),
+            result: "Still executing.".into(),
+            empty_hint: "No work captured yet.".into(),
         }
     }
 
@@ -530,6 +559,19 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_template_subscribes_to_channel_live_events() {
+        let live_html = routes::test_support::render_dashboard_live(sample_dashboard())
+            .expect("dashboard live partial renders");
+        let html = routes::test_support::render_dashboard_page(sample_dashboard(), live_html)
+            .expect("dashboard page renders");
+
+        assert!(html.contains("data-live-events-types=\"dashboard,session,run,queue,channel\""));
+        assert!(html.contains(
+            "data-live-events-url=\"/api/events?types=dashboard,session,run,queue,channel\""
+        ));
+    }
+
+    #[test]
     fn sessions_template_renders_accessible_list_controls() {
         let detail = sample_session_detail();
         let detail_html =
@@ -559,6 +601,37 @@ mod tests {
         assert!(html.contains("data-list-item"));
         assert!(html.contains("data-detail-panel"));
         assert!(!html.contains("hx-get"));
+    }
+
+    #[test]
+    fn runs_template_renders_live_event_hooks() {
+        let detail = sample_run_detail();
+        let detail_html =
+            routes::test_support::render_run_detail(detail.clone()).expect("detail renders");
+        let html = routes::test_support::render_runs_page(
+            RunsPageView {
+                mode_label: "Live runtime".into(),
+                mode_tone: "success",
+                runs: vec![RunListItem {
+                    title: "feature-dev".into(),
+                    subtitle: "chain workflow · Live runtime".into(),
+                    updated_at: "2026-03-10 12:35".into(),
+                    progress_label: "2/4 steps".into(),
+                    badge: "RUNNING".into(),
+                    badge_tone: "cyan",
+                    page_url: "/runs?run=run-1".into(),
+                    queue_page_url: "/queue?run=run-1".into(),
+                    active: true,
+                }],
+                selected: detail,
+            },
+            detail_html,
+        )
+        .expect("runs template renders");
+
+        assert!(html.contains("data-live-events-types=\"run,queue\""));
+        assert!(html.contains("data-live-events-connection"));
+        assert!(html.contains("Search runs"));
     }
 
     #[test]

--- a/crates/opengoose-web/src/routes.rs
+++ b/crates/opengoose-web/src/routes.rs
@@ -643,12 +643,25 @@ struct QueueDetailTemplate {
 pub(crate) mod test_support {
     use super::*;
     use crate::data::{
-        DashboardView, QueueDetailView, ScheduleEditorView, SchedulesPageView, SessionDetailView,
-        SessionsPageView, WorkflowDetailView, WorkflowsPageView,
+        DashboardView, QueueDetailView, RunDetailView, RunsPageView, ScheduleEditorView,
+        SchedulesPageView, SessionDetailView, SessionsPageView, WorkflowDetailView,
+        WorkflowsPageView,
     };
 
     pub(crate) fn render_dashboard_live(dashboard: DashboardView) -> PartialResult {
         render_partial(&DashboardLiveTemplate { dashboard })
+    }
+
+    pub(crate) fn render_dashboard_page(
+        dashboard: DashboardView,
+        live_html: String,
+    ) -> PartialResult {
+        render_partial(&DashboardTemplate {
+            page_title: "Dashboard",
+            current_nav: "dashboard",
+            dashboard,
+            live_html,
+        })
     }
 
     pub(crate) fn render_session_detail(detail: SessionDetailView) -> PartialResult {
@@ -662,6 +675,19 @@ pub(crate) mod test_support {
         render_partial(&SessionsTemplate {
             page_title: "Sessions",
             current_nav: "sessions",
+            page,
+            detail_html,
+        })
+    }
+
+    pub(crate) fn render_run_detail(detail: RunDetailView) -> PartialResult {
+        render_partial(&RunDetailTemplate { detail })
+    }
+
+    pub(crate) fn render_runs_page(page: RunsPageView, detail_html: String) -> PartialResult {
+        render_partial(&RunsTemplate {
+            page_title: "Runs",
+            current_nav: "runs",
             page,
             detail_html,
         })

--- a/crates/opengoose-web/templates/dashboard.html
+++ b/crates/opengoose-web/templates/dashboard.html
@@ -4,8 +4,8 @@
 <section
   data-dashboard-stream-root
   data-live-events
-  data-live-events-types="dashboard,session,run,queue"
-  data-live-events-url="/api/events?types=dashboard,session,run,queue"
+  data-live-events-types="dashboard,session,run,queue,channel"
+  data-live-events-url="/api/events?types=dashboard,session,run,queue,channel"
   data-live-events-targets="#dashboard-live"
 >
   <section class="hero-panel">
@@ -21,7 +21,7 @@
         <span class="chip tone-amber" data-dashboard-connection data-live-events-connection role="status" aria-live="polite">Connecting</span>
       </div>
       <p>{{ dashboard.stream_summary }}</p>
-      <p class="heartbeat" aria-live="polite">Live snapshots re-render the board below as session, run, and queue events arrive.</p>
+      <p class="heartbeat" aria-live="polite">Live snapshots re-render the board below as session, run, queue, and channel events arrive.</p>
     </div>
   </section>
 

--- a/crates/opengoose-web/templates/runs.html
+++ b/crates/opengoose-web/templates/runs.html
@@ -1,63 +1,73 @@
 {% extends "base.html" %}
 
 {% block content %}
-<section class="page-intro">
-  <div>
-    <p class="eyebrow">Runs</p>
-    <h1>Follow orchestration progress, work items, and internal broadcasts.</h1>
-  </div>
-  <span class="chip tone-{{ page.mode_tone }}">{{ page.mode_label }}</span>
-</section>
+<section
+  data-live-events
+  data-live-events-types="run,queue"
+  data-live-events-url="/api/events?types=run,queue"
+  data-live-events-targets=".page-intro,.detail-shell"
+>
+  <section class="page-intro">
+    <div>
+      <p class="eyebrow">Runs</p>
+      <h1>Follow orchestration progress, work items, and internal broadcasts.</h1>
+    </div>
+    <div class="live-chip-row">
+      <span class="chip tone-{{ page.mode_tone }}">{{ page.mode_label }}</span>
+      <span class="chip tone-amber" data-live-events-connection role="status" aria-live="polite">Connecting</span>
+    </div>
+  </section>
 
-<section class="detail-shell">
-  <aside class="rail-panel panel" data-list-shell data-list-label="runs">
-    <div class="list-toolbar" role="search" aria-label="Filter runs">
-      <div class="control-row">
-        <label class="control-field control-field-search">
-          <span>Search runs</span>
-          <input type="search" placeholder="Team, workflow, progress" autocomplete="off" data-list-search>
-        </label>
-        <label class="control-field control-field-compact">
-          <span>Page size</span>
-          <select data-list-page-size>
-            <option value="6">6</option>
-            <option value="8" selected>8</option>
-            <option value="12">12</option>
-          </select>
-        </label>
+  <section class="detail-shell">
+    <aside class="rail-panel panel" data-list-shell data-list-label="runs">
+      <div class="list-toolbar" role="search" aria-label="Filter runs">
+        <div class="control-row">
+          <label class="control-field control-field-search">
+            <span>Search runs</span>
+            <input type="search" placeholder="Team, workflow, progress" autocomplete="off" data-list-search>
+          </label>
+          <label class="control-field control-field-compact">
+            <span>Page size</span>
+            <select data-list-page-size>
+              <option value="6">6</option>
+              <option value="8" selected>8</option>
+              <option value="12">12</option>
+            </select>
+          </label>
+        </div>
+        <p class="list-status" data-list-status role="status" aria-live="polite"></p>
       </div>
-      <p class="list-status" data-list-status role="status" aria-live="polite"></p>
-    </div>
-    <p class="empty-hint empty-hint-inline" data-list-empty hidden>No runs match the current filter.</p>
-    <nav class="rail-list" data-list aria-label="Run list">
-    {% for run in page.runs %}
-    <a
-      href="{{ run.page_url }}"
-      class="rail-item{% if run.active %} is-active{% endif %}"
-      {% if run.active %}aria-current="page"{% endif %}
-      data-list-item
-      data-search="{{ run.title }} {{ run.subtitle }} {{ run.progress_label }} {{ run.badge }}"
-    >
-      <div>
-        <p class="rail-title">{{ run.title }}</p>
-        <p class="rail-subtitle">{{ run.subtitle }}</p>
+      <p class="empty-hint empty-hint-inline" data-list-empty hidden>No runs match the current filter.</p>
+      <nav class="rail-list" data-list aria-label="Run list">
+      {% for run in page.runs %}
+      <a
+        href="{{ run.page_url }}"
+        class="rail-item{% if run.active %} is-active{% endif %}"
+        {% if run.active %}aria-current="page"{% endif %}
+        data-list-item
+        data-search="{{ run.title }} {{ run.subtitle }} {{ run.progress_label }} {{ run.badge }}"
+      >
+        <div>
+          <p class="rail-title">{{ run.title }}</p>
+          <p class="rail-subtitle">{{ run.subtitle }}</p>
+        </div>
+        <div class="rail-meta">
+          <span class="chip tone-{{ run.badge_tone }}">{{ run.badge }}</span>
+          <small>{{ run.updated_at }}</small>
+        </div>
+        <p class="rail-preview">{{ run.progress_label }}</p>
+      </a>
+      {% endfor %}
+      </nav>
+      <div class="pager" data-list-pagination>
+        <button class="secondary-button" type="button" data-list-prev>Previous</button>
+        <p class="pager-label" data-list-page>Page 1 of 1</p>
+        <button class="secondary-button" type="button" data-list-next>Next</button>
       </div>
-      <div class="rail-meta">
-        <span class="chip tone-{{ run.badge_tone }}">{{ run.badge }}</span>
-        <small>{{ run.updated_at }}</small>
-      </div>
-      <p class="rail-preview">{{ run.progress_label }}</p>
-    </a>
-    {% endfor %}
-    </nav>
-    <div class="pager" data-list-pagination>
-      <button class="secondary-button" type="button" data-list-prev>Previous</button>
-      <p class="pager-label" data-list-page>Page 1 of 1</p>
-      <button class="secondary-button" type="button" data-list-next>Next</button>
-    </div>
-  </aside>
-  <section class="detail-frame">
-    <div id="detail-panel" class="detail-panel" data-detail-panel tabindex="-1" aria-live="polite" aria-busy="false">{{ detail_html|safe }}</div>
+    </aside>
+    <section class="detail-frame">
+      <div id="detail-panel" class="detail-panel" data-detail-panel tabindex="-1" aria-live="polite" aria-busy="false">{{ detail_html|safe }}</div>
+    </section>
   </section>
 </section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add explicit EventSource reconnect/backoff handling to the shared live-events client
- wire the runs page into live run/queue refresh with a visible connection chip
- expand dashboard live refresh to include channel events and add regression coverage for the new hooks
- make two existing workspace checks deterministic so cargo clippy/test complete on this branch

## Verification
- cargo build
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test

Paperclip issue: OPE-156
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
