### PR TITLE
test: Add CLI command parsing and integration tests [OPE-165]

### DIFF
--- a/crates/opengoose-cli/src/main.rs
+++ b/crates/opengoose-cli/src/main.rs
@@ -234,6 +234,247 @@ mod tests {
     }
 
     #[test]
+    fn parse_team_list_subcommand() {
+        let cli = Cli::parse_from(["opengoose", "team", "list"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Team {
+                action: cmd::team::TeamAction::List
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_team_add_force_subcommand() {
+        let cli = Cli::parse_from([
+            "opengoose",
+            "team",
+            "add",
+            "/tmp/custom-team.yaml",
+            "--force",
+        ]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Add { path, force },
+            }) => {
+                assert_eq!(path, std::path::PathBuf::from("/tmp/custom-team.yaml"));
+                assert!(force);
+            }
+            _ => panic!("expected Team add command"),
+        }
+    }
+
+    #[test]
+    fn parse_team_run_subcommand() {
+        let cli = Cli::parse_from(["opengoose", "team", "run", "code-review", "Ship it"]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Run { team, input },
+            }) => {
+                assert_eq!(team, "code-review");
+                assert_eq!(input, "Ship it");
+            }
+            _ => panic!("expected Team run command"),
+        }
+    }
+
+    #[test]
+    fn parse_team_status_with_run_id() {
+        let cli = Cli::parse_from(["opengoose", "team", "status", "run-123"]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Status { run_id },
+            }) => {
+                assert_eq!(run_id.as_deref(), Some("run-123"));
+            }
+            _ => panic!("expected Team status command"),
+        }
+    }
+
+    #[test]
+    fn parse_team_status_without_run_id() {
+        let cli = Cli::parse_from(["opengoose", "team", "status"]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Status { run_id },
+            }) => {
+                assert!(run_id.is_none());
+            }
+            _ => panic!("expected Team status command"),
+        }
+    }
+
+    #[test]
+    fn parse_team_logs_subcommand() {
+        let cli = Cli::parse_from(["opengoose", "team", "logs", "run-456"]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Logs { run_id },
+            }) => {
+                assert_eq!(run_id, "run-456");
+            }
+            _ => panic!("expected Team logs command"),
+        }
+    }
+
+    #[test]
+    fn parse_message_send_directed_subcommand() {
+        let cli = Cli::parse_from([
+            "opengoose",
+            "message",
+            "send",
+            "--from",
+            "frontend",
+            "--to",
+            "backend",
+            "hello there",
+        ]);
+
+        match cli.command {
+            Some(Command::Message {
+                action:
+                    cmd::message::MessageAction::Send {
+                        from,
+                        to,
+                        channel,
+                        payload,
+                        session,
+                    },
+            }) => {
+                assert_eq!(from, "frontend");
+                assert_eq!(to.as_deref(), Some("backend"));
+                assert!(channel.is_none());
+                assert_eq!(payload, "hello there");
+                assert_eq!(session, "cli:local:default");
+            }
+            _ => panic!("expected Message send command"),
+        }
+    }
+
+    #[test]
+    fn parse_message_send_channel_subcommand() {
+        let cli = Cli::parse_from([
+            "opengoose",
+            "message",
+            "send",
+            "--from",
+            "frontend",
+            "--channel",
+            "triage",
+            "hello channel",
+        ]);
+
+        match cli.command {
+            Some(Command::Message {
+                action:
+                    cmd::message::MessageAction::Send {
+                        from,
+                        to,
+                        channel,
+                        payload,
+                        session,
+                    },
+            }) => {
+                assert_eq!(from, "frontend");
+                assert!(to.is_none());
+                assert_eq!(channel.as_deref(), Some("triage"));
+                assert_eq!(payload, "hello channel");
+                assert_eq!(session, "cli:local:default");
+            }
+            _ => panic!("expected Message send command"),
+        }
+    }
+
+    #[test]
+    fn parse_message_list_filters() {
+        let cli = Cli::parse_from([
+            "opengoose",
+            "message",
+            "list",
+            "--session",
+            "cli:test:session",
+            "--limit",
+            "5",
+            "--agent",
+            "backend",
+        ]);
+
+        match cli.command {
+            Some(Command::Message {
+                action:
+                    cmd::message::MessageAction::List {
+                        session,
+                        limit,
+                        agent,
+                        channel,
+                    },
+            }) => {
+                assert_eq!(session, "cli:test:session");
+                assert_eq!(limit, 5);
+                assert_eq!(agent.as_deref(), Some("backend"));
+                assert!(channel.is_none());
+            }
+            _ => panic!("expected Message list command"),
+        }
+    }
+
+    #[test]
+    fn parse_message_subscribe_timeout() {
+        let cli = Cli::parse_from([
+            "opengoose",
+            "message",
+            "subscribe",
+            "--channel",
+            "ops",
+            "--timeout",
+            "30",
+        ]);
+
+        match cli.command {
+            Some(Command::Message {
+                action:
+                    cmd::message::MessageAction::Subscribe {
+                        channel,
+                        agent,
+                        timeout,
+                    },
+            }) => {
+                assert_eq!(channel.as_deref(), Some("ops"));
+                assert!(agent.is_none());
+                assert_eq!(timeout, 30);
+            }
+            _ => panic!("expected Message subscribe command"),
+        }
+    }
+
+    #[test]
+    fn parse_message_pending_subcommand() {
+        let cli = Cli::parse_from([
+            "opengoose",
+            "message",
+            "pending",
+            "frontend",
+            "--session",
+            "cli:test:pending",
+        ]);
+
+        match cli.command {
+            Some(Command::Message {
+                action: cmd::message::MessageAction::Pending { agent, session },
+            }) => {
+                assert_eq!(agent, "frontend");
+                assert_eq!(session, "cli:test:pending");
+            }
+            _ => panic!("expected Message pending command"),
+        }
+    }
+
+    #[test]
     fn parse_web_default_port() {
         let cli = Cli::parse_from(["opengoose", "web"]);
         match cli.command {

--- a/crates/opengoose-cli/tests/cli_smoke.rs
+++ b/crates/opengoose-cli/tests/cli_smoke.rs
@@ -40,6 +40,18 @@ fn stderr_json(output: &Output) -> Value {
     serde_json::from_str(&stderr(output)).unwrap()
 }
 
+fn assert_runtime_error_message(output: &Output, kind: &str, expected_message: &str) {
+    assert!(!output.status.success());
+    let error = &stderr_json(output)["error"];
+    assert_eq!(error["kind"], Value::from(kind));
+    assert!(
+        error["message"]
+            .as_str()
+            .is_some_and(|message| message.contains(expected_message)),
+        "unexpected error payload: {error}"
+    );
+}
+
 #[test]
 fn profile_commands_work_end_to_end() {
     let (_temp, home, goose_root) = test_env();
@@ -174,6 +186,59 @@ agents:
 }
 
 #[test]
+fn run_command_rejects_json_output() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(&home, &goose_root, &["--json", "run"]);
+    assert_runtime_error_message(&output, "unsupported_output", "does not support --json");
+}
+
+#[test]
+fn team_status_without_runs_reports_empty_state() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(&home, &goose_root, &["team", "status"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("No team runs found."));
+}
+
+#[test]
+fn team_status_missing_run_reports_not_found() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(
+        &home,
+        &goose_root,
+        &["--json", "team", "status", "missing-run"],
+    );
+    assert_runtime_error_message(&output, "runtime_error", "run 'missing-run' not found");
+}
+
+#[test]
+fn team_logs_missing_run_reports_not_found() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(
+        &home,
+        &goose_root,
+        &["--json", "team", "logs", "missing-run"],
+    );
+    assert_runtime_error_message(&output, "runtime_error", "run 'missing-run' not found");
+}
+
+#[test]
+fn team_add_missing_file_reports_structured_error() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(
+        &home,
+        &goose_root,
+        &["--json", "team", "add", "/definitely/missing/team.yaml"],
+    );
+    assert_runtime_error_message(&output, "not_found", "file not found");
+}
+
+#[test]
 fn auth_list_and_models_error_paths_work() {
     let (_temp, home, goose_root) = test_env();
 
@@ -260,6 +325,136 @@ fn json_output_supports_auth_and_errors() {
             .unwrap()
             .contains("Unknown provider: definitely-unknown-provider")
     );
+}
+
+#[test]
+fn message_send_requires_destination() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(
+        &home,
+        &goose_root,
+        &["--json", "message", "send", "--from", "frontend", "hello"],
+    );
+    assert_runtime_error_message(
+        &output,
+        "runtime_error",
+        "specify either --to <agent> or --channel <name>",
+    );
+}
+
+#[test]
+fn message_send_rejects_to_and_channel_together() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(
+        &home,
+        &goose_root,
+        &[
+            "--json",
+            "message",
+            "send",
+            "--from",
+            "frontend",
+            "--to",
+            "backend",
+            "--channel",
+            "ops",
+            "hello",
+        ],
+    );
+    assert_runtime_error_message(
+        &output,
+        "runtime_error",
+        "specify either --to or --channel, not both",
+    );
+}
+
+#[test]
+fn message_list_empty_session_reports_no_messages() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(&home, &goose_root, &["message", "list"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("No messages found."));
+}
+
+#[test]
+fn message_pending_empty_session_reports_no_messages() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(&home, &goose_root, &["message", "pending", "backend"]);
+    assert!(output.status.success());
+    assert!(stdout(&output).contains("No pending messages for 'backend'."));
+}
+
+#[test]
+fn message_directed_round_trip_lists_and_receives_pending_messages() {
+    let (_temp, home, goose_root) = test_env();
+
+    let send = run_cli(
+        &home,
+        &goose_root,
+        &[
+            "message",
+            "send",
+            "--from",
+            "frontend",
+            "--to",
+            "backend",
+            "please review",
+        ],
+    );
+    assert!(send.status.success());
+    assert!(stdout(&send).contains("Directed message sent"));
+
+    let list = run_cli(
+        &home,
+        &goose_root,
+        &["message", "list", "--agent", "backend"],
+    );
+    assert!(list.status.success());
+    let list_stdout = stdout(&list);
+    assert!(list_stdout.contains("frontend"));
+    assert!(list_stdout.contains("backend"));
+    assert!(list_stdout.contains("directed"));
+    assert!(list_stdout.contains("please review"));
+
+    let pending = run_cli(&home, &goose_root, &["message", "pending", "backend"]);
+    assert!(pending.status.success());
+    let pending_stdout = stdout(&pending);
+    assert!(pending_stdout.contains("Pending messages for 'backend':"));
+    assert!(pending_stdout.contains("frontend"));
+    assert!(pending_stdout.contains("please review"));
+}
+
+#[test]
+fn message_channel_round_trip_lists_history() {
+    let (_temp, home, goose_root) = test_env();
+
+    let send = run_cli(
+        &home,
+        &goose_root,
+        &[
+            "message",
+            "send",
+            "--from",
+            "frontend",
+            "--channel",
+            "ops",
+            "channel hello",
+        ],
+    );
+    assert!(send.status.success());
+    assert!(stdout(&send).contains("Channel message published"));
+
+    let list = run_cli(&home, &goose_root, &["message", "list", "--channel", "ops"]);
+    assert!(list.status.success());
+    let list_stdout = stdout(&list);
+    assert!(list_stdout.contains("frontend"));
+    assert!(list_stdout.contains("ops"));
+    assert!(list_stdout.contains("channel"));
+    assert!(list_stdout.contains("channel hello"));
 }
 
 #[test]

--- a/crates/opengoose-provider-bridge/src/lib.rs
+++ b/crates/opengoose-provider-bridge/src/lib.rs
@@ -127,7 +127,13 @@ impl GooseProviderService {
     /// Store a credential value in the OS keyring and update config metadata.
     pub fn store_credential(provider_id: &str, env_var: &str, value: &str) -> anyhow::Result<()> {
         let mut config = ConfigFile::load()?;
-        Self::store_credential_in_config(provider_id, env_var, value, &KeyringBackend, &mut config)?;
+        Self::store_credential_in_config(
+            provider_id,
+            env_var,
+            value,
+            &KeyringBackend,
+            &mut config,
+        )?;
         config.save()?;
         Ok(())
     }
@@ -320,9 +326,9 @@ mod tests {
         }
 
         fn set(&self, _key: &str, _value: &str) -> SecretResult<()> {
-            Err(opengoose_secrets::SecretError::ConfigIo(std::io::Error::other(
-                "mock keyring unavailable",
-            )))
+            Err(opengoose_secrets::SecretError::ConfigIo(
+                std::io::Error::other("mock keyring unavailable"),
+            ))
         }
 
         fn delete(&self, _key: &str) -> SecretResult<bool> {

--- a/crates/opengoose-teams/src/remote.rs
+++ b/crates/opengoose-teams/src/remote.rs
@@ -806,28 +806,19 @@ mod tests {
         // Initially connected.
         {
             let agents = reg.agents.read().await;
-            assert_eq!(
-                agents["d"].connection_state,
-                ConnectionState::Connected
-            );
+            assert_eq!(agents["d"].connection_state, ConnectionState::Connected);
         }
 
         reg.mark_reconnecting("d").await;
         {
             let agents = reg.agents.read().await;
-            assert_eq!(
-                agents["d"].connection_state,
-                ConnectionState::Reconnecting
-            );
+            assert_eq!(agents["d"].connection_state, ConnectionState::Reconnecting);
         }
 
         reg.mark_connected("d").await;
         {
             let agents = reg.agents.read().await;
-            assert_eq!(
-                agents["d"].connection_state,
-                ConnectionState::Connected
-            );
+            assert_eq!(agents["d"].connection_state, ConnectionState::Connected);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add parser coverage for `team` and `message` subcommands in `main.rs`
- add binary smoke tests for `run`, `team`, and `message` command success and error paths
- include the small rustfmt follow-up changes needed for `cargo fmt --all` to pass

Paperclip issue: OPE-165

## Validation
- `cargo fmt --all`
- `cargo build`
- `cargo clippy --all-targets`
- `cargo test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
