### PR TITLE
test: Expand web handler coverage [OPE-175]

### DIFF
--- a/crates/opengoose-matrix/src/gateway/tests.rs
+++ b/crates/opengoose-matrix/src/gateway/tests.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use opengoose_types::Platform;
 
 use super::{
-    MATRIX_MAX_LEN, MAX_RECONNECT_ATTEMPTS, REQUEST_TIMEOUT, SYNC_TIMEOUT_MS, MatrixGateway,
+    MATRIX_MAX_LEN, MAX_RECONNECT_ATTEMPTS, MatrixGateway, REQUEST_TIMEOUT, SYNC_TIMEOUT_MS,
     urlencoding,
 };
 
@@ -162,8 +162,7 @@ fn test_event_filter_rejects_non_room_message_type() {
 
 #[test]
 fn test_event_filter_rejects_non_text_msgtype() {
-    let image_content =
-        serde_json::json!({"msgtype": "m.image", "url": "mxc://example.com/abc"});
+    let image_content = serde_json::json!({"msgtype": "m.image", "url": "mxc://example.com/abc"});
     assert!(!should_process_event(
         "m.room.message",
         "@alice:example.com",

--- a/crates/opengoose-matrix/src/gateway/urlencoding.rs
+++ b/crates/opengoose-matrix/src/gateway/urlencoding.rs
@@ -4,8 +4,7 @@ pub fn encode(s: &str) -> Encoded {
     Encoded(
         s.bytes()
             .flat_map(|b| {
-                if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b'~'
-                {
+                if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.' || b == b'~' {
                     vec![b as char]
                 } else {
                     format!("%{b:02X}").chars().collect()

--- a/crates/opengoose-teams/src/message_bus.rs
+++ b/crates/opengoose-teams/src/message_bus.rs
@@ -115,7 +115,11 @@ impl MessageBus {
         let event = BusEvent::directed(from, to, payload);
         // Publish to the named agent's channel if any subscriber exists.
         let agent_count = {
-            let directed = self.inner.directed.lock().unwrap_or_else(|e| e.into_inner());
+            let directed = self
+                .inner
+                .directed
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(tx) = directed.get(to) {
                 tx.send(event.clone()).unwrap_or(0)
             } else {
@@ -133,7 +137,11 @@ impl MessageBus {
     pub fn publish(&self, from: &str, channel: &str, payload: &str) -> usize {
         let event = BusEvent::channel(from, channel, payload);
         let channel_count = {
-            let channels = self.inner.channels.lock().unwrap_or_else(|e| e.into_inner());
+            let channels = self
+                .inner
+                .channels
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             if let Some(tx) = channels.get(channel) {
                 tx.send(event.clone()).unwrap_or(0)
             } else {
@@ -149,7 +157,11 @@ impl MessageBus {
     /// Returns a `broadcast::Receiver` that yields `BusEvent` values
     /// addressed to `agent_name`.
     pub fn subscribe_agent(&self, agent_name: &str) -> broadcast::Receiver<BusEvent> {
-        let mut directed = self.inner.directed.lock().unwrap_or_else(|e| e.into_inner());
+        let mut directed = self
+            .inner
+            .directed
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         directed
             .entry(agent_name.to_string())
             .or_insert_with(|| {
@@ -164,7 +176,11 @@ impl MessageBus {
     /// Returns a `broadcast::Receiver` that yields `BusEvent` values
     /// published to `channel_name`.
     pub fn subscribe_channel(&self, channel_name: &str) -> broadcast::Receiver<BusEvent> {
-        let mut channels = self.inner.channels.lock().unwrap_or_else(|e| e.into_inner());
+        let mut channels = self
+            .inner
+            .channels
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         channels
             .entry(channel_name.to_string())
             .or_insert_with(|| {

--- a/crates/opengoose-telegram/src/gateway/tests.rs
+++ b/crates/opengoose-telegram/src/gateway/tests.rs
@@ -2,12 +2,10 @@ use std::time::Duration;
 
 use opengoose_types::Platform;
 
-use super::{
-    TELEGRAM_MAX_LEN, MAX_RECONNECT_ATTEMPTS, REQUEST_TIMEOUT, TelegramGateway,
-};
 use super::types::{
     BotInfo, Chat, MessageEntity, SentMessage, TelegramMessage, TelegramResponse, Update, User,
 };
+use super::{MAX_RECONNECT_ATTEMPTS, REQUEST_TIMEOUT, TELEGRAM_MAX_LEN, TelegramGateway};
 
 #[test]
 fn test_strip_mention() {

--- a/crates/opengoose-web/src/handlers/remote_agents.rs
+++ b/crates/opengoose-web/src/handlers/remote_agents.rs
@@ -479,6 +479,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disconnect_remote_updates_gateway_metrics() {
+        use super::gateway_health;
+
+        let state = make_state(RemoteConfig::default());
+        let (tx, _) = tokio::sync::mpsc::unbounded_channel();
+        state
+            .registry
+            .register("metrics-agent".into(), vec![], "ws://metrics".into(), tx)
+            .await
+            .unwrap();
+
+        let response = disconnect_remote(State(state.clone()), Path("metrics-agent".into()))
+            .await
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let axum::Json(metrics) = gateway_health(State(state)).await;
+        assert_eq!(metrics.active_connections, 0);
+        assert_eq!(metrics.total_connects, 1);
+        assert_eq!(metrics.total_disconnects, 1);
+    }
+
+    #[tokio::test]
     async fn gateway_health_returns_zero_metrics_when_empty() {
         use super::gateway_health;
 

--- a/crates/opengoose-web/src/handlers/triggers.rs
+++ b/crates/opengoose-web/src/handlers/triggers.rs
@@ -258,57 +258,17 @@ pub async fn test_trigger(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-    use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use axum::Json;
     use axum::extract::{Path, State};
     use axum::http::StatusCode;
-    use opengoose_persistence::{
-        AlertStore, Database, OrchestrationStore, ScheduleStore, SessionStore, TriggerStore,
-    };
-    use opengoose_profiles::ProfileStore;
-    use opengoose_teams::TeamStore;
-    use opengoose_types::{ChannelMetricsStore, EventBus};
 
     use super::{
-        CreateTriggerRequest, SetEnabledRequest, UpdateTriggerRequest, create_trigger,
-        delete_trigger, get_trigger, list_triggers, set_trigger_enabled, update_trigger,
+        CreateTriggerRequest, SetEnabledRequest, TestTriggerRequest, UpdateTriggerRequest,
+        create_trigger, delete_trigger, get_trigger, list_triggers, set_trigger_enabled,
+        test_trigger, update_trigger,
     };
     use crate::error::WebError;
-    use crate::state::AppState;
-
-    fn unique_temp_dir(label: &str) -> PathBuf {
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time should be after epoch")
-            .as_nanos();
-        std::env::temp_dir().join(format!(
-            "opengoose-web-triggers-{label}-{}-{suffix}",
-            std::process::id()
-        ))
-    }
-
-    fn make_state() -> AppState {
-        let db = Arc::new(Database::open_in_memory().expect("in-memory db should open"));
-        let teams_dir = unique_temp_dir("teams");
-        let profiles_dir = unique_temp_dir("profiles");
-        std::fs::create_dir_all(&teams_dir).unwrap();
-        std::fs::create_dir_all(&profiles_dir).unwrap();
-        AppState {
-            db: db.clone(),
-            session_store: Arc::new(SessionStore::new(db.clone())),
-            orchestration_store: Arc::new(OrchestrationStore::new(db.clone())),
-            profile_store: Arc::new(ProfileStore::with_dir(profiles_dir)),
-            team_store: Arc::new(TeamStore::with_dir(teams_dir)),
-            schedule_store: Arc::new(ScheduleStore::new(db.clone())),
-            trigger_store: Arc::new(TriggerStore::new(db.clone())),
-            alert_store: Arc::new(AlertStore::new(db)),
-            channel_metrics: ChannelMetricsStore::new(),
-            event_bus: EventBus::new(256),
-        }
-    }
+    use crate::handlers::test_support::make_state;
 
     #[tokio::test]
     async fn list_triggers_returns_empty_vec_initially() {
@@ -370,6 +330,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_trigger_trims_name_team_and_trigger_type() {
+        let state = make_state();
+
+        let (_, Json(created)) = create_trigger(
+            State(state),
+            Json(CreateTriggerRequest {
+                name: "  on-pr  ".into(),
+                trigger_type: " webhook_received ".into(),
+                condition_json: None,
+                team_name: " review-team ".into(),
+                input: Some("review the PR".into()),
+            }),
+        )
+        .await
+        .expect("create should succeed");
+
+        assert_eq!(created.name, "on-pr");
+        assert_eq!(created.trigger_type, "webhook_received");
+        assert_eq!(created.team_name, "review-team");
+    }
+
+    #[tokio::test]
     async fn create_trigger_rejects_blank_name() {
         let err = create_trigger(
             State(make_state()),
@@ -384,6 +366,42 @@ mod tests {
         .await
         .expect_err("blank name should be rejected");
         assert!(matches!(err, WebError::UnprocessableEntity(msg) if msg.contains("`name`")));
+    }
+
+    #[tokio::test]
+    async fn create_trigger_rejects_blank_team_name() {
+        let err = create_trigger(
+            State(make_state()),
+            Json(CreateTriggerRequest {
+                name: "on-pr".into(),
+                trigger_type: "webhook_received".into(),
+                condition_json: None,
+                team_name: "   ".into(),
+                input: None,
+            }),
+        )
+        .await
+        .expect_err("blank team name should be rejected");
+        assert!(matches!(err, WebError::UnprocessableEntity(msg) if msg.contains("`team_name`")));
+    }
+
+    #[tokio::test]
+    async fn create_trigger_rejects_blank_trigger_type() {
+        let err = create_trigger(
+            State(make_state()),
+            Json(CreateTriggerRequest {
+                name: "on-pr".into(),
+                trigger_type: "   ".into(),
+                condition_json: None,
+                team_name: "team".into(),
+                input: None,
+            }),
+        )
+        .await
+        .expect_err("blank trigger type should be rejected");
+        assert!(
+            matches!(err, WebError::UnprocessableEntity(msg) if msg.contains("`trigger_type`"))
+        );
     }
 
     #[tokio::test]
@@ -455,6 +473,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_trigger_trims_fields_and_defaults_optional_values() {
+        let state = make_state();
+        state
+            .trigger_store
+            .create(
+                "my-hook",
+                "webhook_received",
+                r#"{"path":"/old"}"#,
+                "team-a",
+                "old input",
+            )
+            .unwrap();
+
+        let Json(updated) = update_trigger(
+            State(state),
+            Path("my-hook".into()),
+            Json(UpdateTriggerRequest {
+                trigger_type: " file_watch ".into(),
+                condition_json: None,
+                team_name: " team-b ".into(),
+                input: None,
+            }),
+        )
+        .await
+        .expect("update should succeed");
+
+        assert_eq!(updated.trigger_type, "file_watch");
+        assert_eq!(updated.team_name, "team-b");
+        assert_eq!(updated.condition_json, "{}");
+        assert_eq!(updated.input, "");
+    }
+
+    #[tokio::test]
+    async fn update_trigger_rejects_blank_team_name() {
+        let err = update_trigger(
+            State(make_state()),
+            Path("my-hook".into()),
+            Json(UpdateTriggerRequest {
+                trigger_type: "webhook_received".into(),
+                condition_json: None,
+                team_name: "   ".into(),
+                input: None,
+            }),
+        )
+        .await
+        .expect_err("blank team name should fail");
+        assert!(matches!(err, WebError::UnprocessableEntity(msg) if msg.contains("`team_name`")));
+    }
+
+    #[tokio::test]
+    async fn update_trigger_rejects_blank_trigger_type() {
+        let err = update_trigger(
+            State(make_state()),
+            Path("my-hook".into()),
+            Json(UpdateTriggerRequest {
+                trigger_type: "   ".into(),
+                condition_json: None,
+                team_name: "team".into(),
+                input: None,
+            }),
+        )
+        .await
+        .expect_err("blank trigger type should fail");
+        assert!(
+            matches!(err, WebError::UnprocessableEntity(msg) if msg.contains("`trigger_type`"))
+        );
+    }
+
+    #[tokio::test]
+    async fn update_trigger_rejects_invalid_condition_json() {
+        let err = update_trigger(
+            State(make_state()),
+            Path("my-hook".into()),
+            Json(UpdateTriggerRequest {
+                trigger_type: "webhook_received".into(),
+                condition_json: Some("not valid json".into()),
+                team_name: "team".into(),
+                input: None,
+            }),
+        )
+        .await
+        .expect_err("invalid JSON should fail");
+        assert!(matches!(err, WebError::BadRequest(msg) if msg.contains("`condition_json`")));
+    }
+
+    #[tokio::test]
     async fn update_trigger_returns_404_for_missing() {
         let err = update_trigger(
             State(make_state()),
@@ -515,6 +619,77 @@ mod tests {
         .await
         .expect("re-enable should succeed");
         assert_eq!(result["enabled"].as_bool(), Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_trigger_trims_explicit_input() {
+        let state = make_state();
+        state
+            .trigger_store
+            .create("my-hook", "webhook_received", "{}", "team-a", "saved input")
+            .unwrap();
+
+        let (status, Json(result)) = test_trigger(
+            State(state),
+            Path("my-hook".into()),
+            Some(Json(TestTriggerRequest {
+                input: Some("  run now  ".into()),
+            })),
+        )
+        .await
+        .expect("test trigger should succeed");
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(result["trigger"].as_str(), Some("my-hook"));
+        assert_eq!(result["team"].as_str(), Some("team-a"));
+        assert_eq!(result["input"].as_str(), Some("run now"));
+    }
+
+    #[tokio::test]
+    async fn test_trigger_uses_saved_input_when_body_is_missing() {
+        let state = make_state();
+        state
+            .trigger_store
+            .create("my-hook", "webhook_received", "{}", "team-a", "saved input")
+            .unwrap();
+
+        let (_, Json(result)) = test_trigger(State(state), Path("my-hook".into()), None)
+            .await
+            .expect("test trigger should succeed");
+
+        assert_eq!(result["input"].as_str(), Some("saved input"));
+    }
+
+    #[tokio::test]
+    async fn test_trigger_uses_default_input_when_saved_and_body_inputs_are_blank() {
+        let state = make_state();
+        state
+            .trigger_store
+            .create("my-hook", "webhook_received", "{}", "team-a", "")
+            .unwrap();
+
+        let (_, Json(result)) = test_trigger(
+            State(state),
+            Path("my-hook".into()),
+            Some(Json(TestTriggerRequest {
+                input: Some("   ".into()),
+            })),
+        )
+        .await
+        .expect("test trigger should succeed");
+
+        assert_eq!(
+            result["input"].as_str(),
+            Some("Test run fired from the web dashboard for trigger my-hook")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_trigger_returns_404_for_missing_trigger() {
+        let err = test_trigger(State(make_state()), Path("no-such".into()), None)
+            .await
+            .expect_err("missing trigger should fail");
+        assert!(matches!(err, WebError::NotFound(_)));
     }
 
     #[tokio::test]

--- a/crates/opengoose-web/src/handlers/workflows.rs
+++ b/crates/opengoose-web/src/handlers/workflows.rs
@@ -292,22 +292,20 @@ fn status_label(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
-    use std::sync::Arc;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     use axum::Json;
     use axum::extract::{Path, State};
     use axum::http::StatusCode;
-    use opengoose_persistence::{
-        AlertStore, Database, OrchestrationStore, ScheduleStore, SessionStore, TriggerStore,
-    };
-    use opengoose_profiles::ProfileStore;
+    use axum::response::IntoResponse;
     use opengoose_teams::{
-        FanOutConfig, MergeStrategy, OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore,
+        FanOutConfig, MergeStrategy, OrchestrationPattern, TeamAgent, TeamDefinition,
     };
-    use opengoose_types::{ChannelMetricsStore, EventBus};
 
     use super::{TriggerWorkflowRequest, get_workflow, list_workflows, trigger_workflow};
+    use crate::error::WebError;
+    use crate::handlers::test_support::{
+        make_state_with_dirs, sample_team as shared_sample_team, unique_temp_dir, unique_temp_path,
+    };
     use crate::state::AppState;
 
     struct TestContext {
@@ -315,41 +313,16 @@ mod tests {
         teams_dir: PathBuf,
     }
 
-    fn unique_temp_dir(label: &str) -> PathBuf {
-        let suffix = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system time should be after epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!(
-            "opengoose-web-workflows-{label}-{}-{suffix}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&dir).expect("temp test dir should be created");
-        dir
-    }
-
     fn make_context() -> TestContext {
-        let db = Arc::new(Database::open_in_memory().expect("in-memory db should open"));
-        let teams_dir = unique_temp_dir("teams");
-        let profiles_dir = unique_temp_dir("profiles");
-
-        let state = AppState {
-            db: db.clone(),
-            session_store: Arc::new(SessionStore::new(db.clone())),
-            orchestration_store: Arc::new(OrchestrationStore::new(db.clone())),
-            profile_store: Arc::new(ProfileStore::with_dir(profiles_dir)),
-            team_store: Arc::new(TeamStore::with_dir(teams_dir.clone())),
-            schedule_store: Arc::new(ScheduleStore::new(db.clone())),
-            trigger_store: Arc::new(TriggerStore::new(db.clone())),
-            alert_store: Arc::new(AlertStore::new(db)),
-            channel_metrics: ChannelMetricsStore::new(),
-            event_bus: EventBus::new(256),
-        };
+        let teams_dir = unique_temp_dir("workflows-teams");
+        let profiles_dir = unique_temp_dir("workflows-profiles");
+        let state = make_state_with_dirs(profiles_dir, teams_dir.clone());
 
         TestContext { state, teams_dir }
     }
 
     fn sample_team(name: &str, workflow: OrchestrationPattern) -> TeamDefinition {
+        let mut team = shared_sample_team(name, "planner");
         let fan_out = if matches!(&workflow, OrchestrationPattern::FanOut) {
             Some(FanOutConfig {
                 merge_strategy: MergeStrategy::Summary,
@@ -358,24 +331,20 @@ mod tests {
             None
         };
 
-        TeamDefinition {
-            version: "1.0.0".into(),
-            title: name.into(),
-            description: Some(format!("{name} description")),
-            workflow,
-            agents: vec![
-                TeamAgent {
-                    profile: "planner".into(),
-                    role: Some("Plan".into()),
-                },
-                TeamAgent {
-                    profile: "builder".into(),
-                    role: Some("Build".into()),
-                },
-            ],
-            router: None,
-            fan_out,
-        }
+        team.version = "1.0.0".into();
+        team.workflow = workflow;
+        team.agents = vec![
+            TeamAgent {
+                profile: "planner".into(),
+                role: Some("Plan".into()),
+            },
+            TeamAgent {
+                profile: "builder".into(),
+                role: Some("Build".into()),
+            },
+        ];
+        team.fan_out = fan_out;
+        team
     }
 
     fn save_team(state: &AppState, team: &TeamDefinition) {
@@ -608,5 +577,40 @@ mod tests {
             blank.input,
             "Manual run requested from the web dashboard for feature-dev"
         );
+    }
+
+    #[tokio::test]
+    async fn list_workflows_propagates_team_store_errors() {
+        let invalid_teams_path = unique_temp_path("workflows-teams-file");
+        std::fs::write(&invalid_teams_path, "not a directory")
+            .expect("team file should be created");
+        let state = make_state_with_dirs(unique_temp_dir("profiles"), invalid_teams_path);
+
+        let err = list_workflows(State(state))
+            .await
+            .err()
+            .expect("invalid team store path should fail");
+
+        assert!(matches!(err, WebError::Team(_)));
+    }
+
+    #[tokio::test]
+    async fn get_workflow_returns_not_found_for_missing_team() {
+        let err = get_workflow(State(make_context().state), Path("missing".into()))
+            .await
+            .err()
+            .expect("missing workflow should fail");
+
+        assert_eq!(err.into_response().status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn trigger_workflow_returns_not_found_for_missing_team() {
+        let err = trigger_workflow(State(make_context().state), Path("missing".into()), None)
+            .await
+            .err()
+            .expect("missing workflow should fail");
+
+        assert_eq!(err.into_response().status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -15,11 +15,11 @@ mod tls;
 /// Re-exported error type for web API and page handlers.
 pub use error::WebError;
 pub use routes::render_dashboard_live_partial;
+pub use server::WebOptions;
 /// Re-exported shared application state for all handlers.
 pub use state::AppState;
 /// Alias kept for backward compatibility.
 pub use state::AppState as SharedAppState;
-pub use server::WebOptions;
 
 use std::sync::Arc;
 
@@ -34,7 +34,6 @@ use crate::handlers::remote_agents::{self, RemoteGatewayState};
 use crate::middleware::{RateLimitConfig, RateLimitLayer};
 use crate::pages::not_found_handler;
 use crate::server::PageState;
-
 
 /// Start the web dashboard and JSON API server.
 ///

--- a/crates/opengoose-web/src/routes.rs
+++ b/crates/opengoose-web/src/routes.rs
@@ -14,7 +14,6 @@ use opengoose_persistence::{Database, MessageQueue, OrchestrationStore, RunStatu
 use serde::Deserialize;
 
 use crate::AppState;
-use crate::server::PageState;
 use crate::data::{
     AgentDetailView, AgentsPageView, DashboardView, HealthResponse, QueueDetailView, QueuePageView,
     RemoteAgentsPageView, RunDetailView, RunsPageView, ScheduleEditorView, ScheduleSaveInput,
@@ -25,6 +24,7 @@ use crate::data::{
     load_triggers_page, load_workflows_page, probe_health, save_schedule, save_team_yaml,
     toggle_schedule,
 };
+use crate::server::PageState;
 
 // --- Result types ---
 


### PR DESCRIPTION
## Summary
- extend `workflows` handler tests to cover missing error paths and shared test-support state setup
- expand `triggers` handler coverage for trim/validation branches and the `test_trigger` endpoint
- add a disconnect metrics assertion for `remote_agents` and keep rustfmt-required reflow from the current toolchain

## Verification
- `cargo fmt --all --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `cargo test`

## Paperclip
- [OPE-175](http://localhost:3131/OPE/issues/OPE-175)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
