### PR TITLE
test: expand pages route coverage [OPE-190]

### DIFF
--- a/crates/opengoose-web/src/data/schedules.rs
+++ b/crates/opengoose-web/src/data/schedules.rs
@@ -641,37 +641,16 @@ fn normalize_input(input: String) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     use opengoose_persistence::{Database, OrchestrationStore, RunStatus};
     use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore};
 
     use super::*;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::test_support::with_temp_home as with_shared_temp_home;
 
     fn with_temp_home(test: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().expect("env lock should succeed");
-        let temp_home =
-            std::env::temp_dir().join(format!("opengoose-schedules-home-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&temp_home);
-        std::fs::create_dir_all(&temp_home).expect("temp home should be created");
-        let saved_home = std::env::var("HOME").ok();
-
-        unsafe {
-            std::env::set_var("HOME", &temp_home);
-        }
-
-        test();
-
-        unsafe {
-            match saved_home {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-
-        let _ = std::fs::remove_dir_all(temp_home);
+        with_shared_temp_home("opengoose-schedules-home", test);
     }
 
     fn test_db() -> Arc<Database> {

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -14,6 +14,8 @@ mod routes;
 /// Server configuration types (bind address, TLS paths).
 pub mod server;
 mod state;
+#[cfg(test)]
+pub(crate) mod test_support;
 mod tls;
 
 /// Re-exported error type for web API and page handlers.

--- a/crates/opengoose-web/src/routes/pages.rs
+++ b/crates/opengoose-web/src/routes/pages.rs
@@ -682,42 +682,21 @@ pub(crate) mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::future::Future;
+    use std::sync::Arc;
 
-    use opengoose_persistence::{Database, ScheduleStore};
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Method, Request};
+    use opengoose_persistence::{
+        Database, OrchestrationStore, ScheduleStore, SessionStore, TriggerStore,
+    };
     use opengoose_teams::remote::{RemoteAgentRegistry, RemoteConfig};
     use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore};
-    use opengoose_types::{ChannelMetricsStore, EventBus};
+    use opengoose_types::{ChannelMetricsStore, EventBus, Platform, SessionKey};
+    use tower::ServiceExt;
 
     use super::*;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn with_temp_home(test: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().expect("env lock should succeed");
-        let temp_home = std::env::temp_dir().join(format!(
-            "opengoose-routes-schedules-home-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&temp_home);
-        std::fs::create_dir_all(&temp_home).expect("temp home should be created");
-        let saved_home = std::env::var("HOME").ok();
-
-        unsafe {
-            std::env::set_var("HOME", &temp_home);
-        }
-
-        test();
-
-        unsafe {
-            match saved_home {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-
-        let _ = std::fs::remove_dir_all(temp_home);
-    }
+    use crate::test_support::with_temp_home;
 
     fn save_team(name: &str) {
         TeamStore::new()
@@ -749,9 +728,305 @@ mod tests {
         }
     }
 
+    fn run_async(test: impl Future<Output = ()>) {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime should build")
+            .block_on(test);
+    }
+
+    fn save_session(db: Arc<Database>, key: &SessionKey, active_team: Option<&str>) {
+        let store = SessionStore::new(db);
+        store
+            .append_user_message(key, "Need a reviewer on this run.", Some("tester"))
+            .expect("session should seed");
+        if let Some(team) = active_team {
+            store
+                .set_active_team(key, Some(team))
+                .expect("active team should seed");
+        }
+    }
+
+    fn save_run(db: Arc<Database>, run_id: &str) {
+        OrchestrationStore::new(db)
+            .create_run(
+                run_id,
+                "discord:ns:ops:chan-1",
+                "ops",
+                "chain",
+                "Review the latest deploy.",
+                3,
+            )
+            .expect("run should seed");
+    }
+
+    async fn read_body(response: axum::response::Response) -> String {
+        let body = to_bytes(response.into_body(), 1024 * 1024)
+            .await
+            .expect("response body should be readable");
+        String::from_utf8(body.to_vec()).expect("response body should be utf-8")
+    }
+
+    #[test]
+    fn page_router_get_routes_return_expected_statuses() {
+        with_temp_home("opengoose-routes-pages-home", || {
+            run_async(async {
+                let app = router(page_state(Arc::new(
+                    Database::open_in_memory().expect("db should open"),
+                )));
+
+                for path in [
+                    "/",
+                    "/dashboard/events",
+                    "/sessions",
+                    "/runs",
+                    "/agents",
+                    "/remote-agents",
+                    "/remote-agents/events",
+                    "/workflows",
+                    "/schedules",
+                    "/triggers",
+                    "/teams",
+                    "/queue",
+                ] {
+                    let response = app
+                        .clone()
+                        .oneshot(
+                            Request::builder()
+                                .method(Method::GET)
+                                .uri(path)
+                                .body(Body::empty())
+                                .unwrap(),
+                        )
+                        .await
+                        .expect("request should be handled");
+
+                    assert_eq!(
+                        response.status(),
+                        StatusCode::OK,
+                        "path `{path}` should render"
+                    );
+                }
+            });
+        });
+    }
+
+    #[test]
+    fn page_router_post_routes_return_expected_statuses() {
+        with_temp_home("opengoose-routes-pages-home", || {
+            run_async(async {
+                let app = router(page_state(Arc::new(
+                    Database::open_in_memory().expect("db should open"),
+                )));
+
+                let schedule_response = app
+                    .clone()
+                    .oneshot(
+                        Request::builder()
+                            .method(Method::POST)
+                            .uri("/schedules")
+                            .header("content-type", "application/x-www-form-urlencoded")
+                            .body(Body::from("intent=unsupported"))
+                            .unwrap(),
+                    )
+                    .await
+                    .expect("schedule request should be handled");
+                assert_eq!(schedule_response.status(), StatusCode::BAD_REQUEST);
+
+                let team_response = app
+                    .oneshot(
+                        Request::builder()
+                            .method(Method::POST)
+                            .uri("/teams")
+                            .header("content-type", "application/x-www-form-urlencoded")
+                            .body(Body::from("original_name=broken&yaml=title%3A+broken"))
+                            .unwrap(),
+                    )
+                    .await
+                    .expect("team request should be handled");
+                assert_eq!(team_response.status(), StatusCode::OK);
+            });
+        });
+    }
+
+    #[tokio::test]
+    async fn dashboard_handler_renders_mock_preview() {
+        let Html(html) = dashboard(State(page_state(Arc::new(
+            Database::open_in_memory().expect("db should open"),
+        ))))
+        .await
+        .expect("handler should render");
+
+        assert!(html.contains("Mock preview"));
+        assert!(html.contains("No runtime data yet"));
+    }
+
+    #[tokio::test]
+    async fn sessions_handler_invalid_selection_falls_back_to_live_session() {
+        let db = Arc::new(Database::open_in_memory().expect("db should open"));
+        let session_key = SessionKey::new(Platform::Discord, "ops", "chan-1");
+        save_session(db.clone(), &session_key, Some("reviewers"));
+
+        let Html(html) = sessions(
+            State(page_state(db)),
+            Query(SessionQuery {
+                session: Some("discord:ns:missing:session".into()),
+            }),
+        )
+        .await
+        .expect("handler should render");
+
+        assert!(html.contains("Live runtime"));
+        assert!(html.contains("Session chan-1"));
+        assert!(html.contains(&session_key.to_stable_id()));
+    }
+
+    #[tokio::test]
+    async fn runs_handler_invalid_selection_falls_back_to_live_run() {
+        let db = Arc::new(Database::open_in_memory().expect("db should open"));
+        save_run(db.clone(), "run-live-1");
+
+        let Html(html) = runs(
+            State(page_state(db)),
+            Query(RunQuery {
+                run: Some("missing-run".into()),
+            }),
+        )
+        .await
+        .expect("handler should render");
+
+        assert!(html.contains("Live runtime"));
+        assert!(html.contains("Run run-live-1"));
+        assert!(html.contains("ops / chain"));
+    }
+
+    #[test]
+    fn agents_handler_renders_bundled_defaults_for_unknown_selection() {
+        with_temp_home("opengoose-routes-pages-home", || {
+            run_async(async {
+                let Html(html) = agents(Query(AgentQuery {
+                    agent: Some("missing-agent".into()),
+                }))
+                .await
+                .expect("handler should render");
+
+                assert!(html.contains("Bundled defaults"));
+                assert!(html.contains("aria-current=\"page\""));
+            });
+        });
+    }
+
+    #[test]
+    fn workflows_handler_renders_bundled_defaults_for_unknown_selection() {
+        with_temp_home("opengoose-routes-pages-home", || {
+            run_async(async {
+                let Html(html) = workflows(
+                    State(page_state(Arc::new(
+                        Database::open_in_memory().expect("db should open"),
+                    ))),
+                    Query(WorkflowQuery {
+                        workflow: Some("missing-workflow".into()),
+                    }),
+                )
+                .await
+                .expect("handler should render");
+
+                assert!(html.contains("Bundled defaults"));
+                assert!(html.contains("Workflow detail"));
+                assert!(html.contains("aria-current=\"page\""));
+            });
+        });
+    }
+
+    #[tokio::test]
+    async fn triggers_handler_invalid_selection_falls_back_to_existing_trigger() {
+        let db = Arc::new(Database::open_in_memory().expect("db should open"));
+        TriggerStore::new(db.clone())
+            .create("incoming", "webhook_received", "{}", "ops", "")
+            .expect("trigger should seed");
+
+        let Html(html) = triggers(
+            State(page_state(db)),
+            Query(TriggerQuery {
+                trigger: Some("missing-trigger".into()),
+            }),
+        )
+        .await
+        .expect("handler should render");
+
+        assert!(html.contains("1 trigger(s)"));
+        assert!(html.contains("incoming"));
+        assert!(html.contains("webhook_received"));
+    }
+
+    #[tokio::test]
+    async fn queue_handler_invalid_selection_falls_back_to_live_run() {
+        let db = Arc::new(Database::open_in_memory().expect("db should open"));
+        save_run(db.clone(), "run-queue-1");
+
+        let Html(html) = queue(
+            State(page_state(db)),
+            Query(RunQuery {
+                run: Some("missing-run".into()),
+            }),
+        )
+        .await
+        .expect("handler should render");
+
+        assert!(html.contains("Live runtime"));
+        assert!(html.contains("Queue run-queue-1"));
+        assert!(html.contains("No queue traffic has been recorded for this run yet."));
+    }
+
+    #[test]
+    fn team_save_invalid_yaml_renders_editor_error_notice() {
+        with_temp_home("opengoose-routes-pages-home", || {
+            run_async(async {
+                let Html(html) = team_save(Form(TeamSaveForm {
+                    original_name: "broken-team".into(),
+                    yaml: "title: broken-team".into(),
+                }))
+                .await
+                .expect("handler should render");
+
+                assert!(html.contains("Fix the YAML validation error and try again."));
+                assert!(html.contains("Editor draft"));
+            });
+        });
+    }
+
+    #[test]
+    fn schedule_action_missing_team_renders_validation_notice() {
+        with_temp_home("opengoose-routes-pages-home", || {
+            run_async(async {
+                let Html(html) = schedule_action(
+                    State(page_state(Arc::new(
+                        Database::open_in_memory().expect("db should open"),
+                    ))),
+                    Form(ScheduleActionForm {
+                        intent: "save".into(),
+                        original_name: None,
+                        name: Some("nightly-ops".into()),
+                        cron_expression: Some("0 0 * * * *".into()),
+                        team_name: Some("missing-team".into()),
+                        input: Some(String::new()),
+                        enabled: Some("yes".into()),
+                        confirm_delete: None,
+                    }),
+                )
+                .await
+                .expect("handler should render");
+
+                assert!(html.contains("The selected team is not installed."));
+                assert!(html.contains("nightly-ops"));
+            });
+        });
+    }
+
     #[test]
     fn schedules_handler_renders_existing_schedule() {
-        with_temp_home(|| {
+        with_temp_home("opengoose-routes-pages-home", || {
             save_team("ops");
             let db = Arc::new(Database::open_in_memory().expect("db should open"));
             ScheduleStore::new(db.clone())
@@ -764,60 +1039,77 @@ mod tests {
                 )
                 .expect("schedule should seed");
 
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("runtime should build")
-                .block_on(async {
-                    let Html(html) = schedules(
-                        State(page_state(db)),
-                        Query(ScheduleQuery {
-                            schedule: Some("nightly-ops".into()),
-                        }),
-                    )
-                    .await
-                    .expect("handler should render");
+            run_async(async {
+                let Html(html) = schedules(
+                    State(page_state(db)),
+                    Query(ScheduleQuery {
+                        schedule: Some("nightly-ops".into()),
+                    }),
+                )
+                .await
+                .expect("handler should render");
 
-                    assert!(html.contains("nightly-ops"));
-                    assert!(html.contains("Recent matching runs"));
-                });
+                assert!(html.contains("nightly-ops"));
+                assert!(html.contains("Recent matching runs"));
+            });
         });
     }
 
     #[test]
     fn schedule_action_creates_schedule_from_form_post() {
-        with_temp_home(|| {
+        with_temp_home("opengoose-routes-pages-home", || {
             save_team("ops");
             let db = Arc::new(Database::open_in_memory().expect("db should open"));
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("runtime should build")
-                .block_on(async {
-                    let Html(html) = schedule_action(
-                        State(page_state(db.clone())),
-                        Form(ScheduleActionForm {
-                            intent: "save".into(),
-                            original_name: None,
-                            name: Some("nightly-ops".into()),
-                            cron_expression: Some("0 0 * * * *".into()),
-                            team_name: Some("ops".into()),
-                            input: Some(String::new()),
-                            enabled: Some("yes".into()),
-                            confirm_delete: None,
-                        }),
-                    )
-                    .await
-                    .expect("save action should render");
+            run_async(async {
+                let Html(html) = schedule_action(
+                    State(page_state(db.clone())),
+                    Form(ScheduleActionForm {
+                        intent: "save".into(),
+                        original_name: None,
+                        name: Some("nightly-ops".into()),
+                        cron_expression: Some("0 0 * * * *".into()),
+                        team_name: Some("ops".into()),
+                        input: Some(String::new()),
+                        enabled: Some("yes".into()),
+                        confirm_delete: None,
+                    }),
+                )
+                .await
+                .expect("save action should render");
 
-                    assert!(html.contains("Schedule created."));
-                    assert!(
-                        ScheduleStore::new(db)
-                            .get_by_name("nightly-ops")
-                            .expect("lookup should succeed")
-                            .is_some()
-                    );
-                });
+                assert!(html.contains("Schedule created."));
+                assert!(
+                    ScheduleStore::new(db)
+                        .get_by_name("nightly-ops")
+                        .expect("lookup should succeed")
+                        .is_some()
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn schedule_action_unsupported_intent_returns_bad_request() {
+        with_temp_home("opengoose-routes-pages-home", || {
+            run_async(async {
+                let response = router(page_state(Arc::new(
+                    Database::open_in_memory().expect("db should open"),
+                )))
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/schedules")
+                        .header("content-type", "application/x-www-form-urlencoded")
+                        .body(Body::from("intent=unsupported"))
+                        .unwrap(),
+                )
+                .await
+                .expect("request should be handled");
+
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+                let html = read_body(response).await;
+                assert!(html.contains("Unsupported schedule action."));
+            });
         });
     }
 

--- a/crates/opengoose-web/src/test_support.rs
+++ b/crates/opengoose-web/src/test_support.rs
@@ -1,0 +1,28 @@
+use std::sync::Mutex;
+
+static HOME_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) fn with_temp_home(prefix: &str, test: impl FnOnce()) {
+    let _guard = HOME_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let temp_home = std::env::temp_dir().join(format!("{prefix}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&temp_home);
+    std::fs::create_dir_all(&temp_home).expect("temp home should be created");
+    let saved_home = std::env::var("HOME").ok();
+
+    unsafe {
+        std::env::set_var("HOME", &temp_home);
+    }
+
+    test();
+
+    unsafe {
+        match saved_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    let _ = std::fs::remove_dir_all(temp_home);
+}


### PR DESCRIPTION
## Summary
- add route-level coverage for all page GET routes and both page POST handlers in `routes/pages.rs`
- add handler coverage for mock preview, invalid selection fallback, and schedule/team error paths
- introduce a shared `HOME` test helper so page and schedule tests serialize temp-home usage safely

## Verification
- cargo fmt --all
- cargo clippy --all-targets
- cargo test

## Paperclip
- OPE-190: http://localhost:3131/OPE/issues/OPE-190
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/119" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
