### PR TITLE
fix: isolate web API router tests [OPE-203]

### DIFF
--- a/crates/opengoose-tui/src/app/event_handler/reducer_tests.rs
+++ b/crates/opengoose-tui/src/app/event_handler/reducer_tests.rs
@@ -114,7 +114,7 @@ fn test_apply_session_and_team_events_update_collections() {
             session_key: session_key.clone(),
         },
     );
-    assert!(app.active_teams.get(&session_key).is_none());
+    assert!(!app.active_teams.contains_key(&session_key));
 }
 
 #[test]

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -394,6 +394,7 @@ mod tests {
 
     use crate::handlers;
     use crate::handlers::dashboard::get_dashboard;
+    use crate::handlers::test_support::make_state;
     use crate::routes::health::{
         MetricsResponse, QueueMetrics, RunMetrics, SessionMetrics, health as health_handler,
     };
@@ -406,9 +407,8 @@ mod tests {
         http::{Method, Request, StatusCode, Uri},
         routing::{get, post},
     };
-    use opengoose_persistence::{Database, RunStatus};
+    use opengoose_persistence::RunStatus;
     use serde_json::Value;
-    use std::sync::Arc;
     use tower::ServiceExt;
 
     async fn api_metrics(
@@ -463,7 +463,7 @@ mod tests {
     }
 
     fn api_router() -> Router {
-        let state = AppState::new(Arc::new(Database::open_in_memory().unwrap())).unwrap();
+        let state = make_state();
 
         Router::new()
             .route("/api/health", get(health_handler))
@@ -639,7 +639,7 @@ mod tests {
     // ── Full API router (includes alerts + fallback) ──────────────────────
 
     fn full_api_router() -> Router {
-        let state = AppState::new(Arc::new(Database::open_in_memory().unwrap())).unwrap();
+        let state = make_state();
 
         Router::new()
             .route("/api/health", get(health_handler))


### PR DESCRIPTION
## Summary
- switch the `opengoose-web` test router helpers to the existing temp-dir-backed test state
- keep the new OpenAPI coverage green by removing user-home store dependence from API router tests
- address the remaining `clippy` warning in the new TUI reducer tests

## Verification
- cargo fmt --all --check
- cargo clippy --all-targets
- cargo test

## Issue
- OPE-203
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
