### PR TITLE
feat: Add alerts management page [OPE-218]

### DIFF
--- a/crates/opengoose-cli/tests/auth_cli.rs
+++ b/crates/opengoose-cli/tests/auth_cli.rs
@@ -79,7 +79,7 @@ fn auth_list_json_reports_local_provider_ready() {
     let providers = body["providers"].as_array().unwrap();
     let local = providers
         .iter()
-        .find(|provider| provider["name"] == Value::from("local"))
+        .find(|provider| provider["name"] == "local")
         .expect("local provider should be listed");
     assert_eq!(local["display_name"], Value::from("Local Inference"));
     assert_eq!(local["auth"], Value::from("none"));

--- a/crates/opengoose-tui/src/app/credential_flow/tests/flow.rs
+++ b/crates/opengoose-tui/src/app/credential_flow/tests/flow.rs
@@ -208,7 +208,9 @@ fn test_advance_credential_flow_without_remaining_keys_stores_and_resets() {
         default: None,
     });
     app.credential_flow.current_key = 1;
-    app.credential_flow.collected.push(("TEST_KEY".into(), "abc".into()));
+    app.credential_flow
+        .collected
+        .push(("TEST_KEY".into(), "abc".into()));
     app.secret_input.visible = true;
     app.secret_input.input = "temporary".into();
     app.secret_input.title = Some("title".into());
@@ -224,5 +226,8 @@ fn test_advance_credential_flow_without_remaining_keys_stores_and_resets() {
         store.secrets.lock().unwrap().get("test_key"),
         Some(&"abc".into())
     );
-    assert_eq!(app.events.back().unwrap().summary, "Authenticated with Test Provider.");
+    assert_eq!(
+        app.events.back().unwrap().summary,
+        "Authenticated with Test Provider."
+    );
 }

--- a/crates/opengoose-tui/src/app/credential_flow/tests/persistence.rs
+++ b/crates/opengoose-tui/src/app/credential_flow/tests/persistence.rs
@@ -127,7 +127,13 @@ fn test_save_credential_and_advance_through_multiple_keys() {
         secrets.get("openai_base_url"),
         Some(&"https://api.openai.com".into())
     );
-    assert!(app.events.back().unwrap().summary.contains("Authenticated with OpenAI."));
+    assert!(
+        app.events
+            .back()
+            .unwrap()
+            .summary
+            .contains("Authenticated with OpenAI.")
+    );
 }
 
 #[test]

--- a/crates/opengoose-tui/src/app/state_tests.rs
+++ b/crates/opengoose-tui/src/app/state_tests.rs
@@ -285,10 +285,15 @@ fn test_initialize_runtime_state_handles_db_open() {
     app.initialize_runtime_state();
 
     if app.session_store.is_none() {
-        let notice = app.status_notice.as_ref().expect("db open failure should set notice");
+        let notice = app
+            .status_notice
+            .as_ref()
+            .expect("db open failure should set notice");
         assert_eq!(notice.level, EventLevel::Error);
         assert!(
-            notice.message.starts_with("Session history is unavailable:")
+            notice
+                .message
+                .starts_with("Session history is unavailable:")
         );
     } else {
         assert!(app.status_notice.is_none());

--- a/crates/opengoose-web/assets/app.css
+++ b/crates/opengoose-web/assets/app.css
@@ -189,7 +189,8 @@ a {
 .nav-link,
 .theme-toggle,
 .primary-button,
-.secondary-button {
+.secondary-button,
+.danger-button {
   border: 1px solid var(--line);
   background: var(--surface);
   color: var(--text);
@@ -201,9 +202,15 @@ a {
 .nav-link:hover,
 .theme-toggle:hover,
 .primary-button:hover,
-.secondary-button:hover {
+.secondary-button:hover,
+.danger-button:hover {
   transform: translateY(-1px);
   border-color: rgba(255, 255, 255, 0.25);
+}
+
+.danger-button {
+  border-color: color-mix(in srgb, var(--rose) 45%, var(--line));
+  background: color-mix(in srgb, var(--rose) 14%, var(--surface));
 }
 
 .nav-link.is-active {
@@ -810,9 +817,16 @@ button:disabled {
   gap: 0.8rem;
 }
 
+.alert-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+}
+
 .schedule-head-actions,
 .schedule-action-row,
-.schedule-secondary-actions {
+.schedule-secondary-actions,
+.alert-inline-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
@@ -850,7 +864,10 @@ button:disabled {
 
 .schedule-form .control-field input,
 .schedule-form .control-field select,
-.schedule-form .schedule-textarea {
+.schedule-form .schedule-textarea,
+.alert-form .control-field input,
+.alert-form .control-field select,
+.alert-form .alert-textarea {
   width: 100%;
   padding: 0.8rem 0.95rem;
   border-radius: 1rem;
@@ -867,6 +884,14 @@ button:disabled {
   line-height: 1.5;
 }
 
+.alert-form .alert-textarea {
+  min-height: 8rem;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 0.96rem;
+  line-height: 1.5;
+}
+
 .schedule-confirm {
   display: inline-flex;
   align-items: center;
@@ -876,6 +901,15 @@ button:disabled {
 
 .schedule-history {
   margin-top: 1.5rem;
+}
+
+.alert-test-result[hidden],
+.alert-history-table[hidden] {
+  display: none;
+}
+
+.alert-test-result {
+  margin-top: 1rem;
 }
 
 .editor-form textarea {
@@ -1014,7 +1048,8 @@ tr[data-table-row]:focus-visible {
     min-height: 18rem;
   }
 
-  .schedule-form-grid {
+  .schedule-form-grid,
+  .alert-form-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/crates/opengoose-web/assets/app.js
+++ b/crates/opengoose-web/assets/app.js
@@ -1,3 +1,4 @@
+import { initAlertsPage } from "./modules/alerts-page.js";
 import { initDashboardStreams } from "./modules/dashboard-stream.js";
 import { initListShells } from "./modules/list-shell.js";
 import { initLiveEvents } from "./modules/live-events.js";
@@ -9,6 +10,7 @@ import { initWorkflowTriggers } from "./modules/workflow-trigger.js";
 initTheme(document);
 initListShells(document);
 initTableShells(document);
+initAlertsPage(document);
 initDashboardStreams(document);
 initLiveEvents(document);
 initRemoteAgentActions(document);

--- a/crates/opengoose-web/assets/modules/alerts-page.js
+++ b/crates/opengoose-web/assets/modules/alerts-page.js
@@ -1,0 +1,266 @@
+const JSON_HEADERS = {
+  accept: "application/json",
+  "content-type": "application/json",
+};
+
+const metricLabel = (metric) => {
+  switch (metric) {
+    case "queue_backlog":
+      return "Queue backlog";
+    case "failed_runs":
+      return "Failed runs";
+    case "error_rate":
+      return "Error runs";
+    default:
+      return String(metric || "");
+  }
+};
+
+const formatValue = (value) => {
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return String(value ?? "");
+  return Number.isInteger(numeric) ? `${numeric}` : numeric.toFixed(2);
+};
+
+const readPayload = async (response) => response.json().catch(() => ({}));
+
+const readErrorMessage = (response, payload) =>
+  payload?.error || `${response.status} ${response.statusText}`.trim();
+
+const setStatus = (element, message) => {
+  if (element) {
+    element.textContent = message;
+  }
+};
+
+const buildHistoryRow = (entry) => {
+  const row = document.createElement("tr");
+  row.setAttribute("data-table-row", "");
+
+  const ruleCell = document.createElement("td");
+  const ruleLink = document.createElement("a");
+  ruleLink.href = `/alerts?alert=${encodeURIComponent(entry.rule_name || "")}`;
+  ruleLink.textContent = entry.rule_name || "Unknown rule";
+  ruleCell.append(ruleLink);
+
+  const metricCell = document.createElement("td");
+  metricCell.textContent = metricLabel(entry.metric);
+
+  const valueCell = document.createElement("td");
+  valueCell.textContent = formatValue(entry.value);
+
+  const triggeredAtCell = document.createElement("td");
+  triggeredAtCell.textContent = entry.triggered_at || "";
+
+  row.append(ruleCell, metricCell, valueCell, triggeredAtCell);
+  return row;
+};
+
+const renderTestResult = (root, payload) => {
+  const container = root.querySelector("[data-alert-test-result]");
+  if (!container) return;
+
+  const triggered = Array.isArray(payload?.triggered) ? payload.triggered : [];
+  const metrics = payload?.metrics || {};
+
+  const headline = document.createElement("strong");
+  headline.textContent = triggered.length
+    ? `${triggered.length} rule(s) triggered in the latest snapshot.`
+    : "Snapshot complete. No rules triggered.";
+
+  const snapshot = document.createElement("p");
+  snapshot.textContent = `Queue backlog ${formatValue(
+    metrics.queue_backlog
+  )} · Failed runs ${formatValue(metrics.failed_runs)} · Error runs ${formatValue(
+    metrics.error_rate
+  )}`;
+
+  container.hidden = false;
+  if (triggered.length) {
+    const detail = document.createElement("p");
+    detail.textContent = `Triggered rules: ${triggered.join(", ")}`;
+    container.replaceChildren(headline, snapshot, detail);
+  } else {
+    container.replaceChildren(headline, snapshot);
+  }
+};
+
+const refreshHistory = async (root) => {
+  const url = root.dataset.alertHistoryUrl;
+  const body = root.querySelector("[data-alert-history-body]");
+  const table = root.querySelector("[data-alert-history-table]");
+  const empty = root.querySelector("[data-alert-history-empty]");
+  if (!url || !body || !table || !empty) return;
+
+  const response = await fetch(url, { headers: { accept: "application/json" } });
+  const payload = await readPayload(response);
+  if (!response.ok) {
+    throw new Error(readErrorMessage(response, payload));
+  }
+
+  const entries = Array.isArray(payload) ? payload : [];
+  body.replaceChildren(...entries.map(buildHistoryRow));
+  table.hidden = entries.length === 0;
+  empty.hidden = entries.length !== 0;
+};
+
+const bindCreateForm = (root, form) => {
+  if (form.dataset.alertCreateBound === "true") return;
+  form.dataset.alertCreateBound = "true";
+
+  const status = form.querySelector("[data-alert-create-status]");
+  const submit = form.querySelector("button[type='submit']");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const data = new FormData(form);
+    const name = String(data.get("name") || "").trim();
+    const description = String(data.get("description") || "").trim();
+    const threshold = Number.parseFloat(String(data.get("threshold") || ""));
+
+    if (!Number.isFinite(threshold)) {
+      setStatus(status, "Threshold must be a finite number.");
+      return;
+    }
+
+    if (submit) submit.disabled = true;
+    setStatus(status, "Creating alert rule…");
+
+    try {
+      const response = await fetch(form.dataset.createUrl || "/api/alerts", {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          name,
+          description: description || null,
+          metric: String(data.get("metric") || ""),
+          condition: String(data.get("condition") || ""),
+          threshold,
+        }),
+      });
+      const payload = await readPayload(response);
+      if (!response.ok) {
+        throw new Error(readErrorMessage(response, payload));
+      }
+
+      setStatus(status, `Alert ${payload.name || name} created. Redirecting…`);
+      window.location.assign(`/alerts?alert=${encodeURIComponent(payload.name || name)}`);
+    } catch (error) {
+      setStatus(
+        status,
+        error instanceof Error ? error.message : "Alert creation failed."
+      );
+    } finally {
+      if (submit) submit.disabled = false;
+    }
+  });
+};
+
+const bindDeleteForm = (form) => {
+  if (form.dataset.alertDeleteBound === "true") return;
+  form.dataset.alertDeleteBound = "true";
+
+  const status = form.querySelector("[data-alert-delete-status]");
+  const confirm = form.querySelector("[data-alert-delete-confirm]");
+  const submit = form.querySelector("button[type='submit']");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    if (confirm && !confirm.checked) {
+      setStatus(status, "Confirm deletion before removing this rule.");
+      return;
+    }
+
+    if (submit) submit.disabled = true;
+    setStatus(status, "Deleting alert rule…");
+
+    try {
+      const response = await fetch(form.dataset.deleteUrl || "", {
+        method: "DELETE",
+        headers: { accept: "application/json" },
+      });
+      const payload = await readPayload(response);
+      if (!response.ok) {
+        throw new Error(readErrorMessage(response, payload));
+      }
+
+      setStatus(status, "Alert deleted. Redirecting…");
+      window.location.assign("/alerts");
+    } catch (error) {
+      setStatus(
+        status,
+        error instanceof Error ? error.message : "Alert deletion failed."
+      );
+    } finally {
+      if (submit) submit.disabled = false;
+    }
+  });
+};
+
+const bindTestButtons = (root) => {
+  const buttons = Array.from(root.querySelectorAll("[data-alert-run-test]"));
+  if (!buttons.length) return;
+
+  buttons.forEach((button) => {
+    if (button.dataset.alertTestBound === "true") return;
+    button.dataset.alertTestBound = "true";
+
+    button.addEventListener("click", async () => {
+      const status = root.querySelector("[data-alert-test-status]");
+      buttons.forEach((candidate) => {
+        candidate.disabled = true;
+      });
+      setStatus(status, "Running alert snapshot…");
+
+      try {
+        const response = await fetch(button.dataset.testUrl || "/api/alerts/test", {
+          method: "POST",
+          headers: { accept: "application/json" },
+        });
+        const payload = await readPayload(response);
+        if (!response.ok) {
+          throw new Error(readErrorMessage(response, payload));
+        }
+
+        const triggered = Array.isArray(payload.triggered) ? payload.triggered : [];
+        setStatus(
+          status,
+          triggered.length
+            ? `Triggered: ${triggered.join(", ")}`
+            : "No enabled rules triggered."
+        );
+        renderTestResult(root, payload);
+        try {
+          await refreshHistory(root);
+        } catch (refreshError) {
+          setStatus(
+            status,
+            refreshError instanceof Error
+              ? `Snapshot recorded, but history refresh failed: ${refreshError.message}`
+              : "Snapshot recorded, but history refresh failed."
+          );
+        }
+      } catch (error) {
+        setStatus(
+          status,
+          error instanceof Error ? error.message : "Alert test failed."
+        );
+      } finally {
+        buttons.forEach((candidate) => {
+          candidate.disabled = false;
+        });
+      }
+    });
+  });
+};
+
+export const initAlertsPage = (root = document) => {
+  root.querySelectorAll?.("[data-alerts-page]").forEach((page) => {
+    page
+      .querySelectorAll("[data-alert-create]")
+      .forEach((form) => bindCreateForm(page, form));
+    page.querySelectorAll("[data-alert-delete]").forEach(bindDeleteForm);
+    bindTestButtons(page);
+  });
+};

--- a/crates/opengoose-web/src/data/alerts.rs
+++ b/crates/opengoose-web/src/data/alerts.rs
@@ -1,0 +1,343 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use opengoose_persistence::{AlertCondition, AlertMetric, AlertRule, AlertStore, Database};
+use urlencoding::encode;
+
+use crate::data::views::{
+    AlertDetailView, AlertHistoryItemView, AlertListItem, AlertsPageView, MetaRow, MetricCard,
+    SelectOption,
+};
+
+const DEFAULT_METRIC: &str = "queue_backlog";
+const DEFAULT_CONDITION: &str = "gt";
+
+/// Load the alerts management page view-model, optionally selecting a rule by name.
+pub fn load_alerts_page(db: Arc<Database>, selected: Option<String>) -> Result<AlertsPageView> {
+    let store = AlertStore::new(db);
+    let rules = store.list()?;
+    let history = build_history_rows(&store.history(50)?);
+    let metrics = build_metric_cards(store.current_metrics()?);
+
+    let selected_name = if rules.is_empty() {
+        String::new()
+    } else {
+        selected
+            .filter(|target| rules.iter().any(|rule| &rule.name == target))
+            .unwrap_or_else(|| rules[0].name.clone())
+    };
+    let selected_rule = rules.iter().find(|rule| rule.name == selected_name);
+    let enabled_count = rules.iter().filter(|rule| rule.enabled).count();
+
+    Ok(AlertsPageView {
+        mode_label: if rules.is_empty() {
+            "No alert rules configured".into()
+        } else {
+            format!("{enabled_count} active of {}", rules.len())
+        },
+        mode_tone: if rules.is_empty() {
+            "neutral"
+        } else if enabled_count == 0 {
+            "amber"
+        } else {
+            "success"
+        },
+        metrics,
+        alerts: rules
+            .iter()
+            .map(|rule| build_alert_list_item(rule, &selected_name))
+            .collect(),
+        selected: match selected_rule {
+            Some(rule) => build_alert_detail(rule, history.clone()),
+            None => placeholder_alert_detail(history),
+        },
+        history_api_url: "/api/alerts/history".into(),
+    })
+}
+
+fn build_alert_list_item(rule: &AlertRule, selected_name: &str) -> AlertListItem {
+    let metric_label = format_metric_label(rule.metric.as_str());
+    let condition_label = format_condition_label(rule.condition.as_str());
+
+    AlertListItem {
+        title: rule.name.clone(),
+        subtitle: format!(
+            "{metric_label} {condition_label} {}",
+            format_number(rule.threshold)
+        ),
+        preview: rule
+            .description
+            .clone()
+            .unwrap_or_else(|| format!("Created {}", rule.created_at)),
+        status_label: if rule.enabled {
+            "enabled".into()
+        } else {
+            "disabled".into()
+        },
+        status_tone: if rule.enabled { "success" } else { "neutral" },
+        page_url: format!("/alerts?alert={}", encode(&rule.name)),
+        active: rule.name == selected_name,
+    }
+}
+
+fn build_alert_detail(rule: &AlertRule, history: Vec<AlertHistoryItemView>) -> AlertDetailView {
+    AlertDetailView {
+        title: rule.name.clone(),
+        subtitle: rule.description.clone().unwrap_or_else(|| {
+            format!(
+                "{} {} {}",
+                format_metric_label(rule.metric.as_str()),
+                format_condition_label(rule.condition.as_str()).to_lowercase(),
+                format_number(rule.threshold)
+            )
+        }),
+        meta: vec![
+            MetaRow {
+                label: "Metric".into(),
+                value: format_metric_label(rule.metric.as_str()),
+            },
+            MetaRow {
+                label: "Condition".into(),
+                value: format_condition_label(rule.condition.as_str()),
+            },
+            MetaRow {
+                label: "Threshold".into(),
+                value: format_number(rule.threshold),
+            },
+            MetaRow {
+                label: "Created".into(),
+                value: rule.created_at.clone(),
+            },
+            MetaRow {
+                label: "Updated".into(),
+                value: rule.updated_at.clone(),
+            },
+        ],
+        status_label: if rule.enabled {
+            "enabled".into()
+        } else {
+            "disabled".into()
+        },
+        status_tone: if rule.enabled { "success" } else { "neutral" },
+        delete_api_url: format!("/api/alerts/{}", encode(&rule.name)),
+        test_api_url: "/api/alerts/test".into(),
+        create_api_url: "/api/alerts".into(),
+        metric_options: build_metric_options(DEFAULT_METRIC),
+        condition_options: build_condition_options(DEFAULT_CONDITION),
+        history,
+        history_hint:
+            "No alert rules have fired yet. Run a test snapshot to record the latest results."
+                .into(),
+        is_placeholder: false,
+    }
+}
+
+fn placeholder_alert_detail(history: Vec<AlertHistoryItemView>) -> AlertDetailView {
+    AlertDetailView {
+        title: "No alert rules configured".into(),
+        subtitle: "Create a threshold rule to monitor queue backlog, failed runs, or runtime error volume.".into(),
+        meta: vec![],
+        status_label: "idle".into(),
+        status_tone: "neutral",
+        delete_api_url: String::new(),
+        test_api_url: "/api/alerts/test".into(),
+        create_api_url: "/api/alerts".into(),
+        metric_options: build_metric_options(DEFAULT_METRIC),
+        condition_options: build_condition_options(DEFAULT_CONDITION),
+        history,
+        history_hint: "No alert rules have fired yet. Run a test snapshot to record the latest results.".into(),
+        is_placeholder: true,
+    }
+}
+
+fn build_metric_options(selected: &str) -> Vec<SelectOption> {
+    AlertMetric::variants()
+        .iter()
+        .map(|metric| SelectOption {
+            value: (*metric).into(),
+            label: format_metric_label(metric),
+            selected: *metric == selected,
+        })
+        .collect()
+}
+
+fn build_condition_options(selected: &str) -> Vec<SelectOption> {
+    AlertCondition::variants()
+        .iter()
+        .map(|condition| SelectOption {
+            value: (*condition).into(),
+            label: format_condition_label(condition),
+            selected: *condition == selected,
+        })
+        .collect()
+}
+
+fn build_history_rows(
+    entries: &[opengoose_persistence::AlertHistoryEntry],
+) -> Vec<AlertHistoryItemView> {
+    entries
+        .iter()
+        .map(|entry| AlertHistoryItemView {
+            rule_name: entry.rule_name.clone(),
+            rule_page_url: format!("/alerts?alert={}", encode(&entry.rule_name)),
+            metric_label: format_metric_label(&entry.metric),
+            value_label: format_number(entry.value),
+            triggered_at: entry.triggered_at.clone(),
+        })
+        .collect()
+}
+
+fn build_metric_cards(metrics: opengoose_persistence::SystemMetrics) -> Vec<MetricCard> {
+    vec![
+        MetricCard {
+            label: "Queue backlog".into(),
+            value: format_number(metrics.queue_backlog),
+            note: "Pending or failed queue entries currently waiting on recovery.".into(),
+            tone: "amber",
+        },
+        MetricCard {
+            label: "Failed runs".into(),
+            value: format_number(metrics.failed_runs),
+            note: "Persisted orchestration runs marked as failed.".into(),
+            tone: "rose",
+        },
+        MetricCard {
+            label: "Error runs".into(),
+            value: format_number(metrics.error_rate),
+            note: "Persisted orchestration runs marked as error.".into(),
+            tone: "cyan",
+        },
+    ]
+}
+
+fn format_metric_label(metric: &str) -> String {
+    match metric {
+        "queue_backlog" => "Queue backlog".into(),
+        "failed_runs" => "Failed runs".into(),
+        "error_rate" => "Error runs".into(),
+        other => other.replace('_', " "),
+    }
+}
+
+fn format_condition_label(condition: &str) -> String {
+    match condition {
+        "gt" => "Greater than".into(),
+        "lt" => "Less than".into(),
+        "gte" => "Greater than or equal".into(),
+        "lte" => "Less than or equal".into(),
+        other => other.into(),
+    }
+}
+
+fn format_number(value: f64) -> String {
+    if (value.fract()).abs() < f64::EPSILON {
+        format!("{value:.0}")
+    } else {
+        format!("{value:.2}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_db() -> Arc<Database> {
+        Arc::new(Database::open_in_memory().unwrap())
+    }
+
+    #[test]
+    fn load_alerts_page_without_rules_returns_placeholder() {
+        let page = load_alerts_page(test_db(), None).expect("page should load");
+
+        assert_eq!(page.mode_label, "No alert rules configured");
+        assert_eq!(page.mode_tone, "neutral");
+        assert!(page.alerts.is_empty());
+        assert!(page.selected.is_placeholder);
+        assert_eq!(page.metrics.len(), 3);
+    }
+
+    #[test]
+    fn load_alerts_page_selects_named_rule_and_builds_history_links() {
+        let db = test_db();
+        let store = AlertStore::new(db.clone());
+        let first = store
+            .create(
+                "backlog-high",
+                Some("Queue pressure is rising"),
+                &AlertMetric::QueueBacklog,
+                &AlertCondition::GreaterThan,
+                10.0,
+                &[],
+            )
+            .unwrap();
+        let second = store
+            .create(
+                "errors-high",
+                None,
+                &AlertMetric::ErrorRate,
+                &AlertCondition::GreaterThanOrEqual,
+                2.0,
+                &[],
+            )
+            .unwrap();
+        store.record_trigger(&first, 12.0).unwrap();
+        store.record_trigger(&second, 3.0).unwrap();
+
+        let page = load_alerts_page(db, Some("errors-high".into())).expect("page should load");
+
+        assert_eq!(page.mode_label, "2 active of 2");
+        assert_eq!(page.selected.title, "errors-high");
+        assert_eq!(page.selected.status_tone, "success");
+        assert_eq!(page.selected.history.len(), 2);
+        assert_eq!(page.selected.history[0].rule_name, "errors-high");
+        assert_eq!(
+            page.selected.history[0].rule_page_url,
+            "/alerts?alert=errors-high"
+        );
+    }
+
+    #[test]
+    fn load_alerts_page_invalid_selection_falls_back_to_first_rule() {
+        let db = test_db();
+        let store = AlertStore::new(db.clone());
+        store
+            .create(
+                "only-rule",
+                None,
+                &AlertMetric::FailedRuns,
+                &AlertCondition::GreaterThan,
+                5.0,
+                &[],
+            )
+            .unwrap();
+
+        let page = load_alerts_page(db, Some("missing-rule".into())).expect("page should load");
+
+        assert_eq!(page.selected.title, "only-rule");
+    }
+
+    #[test]
+    fn load_alerts_page_reports_disabled_rules_in_mode_label() {
+        let db = test_db();
+        let store = AlertStore::new(db.clone());
+        store
+            .create(
+                "queue-watch",
+                None,
+                &AlertMetric::QueueBacklog,
+                &AlertCondition::GreaterThan,
+                5.0,
+                &[],
+            )
+            .unwrap();
+        store
+            .set_enabled("queue-watch", false)
+            .expect("rule should toggle");
+
+        let page = load_alerts_page(db, None).expect("page should load");
+
+        assert_eq!(page.mode_label, "0 active of 1");
+        assert_eq!(page.mode_tone, "amber");
+        assert_eq!(page.alerts[0].status_label, "disabled");
+    }
+}

--- a/crates/opengoose-web/src/data/mod.rs
+++ b/crates/opengoose-web/src/data/mod.rs
@@ -1,4 +1,5 @@
 mod agents;
+mod alerts;
 mod dashboard;
 mod queue;
 mod remote_agents;
@@ -13,6 +14,7 @@ mod views;
 mod workflows;
 
 pub use agents::{load_agent_detail, load_agents_page};
+pub use alerts::load_alerts_page;
 pub use dashboard::load_dashboard;
 pub use queue::{load_queue_detail, load_queue_page};
 pub use remote_agents::load_remote_agents_page;

--- a/crates/opengoose-web/src/data/views/mod.rs
+++ b/crates/opengoose-web/src/data/views/mod.rs
@@ -317,6 +317,59 @@ pub struct WorkflowsPageView {
     pub selected: WorkflowDetailView,
 }
 
+// ── Alert types ──────────────────────────────────────────────────────────────
+
+/// Summary row for the alert rule list sidebar.
+#[derive(Clone)]
+pub struct AlertListItem {
+    pub title: String,
+    pub subtitle: String,
+    pub preview: String,
+    pub status_label: String,
+    pub status_tone: &'static str,
+    pub page_url: String,
+    pub active: bool,
+}
+
+/// A single row in the recent alert history table.
+#[derive(Clone)]
+pub struct AlertHistoryItemView {
+    pub rule_name: String,
+    pub rule_page_url: String,
+    pub metric_label: String,
+    pub value_label: String,
+    pub triggered_at: String,
+}
+
+/// Full detail/action panel for a selected alert rule.
+#[derive(Clone)]
+pub struct AlertDetailView {
+    pub title: String,
+    pub subtitle: String,
+    pub meta: Vec<MetaRow>,
+    pub status_label: String,
+    pub status_tone: &'static str,
+    pub delete_api_url: String,
+    pub test_api_url: String,
+    pub create_api_url: String,
+    pub metric_options: Vec<SelectOption>,
+    pub condition_options: Vec<SelectOption>,
+    pub history: Vec<AlertHistoryItemView>,
+    pub history_hint: String,
+    pub is_placeholder: bool,
+}
+
+/// View-model for the alerts page (list + selected detail).
+#[derive(Clone)]
+pub struct AlertsPageView {
+    pub mode_label: String,
+    pub mode_tone: &'static str,
+    pub metrics: Vec<MetricCard>,
+    pub alerts: Vec<AlertListItem>,
+    pub selected: AlertDetailView,
+    pub history_api_url: String,
+}
+
 // ── Trigger types ────────────────────────────────────────────────────────────
 
 /// Summary row for the trigger list sidebar.

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -62,11 +62,12 @@ pub async fn serve(options: WebOptions) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use crate::data::{
-        ActivityItem, AlertCard, DashboardView, MessageBubble, MetaRow, MetricCard, Notice,
-        QueueDetailView, QueueMessageView, RunListItem, ScheduleEditorView, ScheduleHistoryItem,
-        ScheduleListItem, SchedulesPageView, SelectOption, SessionDetailView, SessionListItem,
-        SessionsPageView, StatusSegment, TrendBar, WorkflowAutomationView, WorkflowDetailView,
-        WorkflowListItem, WorkflowRunView, WorkflowStepView, WorkflowsPageView,
+        ActivityItem, AlertCard, AlertDetailView, AlertHistoryItemView, AlertListItem,
+        AlertsPageView, DashboardView, MessageBubble, MetaRow, MetricCard, Notice, QueueDetailView,
+        QueueMessageView, RunListItem, ScheduleEditorView, ScheduleHistoryItem, ScheduleListItem,
+        SchedulesPageView, SelectOption, SessionDetailView, SessionListItem, SessionsPageView,
+        StatusSegment, TrendBar, WorkflowAutomationView, WorkflowDetailView, WorkflowListItem,
+        WorkflowRunView, WorkflowStepView, WorkflowsPageView,
     };
     use crate::routes;
 
@@ -274,6 +275,47 @@ mod tests {
         }
     }
 
+    fn sample_alert_detail() -> AlertDetailView {
+        AlertDetailView {
+            title: "queue-backlog-high".into(),
+            subtitle: "Queue backlog is climbing faster than workers recover.".into(),
+            meta: vec![
+                MetaRow {
+                    label: "Metric".into(),
+                    value: "Queue backlog".into(),
+                },
+                MetaRow {
+                    label: "Condition".into(),
+                    value: "Greater than".into(),
+                },
+            ],
+            status_label: "enabled".into(),
+            status_tone: "success",
+            delete_api_url: "/api/alerts/queue-backlog-high".into(),
+            test_api_url: "/api/alerts/test".into(),
+            create_api_url: "/api/alerts".into(),
+            metric_options: vec![SelectOption {
+                value: "queue_backlog".into(),
+                label: "Queue backlog".into(),
+                selected: true,
+            }],
+            condition_options: vec![SelectOption {
+                value: "gt".into(),
+                label: "Greater than".into(),
+                selected: true,
+            }],
+            history: vec![AlertHistoryItemView {
+                rule_name: "queue-backlog-high".into(),
+                rule_page_url: "/alerts?alert=queue-backlog-high".into(),
+                metric_label: "Queue backlog".into(),
+                value_label: "18".into(),
+                triggered_at: "2026-03-10 12:40".into(),
+            }],
+            history_hint: "No alert rules have fired yet.".into(),
+            is_placeholder: false,
+        }
+    }
+
     #[test]
     fn dashboard_live_template_renders_monitoring_sections() {
         let html = routes::test_support::render_dashboard_live(sample_dashboard())
@@ -390,6 +432,44 @@ mod tests {
         assert!(html.contains("data-workflow-trigger"));
         assert!(html.contains("/api/workflows/feature-dev/trigger"));
         assert!(html.contains("Recent runs"));
+    }
+
+    #[test]
+    fn alerts_template_renders_api_driven_controls_and_history() {
+        let detail = sample_alert_detail();
+        let detail_html = routes::test_support::render_alert_detail(detail.clone())
+            .expect("alert detail renders");
+        let html = routes::test_support::render_alerts_page(
+            AlertsPageView {
+                mode_label: "1 active of 1".into(),
+                mode_tone: "success",
+                metrics: vec![MetricCard {
+                    label: "Queue backlog".into(),
+                    value: "18".into(),
+                    note: "Pending or failed queue entries currently waiting on recovery.".into(),
+                    tone: "amber",
+                }],
+                alerts: vec![AlertListItem {
+                    title: "queue-backlog-high".into(),
+                    subtitle: "Queue backlog Greater than 10".into(),
+                    preview: "Queue backlog is climbing faster than workers recover.".into(),
+                    status_label: "enabled".into(),
+                    status_tone: "success",
+                    page_url: "/alerts?alert=queue-backlog-high".into(),
+                    active: true,
+                }],
+                selected: detail,
+                history_api_url: "/api/alerts/history".into(),
+            },
+            detail_html,
+        )
+        .expect("alerts template renders");
+
+        assert!(html.contains("Search alerts"));
+        assert!(html.contains("data-alerts-page"));
+        assert!(html.contains("data-alert-create"));
+        assert!(html.contains("/api/alerts/test"));
+        assert!(html.contains("Recent trigger history"));
     }
 
     use crate::handlers;

--- a/crates/opengoose-web/src/routes/pages.rs
+++ b/crates/opengoose-web/src/routes/pages.rs
@@ -16,13 +16,14 @@ use serde::Deserialize;
 
 use super::{PartialResult, WebResult, internal_error, render_partial, render_template};
 use crate::data::{
-    AgentDetailView, AgentsPageView, DashboardView, QueueDetailView, QueuePageView,
-    RemoteAgentsPageView, RunDetailView, RunsPageView, ScheduleEditorView, ScheduleSaveInput,
-    SchedulesPageView, SessionDetailView, SessionsPageView, TeamEditorView, TeamsPageView,
-    TriggerDetailView, TriggersPageView, WorkflowDetailView, WorkflowsPageView, delete_schedule,
-    load_agents_page, load_dashboard, load_queue_page, load_remote_agents_page, load_runs_page,
-    load_schedules_page, load_sessions_page, load_teams_page, load_triggers_page,
-    load_workflows_page, save_schedule, save_team_yaml, toggle_schedule,
+    AgentDetailView, AgentsPageView, AlertDetailView, AlertsPageView, DashboardView,
+    QueueDetailView, QueuePageView, RemoteAgentsPageView, RunDetailView, RunsPageView,
+    ScheduleEditorView, ScheduleSaveInput, SchedulesPageView, SessionDetailView, SessionsPageView,
+    TeamEditorView, TeamsPageView, TriggerDetailView, TriggersPageView, WorkflowDetailView,
+    WorkflowsPageView, delete_schedule, load_agents_page, load_alerts_page, load_dashboard,
+    load_queue_page, load_remote_agents_page, load_runs_page, load_schedules_page,
+    load_sessions_page, load_teams_page, load_triggers_page, load_workflows_page, save_schedule,
+    save_team_yaml, toggle_schedule,
 };
 use crate::server::PageState;
 
@@ -61,6 +62,11 @@ pub(crate) struct TriggerQuery {
     trigger: Option<String>,
 }
 
+#[derive(Deserialize, Default)]
+pub(crate) struct AlertQuery {
+    alert: Option<String>,
+}
+
 #[derive(Deserialize)]
 pub(crate) struct TeamSaveForm {
     original_name: String,
@@ -91,6 +97,7 @@ pub(crate) fn router(state: PageState) -> Router {
         .route("/workflows", get(workflows))
         .route("/schedules", get(schedules).post(schedule_action))
         .route("/triggers", get(triggers))
+        .route("/alerts", get(alerts))
         .route("/teams", get(teams).post(team_save))
         .route("/queue", get(queue))
         .with_state(state)
@@ -314,6 +321,23 @@ pub(crate) async fn triggers(
     render_template(&TriggersTemplate {
         page_title: "Triggers",
         current_nav: "triggers",
+        page,
+        detail_html,
+    })
+}
+
+pub(crate) async fn alerts(
+    State(state): State<PageState>,
+    Query(query): Query<AlertQuery>,
+) -> WebResult {
+    let page = load_alerts_page(state.db, query.alert).map_err(internal_error)?;
+    let detail_html = render_partial(&AlertDetailTemplate {
+        detail: page.selected.clone(),
+    })?;
+
+    render_template(&AlertsTemplate {
+        page_title: "Alerts",
+        current_nav: "alerts",
         page,
         detail_html,
     })
@@ -586,6 +610,21 @@ struct TriggerDetailTemplate {
 }
 
 #[derive(Template)]
+#[template(path = "alerts.html")]
+struct AlertsTemplate {
+    page_title: &'static str,
+    current_nav: &'static str,
+    page: AlertsPageView,
+    detail_html: String,
+}
+
+#[derive(Template)]
+#[template(path = "partials/alert_detail.html")]
+struct AlertDetailTemplate {
+    detail: AlertDetailView,
+}
+
+#[derive(Template)]
 #[template(path = "teams.html")]
 struct TeamsTemplate {
     page_title: &'static str,
@@ -619,8 +658,9 @@ struct QueueDetailTemplate {
 pub(crate) mod test_support {
     use super::*;
     use crate::data::{
-        DashboardView, QueueDetailView, ScheduleEditorView, SchedulesPageView, SessionDetailView,
-        SessionsPageView, WorkflowDetailView, WorkflowsPageView,
+        AlertDetailView, AlertsPageView, DashboardView, QueueDetailView, ScheduleEditorView,
+        SchedulesPageView, SessionDetailView, SessionsPageView, WorkflowDetailView,
+        WorkflowsPageView,
     };
 
     pub(crate) fn render_dashboard_live(dashboard: DashboardView) -> PartialResult {
@@ -678,6 +718,19 @@ pub(crate) mod test_support {
             detail_html,
         })
     }
+
+    pub(crate) fn render_alert_detail(detail: AlertDetailView) -> PartialResult {
+        render_partial(&AlertDetailTemplate { detail })
+    }
+
+    pub(crate) fn render_alerts_page(page: AlertsPageView, detail_html: String) -> PartialResult {
+        render_partial(&AlertsTemplate {
+            page_title: "Alerts",
+            current_nav: "alerts",
+            page,
+            detail_html,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -688,7 +741,7 @@ mod tests {
     use axum::body::{Body, to_bytes};
     use axum::http::{Method, Request};
     use opengoose_persistence::{
-        Database, OrchestrationStore, ScheduleStore, SessionStore, TriggerStore,
+        AlertStore, Database, OrchestrationStore, ScheduleStore, SessionStore, TriggerStore,
     };
     use opengoose_teams::remote::{RemoteAgentRegistry, RemoteConfig};
     use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore};
@@ -787,6 +840,7 @@ mod tests {
                     "/workflows",
                     "/schedules",
                     "/triggers",
+                    "/alerts",
                     "/teams",
                     "/queue",
                 ] {
@@ -958,6 +1012,35 @@ mod tests {
         assert!(html.contains("1 trigger(s)"));
         assert!(html.contains("incoming"));
         assert!(html.contains("webhook_received"));
+    }
+
+    #[tokio::test]
+    async fn alerts_handler_invalid_selection_falls_back_to_existing_alert() {
+        let db = Arc::new(Database::open_in_memory().expect("db should open"));
+        AlertStore::new(db.clone())
+            .create(
+                "queue-watch",
+                Some("Queue backlog exceeded"),
+                &opengoose_persistence::AlertMetric::QueueBacklog,
+                &opengoose_persistence::AlertCondition::GreaterThan,
+                10.0,
+                &[],
+            )
+            .expect("alert should seed");
+
+        let Html(html) = alerts(
+            State(page_state(db)),
+            Query(AlertQuery {
+                alert: Some("missing-alert".into()),
+            }),
+        )
+        .await
+        .expect("handler should render");
+
+        assert!(html.contains("1 active of 1"));
+        assert!(html.contains("queue-watch"));
+        assert!(html.contains("Queue backlog"));
+        assert!(html.contains("Recent trigger history"));
     }
 
     #[tokio::test]

--- a/crates/opengoose-web/templates/alerts.html
+++ b/crates/opengoose-web/templates/alerts.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="page-intro">
+  <div>
+    <p class="eyebrow">Alerts</p>
+    <h1>Manage threshold rules, test live conditions, and inspect recent trigger history.</h1>
+  </div>
+  <span class="chip tone-{{ page.mode_tone }}">{{ page.mode_label }}</span>
+</section>
+
+<section class="metric-grid">
+  {% for metric in page.metrics %}
+  <article class="metric-card tone-{{ metric.tone }}">
+    <p class="metric-label">{{ metric.label }}</p>
+    <strong class="metric-value">{{ metric.value }}</strong>
+    <p class="metric-note">{{ metric.note }}</p>
+  </article>
+  {% endfor %}
+</section>
+
+<section class="detail-shell" data-alerts-page data-alert-history-url="{{ page.history_api_url }}">
+  <aside class="rail-panel panel" data-list-shell data-list-label="alerts">
+    <div class="list-toolbar" role="search" aria-label="Filter alerts">
+      <div class="control-row">
+        <label class="control-field control-field-search">
+          <span>Search alerts</span>
+          <input type="search" placeholder="Name, metric, description" autocomplete="off" data-list-search>
+        </label>
+        <label class="control-field control-field-compact">
+          <span>Page size</span>
+          <select data-list-page-size>
+            <option value="6">6</option>
+            <option value="8" selected>8</option>
+            <option value="12">12</option>
+          </select>
+        </label>
+      </div>
+      <p class="list-status" data-list-status role="status" aria-live="polite"></p>
+    </div>
+    <p class="empty-hint empty-hint-inline" data-list-empty hidden>No alerts match the current filter.</p>
+    <nav class="rail-list" data-list aria-label="Alert rule list">
+    {% for alert in page.alerts %}
+    <a
+      href="{{ alert.page_url }}"
+      class="rail-item{% if alert.active %} is-active{% endif %}"
+      {% if alert.active %}aria-current="page"{% endif %}
+      data-list-item
+      data-search="{{ alert.title }} {{ alert.subtitle }} {{ alert.preview }} {{ alert.status_label }}"
+    >
+      <div>
+        <p class="rail-title">{{ alert.title }}</p>
+        <p class="rail-subtitle">{{ alert.subtitle }}</p>
+      </div>
+      <div class="rail-meta">
+        <span class="chip tone-{{ alert.status_tone }}">{{ alert.status_label }}</span>
+      </div>
+      <p class="rail-preview">{{ alert.preview }}</p>
+    </a>
+    {% endfor %}
+    </nav>
+    <div class="pager" data-list-pagination>
+      <button class="secondary-button" type="button" data-list-prev>Previous</button>
+      <p class="pager-label" data-list-page>Page 1 of 1</p>
+      <button class="secondary-button" type="button" data-list-next>Next</button>
+    </div>
+  </aside>
+  <section class="detail-frame">
+    <div id="detail-panel" class="detail-panel" data-detail-panel tabindex="-1" aria-live="polite" aria-busy="false">{{ detail_html|safe }}</div>
+  </section>
+</section>
+{% endblock %}

--- a/crates/opengoose-web/templates/base.html
+++ b/crates/opengoose-web/templates/base.html
@@ -38,6 +38,7 @@
         <a href="/workflows" class="nav-link{% if current_nav == "workflows" %} is-active{% endif %}" {% if current_nav == "workflows" %}aria-current="page"{% endif %}>Workflows</a>
         <a href="/schedules" class="nav-link{% if current_nav == "schedules" %} is-active{% endif %}" {% if current_nav == "schedules" %}aria-current="page"{% endif %}>Schedules</a>
         <a href="/triggers" class="nav-link{% if current_nav == "triggers" %} is-active{% endif %}" {% if current_nav == "triggers" %}aria-current="page"{% endif %}>Triggers</a>
+        <a href="/alerts" class="nav-link{% if current_nav == "alerts" %} is-active{% endif %}" {% if current_nav == "alerts" %}aria-current="page"{% endif %}>Alerts</a>
         <a href="/teams" class="nav-link{% if current_nav == "teams" %} is-active{% endif %}" {% if current_nav == "teams" %}aria-current="page"{% endif %}>Teams</a>
         <a href="/queue" class="nav-link{% if current_nav == "queue" %} is-active{% endif %}" {% if current_nav == "queue" %}aria-current="page"{% endif %}>Queue</a>
       </nav>

--- a/crates/opengoose-web/templates/partials/alert_detail.html
+++ b/crates/opengoose-web/templates/partials/alert_detail.html
@@ -1,0 +1,138 @@
+<section class="detail-card">
+  <div class="detail-head">
+    <div>
+      <p class="eyebrow">Alerts</p>
+      <h2>{{ detail.title }}</h2>
+      <p>{{ detail.subtitle }}</p>
+    </div>
+    <div class="live-chip-row">
+      <span class="chip tone-{{ detail.status_tone }}">{{ detail.status_label }}</span>
+      <button class="secondary-button" type="button" {% if detail.is_placeholder %}disabled{% endif %} data-alert-run-test data-test-url="{{ detail.test_api_url }}">Run test snapshot</button>
+    </div>
+  </div>
+
+  {% if detail.is_placeholder %}
+  <p class="surface-feedback">Alert rules evaluate live queue and run health using the existing alerts API endpoints.</p>
+  {% else %}
+  <dl class="meta-grid">
+    {% for row in detail.meta %}
+    <div class="meta-item">
+      <dt>{{ row.label }}</dt>
+      <dd>{{ row.value }}</dd>
+    </div>
+    {% endfor %}
+  </dl>
+
+  <div class="timeline">
+    <div class="timeline-item">
+      <div>
+        <p class="rail-title">Evaluate all enabled rules</p>
+        <p class="rail-subtitle">Run the same snapshot used by <code>/api/alerts/test</code> and append any new trigger events to history.</p>
+      </div>
+      <div class="alert-inline-actions">
+        <button class="secondary-button" type="button" data-alert-run-test data-test-url="{{ detail.test_api_url }}">Run test</button>
+        <p class="detail-status" data-alert-test-status role="status" aria-live="polite"></p>
+      </div>
+    </div>
+
+    <div class="timeline-item">
+      <div>
+        <p class="rail-title">Delete this rule</p>
+        <p class="rail-subtitle">Remove the selected alert rule while keeping the recorded trigger history.</p>
+      </div>
+      <form class="alert-inline-actions" data-alert-delete data-delete-url="{{ detail.delete_api_url }}">
+        <label class="schedule-confirm">
+          <input type="checkbox" value="yes" data-alert-delete-confirm>
+          <span>Confirm deletion of <strong>{{ detail.title }}</strong></span>
+        </label>
+        <button class="danger-button" type="submit">Delete alert</button>
+        <p class="detail-status" data-alert-delete-status role="status" aria-live="polite"></p>
+      </form>
+    </div>
+  </div>
+
+  <div class="notice tone-neutral alert-test-result" data-alert-test-result hidden></div>
+  {% endif %}
+</section>
+
+<section class="detail-card">
+  <div class="panel-head">
+    <div>
+      <p class="eyebrow">Create alert</p>
+      <h2>Add a new threshold rule</h2>
+    </div>
+  </div>
+
+  <form class="editor-form alert-form" data-alert-create data-create-url="{{ detail.create_api_url }}">
+    <div class="alert-form-grid">
+      <label class="control-field">
+        <span>Rule name</span>
+        <input type="text" name="name" placeholder="queue-backlog-high" required>
+      </label>
+      <label class="control-field">
+        <span>Metric</span>
+        <select name="metric">
+          {% for option in detail.metric_options %}
+          <option value="{{ option.value }}"{% if option.selected %} selected{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="control-field">
+        <span>Condition</span>
+        <select name="condition">
+          {% for option in detail.condition_options %}
+          <option value="{{ option.value }}"{% if option.selected %} selected{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="control-field">
+        <span>Threshold</span>
+        <input type="number" name="threshold" step="any" min="0" placeholder="10" required>
+      </label>
+    </div>
+
+    <label class="control-field">
+      <span>Description</span>
+      <textarea class="alert-textarea" name="description" rows="5" placeholder="Optional operator-facing note explaining why this rule exists."></textarea>
+    </label>
+
+    <div class="alert-inline-actions">
+      <button class="primary-button" type="submit">Create alert</button>
+      <p class="detail-status" data-alert-create-status role="status" aria-live="polite"></p>
+    </div>
+  </form>
+</section>
+
+<section class="detail-card">
+  <div class="panel-head">
+    <div>
+      <p class="eyebrow">History</p>
+      <h2>Recent trigger history</h2>
+    </div>
+  </div>
+
+  <p class="empty-hint"{% if detail.history.len() > 0 %} hidden{% endif %} data-alert-history-empty>{{ detail.history_hint }}</p>
+
+  <div class="table-wrap alert-history-table"{% if detail.history.len() == 0 %} hidden{% endif %} data-alert-history-table>
+    <table aria-label="Recent alert history">
+      <thead>
+        <tr>
+          <th>Rule</th>
+          <th>Metric</th>
+          <th>Observed value</th>
+          <th>Triggered at</th>
+        </tr>
+      </thead>
+      <tbody data-alert-history-body>
+      {% for item in detail.history %}
+        <tr data-table-row>
+          <td><a href="{{ item.rule_page_url }}">{{ item.rule_name }}</a></td>
+          <td>{{ item.metric_label }}</td>
+          <td>{{ item.value_label }}</td>
+          <td>{{ item.triggered_at }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a dedicated `/alerts` page with a nav entry, rule rail, create/delete controls, test snapshots, and recent trigger history
- wire alert page data/view models, templates, and a small browser module that uses the existing `/api/alerts`, `/api/alerts/history`, and `/api/alerts/test` endpoints
- add page/data coverage and keep workspace gates green, including the small formatting/clippy cleanups required outside the web crate

## Verification
- cargo fmt --all --check
- cargo clippy --all-targets -- -D warnings
- cargo test

Paperclip issue: OPE-218
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
