### PR TITLE
feat: Add tracing instrumentation to async orchestration hotspots [OPE-232]

### DIFF
--- a/crates/opengoose-core/src/bridge.rs
+++ b/crates/opengoose-core/src/bridge.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use tracing::{debug, info};
+use tracing::{debug, info, instrument};
 
 use crate::engine::Engine;
 use crate::error::GatewayError;
@@ -40,6 +40,7 @@ impl GatewayBridge {
     }
 
     /// Called by Gateway.start() — stores the handler and emits GooseReady.
+    #[instrument(skip(self, handler))]
     pub async fn on_start(&self, handler: GatewayHandler) {
         info!("gateway_bridge_start: opengoose gateway bridge registered with goose");
         self.engine.event_bus().emit(AppEventKind::GooseReady);
@@ -47,6 +48,7 @@ impl GatewayBridge {
     }
 
     /// Store the pairing store reference for later use.
+    #[instrument(skip(self, store))]
     pub async fn set_pairing_store(&self, store: Arc<PairingStore>) {
         *self.pairing_store.write().await = Some(store);
     }
@@ -80,6 +82,7 @@ impl GatewayBridge {
     }
 
     /// Generate a 6-character pairing code (300s expiry) and emit it on the event bus.
+    #[instrument(skip(self), fields(platform = %platform))]
     pub async fn generate_pairing_code(&self, platform: &str) -> Result<String, GatewayError> {
         debug!(gateway_type = %platform, "generate_pairing_code");
 
@@ -109,6 +112,14 @@ impl GatewayBridge {
     /// Returns `Some(receiver)` if a team handles the message via streaming.
     /// Returns `None` if no team is active (falls through to Goose single-agent,
     /// which responds via the `Gateway::send_message` callback — no streaming).
+    #[instrument(
+        skip(self, display_name, text),
+        fields(
+            session_id = %session_key.to_stable_id(),
+            has_display_name = display_name.is_some(),
+            text_len = text.chars().count()
+        )
+    )]
     pub async fn relay_message_streaming(
         &self,
         session_key: &SessionKey,
@@ -157,6 +168,16 @@ impl GatewayBridge {
     /// a `send_message` callback), `false` if the Goose single-agent path was
     /// used (response arrives via `Gateway::send_message`).
     #[allow(clippy::too_many_arguments)]
+    #[instrument(
+        skip(self, display_name, text, responder, throttle),
+        fields(
+            session_id = %session_key.to_stable_id(),
+            channel_id = %channel_id,
+            has_display_name = display_name.is_some(),
+            text_len = text.chars().count(),
+            max_display_len
+        )
+    )]
     pub async fn relay_and_drive_stream(
         &self,
         session_key: &SessionKey,
@@ -227,6 +248,14 @@ impl GatewayBridge {
     ///
     /// Returns the decoded `SessionKey` so the bridge can route replies back to
     /// the originating channel without adapters re-parsing the stable ID.
+    #[instrument(
+        skip(self, body),
+        fields(
+            session_id = %user_id,
+            gateway_type = %gateway_type,
+            body_len = body.chars().count()
+        )
+    )]
     async fn on_outgoing_message(
         &self,
         user_id: &str,
@@ -265,6 +294,14 @@ impl GatewayBridge {
 
     /// Persist an outgoing Goose response, emit pairing events when needed, and
     /// return the destination channel ID for platform-specific delivery.
+    #[instrument(
+        skip(self, body),
+        fields(
+            session_id = %user_id,
+            gateway_type = %gateway_type,
+            body_len = body.chars().count()
+        )
+    )]
     pub async fn route_outgoing_text(
         &self,
         user_id: &str,

--- a/crates/opengoose-core/src/engine/streaming.rs
+++ b/crates/opengoose-core/src/engine/streaming.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use tracing::{debug, info, info_span, warn};
+use tracing::{debug, info, info_span, instrument, warn};
 use uuid::Uuid;
 
 use opengoose_persistence::{Database, SessionStore};
@@ -51,6 +51,14 @@ impl Engine {
     /// Always returns `Some(receiver)` — the Goose single-agent fallback is
     /// bypassed so that every conversation goes through the profile + workspace
     /// system.
+    #[instrument(
+        skip(self, author, text),
+        fields(
+            session_id = %session_key.to_stable_id(),
+            has_author = author.is_some(),
+            text_len = text.chars().count()
+        )
+    )]
     pub async fn process_message_streaming(
         &self,
         session_key: &SessionKey,
@@ -190,6 +198,13 @@ impl Engine {
     /// Loads the `main` profile, seeds conversation history, and drives `AgentRunner::run_streaming`.
     /// Returns the full accumulated response text when the agent finishes.
     /// The caller is responsible for sending [`StreamChunk::Done`] afterwards.
+    #[instrument(
+        skip(profile_store, db, input, tx),
+        fields(
+            session_id = %session_key.to_stable_id(),
+            input_len = input.chars().count()
+        )
+    )]
     async fn stream_default_profile(
         profile_store: Option<ProfileStore>,
         db: Arc<Database>,
@@ -236,6 +251,14 @@ impl Engine {
         Ok(output.response)
     }
 
+    #[instrument(
+        skip(self, input),
+        fields(
+            session_id = %session_key.to_stable_id(),
+            team_name = %team_name,
+            input_len = input.chars().count()
+        )
+    )]
     async fn run_team_orchestration(
         &self,
         session_key: &SessionKey,

--- a/crates/opengoose-discord/src/lib.rs
+++ b/crates/opengoose-discord/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Discord channel adapter for OpenGoose.
 //!
 //! Implements the `Gateway` trait for Discord bots using the

--- a/crates/opengoose-matrix/src/lib.rs
+++ b/crates/opengoose-matrix/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Matrix channel adapter for OpenGoose.
 //!
 //! Implements the goose [`Gateway`] trait for Matrix homeservers using the

--- a/crates/opengoose-persistence/src/db.rs
+++ b/crates/opengoose-persistence/src/db.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use diesel::prelude::*;
 use diesel::sqlite::SqliteConnection;
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness, embed_migrations};
-use tracing::info;
+use tracing::{info, instrument};
 
 use crate::error::{PersistenceError, PersistenceResult};
 
@@ -31,12 +31,14 @@ pub struct Database {
 
 impl Database {
     /// Open or create the database at `~/.opengoose/sessions.db`.
+    #[instrument]
     pub fn open() -> PersistenceResult<Self> {
         let path = Self::default_path()?;
         Self::open_at(path)
     }
 
     /// Open or create the database at a specific path.
+    #[instrument(fields(path = %path.display()))]
     pub fn open_at(path: PathBuf) -> PersistenceResult<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -53,6 +55,7 @@ impl Database {
     }
 
     /// Open an in-memory database (for testing).
+    #[instrument]
     pub fn open_in_memory() -> PersistenceResult<Self> {
         let mut conn = SqliteConnection::establish(":memory:")?;
         Self::setup_pragmas(&mut conn)?;
@@ -64,6 +67,7 @@ impl Database {
     }
 
     /// Execute a closure with access to the underlying connection.
+    #[instrument(skip(self, f))]
     pub(crate) fn with<F, T>(&self, f: F) -> PersistenceResult<T>
     where
         F: FnOnce(&mut SqliteConnection) -> PersistenceResult<T>,

--- a/crates/opengoose-slack/src/lib.rs
+++ b/crates/opengoose-slack/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Slack channel adapter for OpenGoose.
 //!
 //! Implements the `Gateway` trait for Slack workspaces using

--- a/crates/opengoose-teams/src/orchestrator.rs
+++ b/crates/opengoose-teams/src/orchestrator.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{Result, anyhow};
 use tokio::sync::Mutex;
-use tracing::{info, warn};
+use tracing::{info, instrument, warn};
 
 use opengoose_persistence::{MessageType, WorkStatus};
 use opengoose_profiles::ProfileStore;
@@ -46,6 +46,15 @@ impl TeamOrchestrator {
         }
     }
 
+    #[instrument(
+        skip(self, input, ctx),
+        fields(
+            team = %self.team.name(),
+            workflow = ?self.team.workflow,
+            session_id = %ctx.session_key.to_stable_id(),
+            input_len = input.chars().count()
+        )
+    )]
     pub async fn execute(&self, input: &str, ctx: &OrchestrationContext) -> Result<String> {
         info!(team = %self.team.name(), workflow = ?self.team.workflow, "executing team");
 
@@ -178,6 +187,15 @@ impl TeamOrchestrator {
         Ok(final_response)
     }
 
+    #[instrument(
+        skip(self, ctx),
+        fields(
+            team = %self.team.name(),
+            workflow = ?self.team.workflow,
+            session_id = %ctx.session_key.to_stable_id(),
+            parent_work_id
+        )
+    )]
     pub async fn resume(&self, ctx: &OrchestrationContext, parent_work_id: i32) -> Result<String> {
         if self.team.workflow != OrchestrationPattern::Chain {
             return Err(anyhow!(
@@ -227,6 +245,15 @@ impl TeamOrchestrator {
         result
     }
 
+    #[instrument(
+        skip(self, ctx, pool),
+        fields(
+            team = %self.team.name(),
+            session_id = %ctx.session_key.to_stable_id(),
+            parent_work_id,
+            depth
+        )
+    )]
     async fn process_pending_delegations(
         &self,
         ctx: &OrchestrationContext,

--- a/crates/opengoose-telegram/src/lib.rs
+++ b/crates/opengoose-telegram/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! Telegram channel adapter for OpenGoose.
 //!
 //! Implements the `Gateway` trait for Telegram bots using the


### PR DESCRIPTION
## Summary
- add `#[instrument]` spans to engine streaming, gateway bridge, team orchestration, and database entry points
- record stable IDs and payload lengths while explicitly skipping raw message bodies, display names, and other non-debug inputs
- add recursion-limit crate attrs to channel adapter crates so the deeper instrumented async futures still type-check cleanly

## Verification
- `cargo fmt --all`
- `cargo clippy --all-targets`
- `cargo test`

Paperclip issue: OPE-232
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
