### PR TITLE
refactor: Centralize pairing routing in GatewayBridge [OPE-225]

### DIFF
--- a/crates/opengoose-core/src/bridge.rs
+++ b/crates/opengoose-core/src/bridge.rs
@@ -225,9 +225,9 @@ impl GatewayBridge {
     /// Called from `Gateway::send_message` — handles persistence, pairing detection,
     /// and event emission for outgoing messages from the Goose single-agent path.
     ///
-    /// Returns the decoded `SessionKey` so callers can reuse it for platform-specific
-    /// sending without re-parsing the stable ID.
-    pub async fn on_outgoing_message(
+    /// Returns the decoded `SessionKey` so the bridge can route replies back to
+    /// the originating channel without adapters re-parsing the stable ID.
+    async fn on_outgoing_message(
         &self,
         user_id: &str,
         body: &str,
@@ -261,6 +261,19 @@ impl GatewayBridge {
         });
 
         session_key
+    }
+
+    /// Persist an outgoing Goose response, emit pairing events when needed, and
+    /// return the destination channel ID for platform-specific delivery.
+    pub async fn route_outgoing_text(
+        &self,
+        user_id: &str,
+        body: &str,
+        gateway_type: &str,
+    ) -> String {
+        self.on_outgoing_message(user_id, body, gateway_type)
+            .await
+            .channel_id
     }
 }
 
@@ -403,6 +416,60 @@ mod tests {
             response.kind,
             AppEventKind::ResponseSent { session_key, content }
             if session_key == key && content == PAIRING_PROMPT
+        ));
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+    }
+
+    #[tokio::test]
+    async fn route_outgoing_text_returns_channel_id_and_emits_pairing_events() {
+        let _guard = GOOSE_ENV_LOCK.lock().await;
+        ensure_goose_test_root();
+
+        let event_bus = EventBus::new(16);
+        let mut rx = event_bus.subscribe();
+        let bridge = GatewayBridge::new(test_engine(event_bus));
+        let store = Arc::new(PairingStore::new().unwrap());
+        bridge.set_pairing_store(store.clone()).await;
+        let key = test_key();
+
+        let channel_id = bridge
+            .route_outgoing_text(&key.to_stable_id(), PAIRING_PROMPT, "discord")
+            .await;
+
+        assert_eq!(channel_id, key.channel_id);
+        let pairing = rx.try_recv().unwrap();
+        let code = match pairing.kind {
+            AppEventKind::PairingCodeGenerated { code } => code,
+            other => unreachable!("expected pairing code event, got {}", other),
+        };
+        assert_eq!(
+            store.consume_pending_code(&code).await.unwrap(),
+            Some("discord".into())
+        );
+        assert!(matches!(
+            rx.try_recv().unwrap().kind,
+            AppEventKind::ResponseSent { session_key, content }
+            if session_key == key && content == PAIRING_PROMPT
+        ));
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+
+        let channel_id = bridge
+            .route_outgoing_text(
+                &key.to_stable_id(),
+                "Paired! You can now chat with goose.",
+                "discord",
+            )
+            .await;
+
+        assert_eq!(channel_id, key.channel_id);
+        assert!(matches!(
+            rx.try_recv().unwrap().kind,
+            AppEventKind::PairingCompleted { session_key } if session_key == key
+        ));
+        assert!(matches!(
+            rx.try_recv().unwrap().kind,
+            AppEventKind::ResponseSent { session_key, content }
+            if session_key == key && content == "Paired! You can now chat with goose."
         ));
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
     }

--- a/crates/opengoose-discord/src/gateway/mod.rs
+++ b/crates/opengoose-discord/src/gateway/mod.rs
@@ -241,10 +241,10 @@ impl Gateway for DiscordGateway {
             }
             OutgoingMessage::Text { body } => {
                 debug!(user_id = %user.user_id, body_len = body.len(), "discord outgoing text message");
-                // Bridge handles persistence, pairing detection, events and returns the session key
-                let session_key = self
+                // Bridge handles persistence, pairing detection, events, and channel routing.
+                let channel_id = self
                     .bridge
-                    .on_outgoing_message(&user.user_id, &body, "discord")
+                    .route_outgoing_text(&user.user_id, &body, "discord")
                     .await;
 
                 // If a draft placeholder exists, replace it in-place; otherwise
@@ -259,7 +259,7 @@ impl Gateway for DiscordGateway {
                     Some(handle) => {
                         if let Err(e) = self.finalize_draft(&handle, &body).await {
                             tracing::warn!(error = %e, "failed to finalize draft; falling back to new message");
-                            let channel_id = match session_key.channel_id.parse::<u64>() {
+                            let channel_id = match channel_id.parse::<u64>() {
                                 Ok(id) => Id::<ChannelMarker>::new(id),
                                 Err(_) => return Ok(()),
                             };
@@ -267,10 +267,10 @@ impl Gateway for DiscordGateway {
                         }
                     }
                     None => {
-                        let channel_id = match session_key.channel_id.parse::<u64>() {
+                        let channel_id = match channel_id.parse::<u64>() {
                             Ok(id) => Id::<ChannelMarker>::new(id),
                             Err(_) => {
-                                warn!(channel_id = %session_key.channel_id, "invalid channel id");
+                                warn!(channel_id = %channel_id, "invalid channel id");
                                 return Ok(());
                             }
                         };

--- a/crates/opengoose-matrix/src/gateway/mod.rs
+++ b/crates/opengoose-matrix/src/gateway/mod.rs
@@ -456,12 +456,12 @@ impl Gateway for MatrixGateway {
         message: OutgoingMessage,
     ) -> anyhow::Result<()> {
         if let OutgoingMessage::Text { body } = message {
-            let session_key = self
+            let channel_id = self
                 .bridge
-                .on_outgoing_message(&user.user_id, &body, "matrix")
+                .route_outgoing_text(&user.user_id, &body, "matrix")
                 .await;
 
-            if let Err(e) = self.post_message(&session_key.channel_id, &body).await {
+            if let Err(e) = self.post_message(&channel_id, &body).await {
                 error!(%e, "failed to send matrix message");
             }
         }

--- a/crates/opengoose-slack/src/gateway/mod.rs
+++ b/crates/opengoose-slack/src/gateway/mod.rs
@@ -339,12 +339,12 @@ impl Gateway for SlackGateway {
         message: OutgoingMessage,
     ) -> anyhow::Result<()> {
         if let OutgoingMessage::Text { body } = message {
-            let session_key = self
+            let channel_id = self
                 .bridge
-                .on_outgoing_message(&user.user_id, &body, "slack")
+                .route_outgoing_text(&user.user_id, &body, "slack")
                 .await;
 
-            if let Err(e) = self.post_message(&session_key.channel_id, &body).await {
+            if let Err(e) = self.post_message(&channel_id, &body).await {
                 error!(%e, "failed to send slack message");
             }
         }

--- a/crates/opengoose-telegram/src/gateway/mod.rs
+++ b/crates/opengoose-telegram/src/gateway/mod.rs
@@ -291,11 +291,10 @@ impl Gateway for TelegramGateway {
         // Extract the raw chat_id once (e.g. "telegram:direct:12345" -> "12345")
         // because goose's TelegramGateway expects a raw Telegram chat ID.
         let raw_channel_id = if let OutgoingMessage::Text { ref body } = message {
-            // Bridge handles persistence, pairing detection, events and returns the session key
+            // Bridge handles persistence, pairing detection, events, and channel routing.
             self.bridge
-                .on_outgoing_message(&user.user_id, body, "telegram")
+                .route_outgoing_text(&user.user_id, body, "telegram")
                 .await
-                .channel_id
         } else {
             SessionKey::from_stable_id(&user.user_id).channel_id
         };


### PR DESCRIPTION
## Summary
- add a dedicated GatewayBridge helper that persists outgoing Goose text, emits pairing events, and returns the routed channel id adapters should deliver to
- switch Discord, Slack, Telegram, and Matrix gateways to delegate outgoing pairing routing through the bridge helper
- add a bridge-level test covering pairing prompt generation and pairing completion routing through the new API

## Validation
- cargo test -p opengoose-core -p opengoose-discord -p opengoose-slack -p opengoose-telegram -p opengoose-matrix
- cargo clippy -p opengoose-core -p opengoose-discord -p opengoose-slack -p opengoose-telegram -p opengoose-matrix --all-targets -- -D warnings

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
