### PR TITLE
feat: Add container deployment artifacts [OPE-233]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+target
+**/target
+agents
+docs
+.DS_Store
+.env
+*.db
+*.db-shm
+*.db-wal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+FROM rust:1-bookworm AS chef
+RUN cargo install cargo-chef --locked
+WORKDIR /app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS deps
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json
+
+FROM chef AS builder
+COPY . .
+COPY --from=deps /app/target /app/target
+RUN cargo build --release --locked --package opengoose-cli
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        libgcc-s1 \
+        libgomp1 \
+        libssl3 \
+        libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd --system --create-home --home-dir /home/opengoose --uid 10001 opengoose
+WORKDIR /home/opengoose
+COPY --from=builder /app/target/release/opengoose /usr/local/bin/opengoose
+ENV HOME=/var/lib/opengoose \
+    OPENGOOSE_HOST=0.0.0.0 \
+    OPENGOOSE_PORT=8080 \
+    OPENGOOSE_DB_PATH=/var/lib/opengoose/sessions.db \
+    GOOSE_DISABLE_KEYRING=1 \
+    RUST_LOG=info
+RUN mkdir -p /var/lib/opengoose \
+    && chown -R opengoose:opengoose /var/lib/opengoose /home/opengoose
+VOLUME ["/var/lib/opengoose"]
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD curl -fsS "http://127.0.0.1:${OPENGOOSE_PORT}/api/health/live" >/dev/null || exit 1
+USER opengoose
+ENTRYPOINT ["opengoose"]
+CMD ["web"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ opengoose
 ```bash
 # Runtime
 opengoose run
-opengoose web --port 8080
+opengoose web --host 0.0.0.0 --port 8080
 
 # Machine-readable output
 opengoose --json auth list
@@ -64,6 +64,44 @@ opengoose team init [--force]
 opengoose completion bash
 opengoose completion zsh
 ```
+
+## Container Deployment
+
+```bash
+# Build the production image
+docker build -t opengoose .
+
+# Run the web server in a container
+docker run --rm \
+  -p 8080:8080 \
+  -e HOME=/var/lib/opengoose \
+  -e OPENGOOSE_HOST=0.0.0.0 \
+  -e OPENGOOSE_PORT=8080 \
+  -e OPENGOOSE_DB_PATH=/var/lib/opengoose/sessions.db \
+  -e OPENAI_API_KEY=your-key \
+  -v opengoose-data:/var/lib/opengoose \
+  opengoose
+
+# Or use the included compose file for local container development
+docker compose up --build
+```
+
+The image runs `opengoose web` by default, exposes health endpoints at
+`/api/health`, `/api/health/ready`, and `/api/health/live`, and stores
+persistent state under `/var/lib/opengoose`.
+
+### Runtime Env Vars
+
+- `OPENGOOSE_HOST`: HTTP bind address for `opengoose web`. Defaults to `127.0.0.1` locally; set `0.0.0.0` in containers.
+- `OPENGOOSE_PORT`: HTTP port for `opengoose web`. Defaults to `8080`.
+- `OPENGOOSE_DB_PATH`: SQLite database path. Defaults to `$HOME/.opengoose/sessions.db` when unset.
+- `HOME`: Controls where OpenGoose stores profiles, teams, and secret metadata. The container image uses `/var/lib/opengoose`.
+- Provider and channel credentials: set the environment variables your deployment needs, such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `TELEGRAM_BOT_TOKEN`, `MATRIX_HOMESERVER_URL`, and `MATRIX_ACCESS_TOKEN`.
+
+The included [docker-compose.yml](docker-compose.yml) mounts a named volume for
+SQLite persistence, disables keyring usage by default for container workflows,
+and maps `OPENGOOSE_PORT` through to the host so `.env` or shell overrides work
+without editing the file.
 
 ## Workspace Crates
 

--- a/crates/opengoose-cli/src/cmd/api_key.rs
+++ b/crates/opengoose-cli/src/cmd/api_key.rs
@@ -68,8 +68,8 @@ pub fn execute(action: ApiKeyAction, output: CliOutput) -> Result<()> {
                 println!("No API keys found.");
             } else {
                 println!(
-                    "{:<38} {:<30} {:<22} {}",
-                    "ID", "DESCRIPTION", "CREATED", "LAST USED"
+                    "{:<38} {:<30} {:<22} LAST USED",
+                    "ID", "DESCRIPTION", "CREATED"
                 );
                 for k in &keys {
                     println!(

--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -22,6 +22,7 @@ use opengoose_tui::{AppMode, ComposerRequest, TuiTracingLayer};
 use opengoose_types::{AppEventKind, EventBus};
 
 const ALERT_EVALUATION_INTERVAL: Duration = Duration::from_secs(30);
+type GatewayBuilder = fn(&[&str], Arc<GatewayBridge>, EventBus) -> anyhow::Result<Arc<dyn Gateway>>;
 
 /// Declarative specification for constructing a gateway from credentials.
 ///
@@ -31,7 +32,7 @@ struct GatewaySpec {
     /// Secret keys that must all resolve (order matches `build` parameter order).
     keys: Vec<SecretKey>,
     /// Construct the gateway from resolved credential values, a bridge, and the event bus.
-    build: fn(&[&str], Arc<GatewayBridge>, EventBus) -> anyhow::Result<Arc<dyn Gateway>>,
+    build: GatewayBuilder,
 }
 
 /// Registry of all supported gateway specifications.

--- a/crates/opengoose-cli/src/cmd/web.rs
+++ b/crates/opengoose-cli/src/cmd/web.rs
@@ -1,16 +1,161 @@
-use anyhow::Result;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use anyhow::{Context, Result};
 use opengoose_web::{WebOptions, serve};
+
+const DEFAULT_WEB_HOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+const DEFAULT_WEB_PORT: u16 = 8080;
+const HOST_ENV_VAR: &str = "OPENGOOSE_HOST";
+const PORT_ENV_VAR: &str = "OPENGOOSE_PORT";
 
 /// Run the web dashboard server.
 pub async fn execute(
-    port: u16,
+    host: Option<IpAddr>,
+    port: Option<u16>,
     tls_cert: Option<std::path::PathBuf>,
     tls_key: Option<std::path::PathBuf>,
 ) -> Result<()> {
+    let bind = resolve_bind_addr(host, port)?;
     serve(WebOptions {
-        bind: ([127, 0, 0, 1], port).into(),
+        bind,
         tls_cert_path: tls_cert,
         tls_key_path: tls_key,
     })
     .await
+}
+
+fn resolve_bind_addr(host: Option<IpAddr>, port: Option<u16>) -> Result<SocketAddr> {
+    Ok(SocketAddr::from((resolve_host(host)?, resolve_port(port)?)))
+}
+
+fn resolve_host(host: Option<IpAddr>) -> Result<IpAddr> {
+    match host {
+        Some(host) => Ok(host),
+        None => resolve_host_from_env(),
+    }
+}
+
+fn resolve_port(port: Option<u16>) -> Result<u16> {
+    match port {
+        Some(port) => Ok(port),
+        None => resolve_port_from_env(),
+    }
+}
+
+fn resolve_host_from_env() -> Result<IpAddr> {
+    let Some(host) = std::env::var_os(HOST_ENV_VAR) else {
+        return Ok(DEFAULT_WEB_HOST);
+    };
+
+    let host = host.to_string_lossy();
+    let trimmed = host.trim();
+    if trimmed.is_empty() {
+        return Ok(DEFAULT_WEB_HOST);
+    }
+
+    trimmed.parse().with_context(|| {
+        format!("invalid {HOST_ENV_VAR} value `{trimmed}`: expected an IP address")
+    })
+}
+
+fn resolve_port_from_env() -> Result<u16> {
+    let Some(port) = std::env::var_os(PORT_ENV_VAR) else {
+        return Ok(DEFAULT_WEB_PORT);
+    };
+
+    let port = port.to_string_lossy();
+    let trimmed = port.trim();
+    if trimmed.is_empty() {
+        return Ok(DEFAULT_WEB_PORT);
+    }
+
+    trimmed.parse().with_context(|| {
+        format!("invalid {PORT_ENV_VAR} value `{trimmed}`: expected a port number")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_web_env<T>(host: Option<&str>, port: Option<&str>, test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved_host = std::env::var(HOST_ENV_VAR).ok();
+        let saved_port = std::env::var(PORT_ENV_VAR).ok();
+
+        unsafe {
+            match host {
+                Some(value) => std::env::set_var(HOST_ENV_VAR, value),
+                None => std::env::remove_var(HOST_ENV_VAR),
+            }
+            match port {
+                Some(value) => std::env::set_var(PORT_ENV_VAR, value),
+                None => std::env::remove_var(PORT_ENV_VAR),
+            }
+        }
+
+        let result = test();
+
+        unsafe {
+            match saved_host {
+                Some(value) => std::env::set_var(HOST_ENV_VAR, value),
+                None => std::env::remove_var(HOST_ENV_VAR),
+            }
+            match saved_port {
+                Some(value) => std::env::set_var(PORT_ENV_VAR, value),
+                None => std::env::remove_var(PORT_ENV_VAR),
+            }
+        }
+
+        result
+    }
+
+    #[test]
+    fn resolve_bind_addr_defaults_to_localhost_8080() {
+        with_web_env(None, None, || {
+            let bind = resolve_bind_addr(None, None).unwrap();
+            assert_eq!(bind, SocketAddr::from((Ipv4Addr::LOCALHOST, 8080)));
+        });
+    }
+
+    #[test]
+    fn resolve_bind_addr_uses_env_when_flags_are_absent() {
+        with_web_env(Some("0.0.0.0"), Some("9090"), || {
+            let bind = resolve_bind_addr(None, None).unwrap();
+            assert_eq!(bind, SocketAddr::from(([0, 0, 0, 0], 9090)));
+        });
+    }
+
+    #[test]
+    fn resolve_bind_addr_prefers_cli_flags_over_env() {
+        with_web_env(Some("127.0.0.1"), Some("9090"), || {
+            let bind = resolve_bind_addr(Some("0.0.0.0".parse().unwrap()), Some(8081)).unwrap();
+            assert_eq!(bind, SocketAddr::from(([0, 0, 0, 0], 8081)));
+        });
+    }
+
+    #[test]
+    fn resolve_bind_addr_rejects_invalid_host_env() {
+        with_web_env(Some("not-an-ip"), None, || {
+            let err = resolve_bind_addr(None, None).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid OPENGOOSE_HOST value"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_bind_addr_rejects_invalid_port_env() {
+        with_web_env(None, Some("abc"), || {
+            let err = resolve_bind_addr(None, None).unwrap_err();
+            assert!(
+                err.to_string().contains("invalid OPENGOOSE_PORT value"),
+                "unexpected error: {err}"
+            );
+        });
+    }
 }

--- a/crates/opengoose-cli/src/main.rs
+++ b/crates/opengoose-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod cmd;
 
+use std::net::IpAddr;
 use std::process::ExitCode;
 
 use anyhow::{Result, bail};
@@ -119,9 +120,12 @@ enum Command {
     },
     /// Start the web dashboard server
     Web {
+        /// IP address to bind the HTTP listener to
+        #[arg(long)]
+        host: Option<IpAddr>,
         /// Port to listen on
-        #[arg(long, default_value_t = 8080)]
-        port: u16,
+        #[arg(long)]
+        port: Option<u16>,
         /// Path to TLS certificate PEM file (enables HTTPS/WSS when provided with --tls-key)
         #[arg(long)]
         tls_cert: Option<std::path::PathBuf>,
@@ -207,7 +211,12 @@ fn run(cli: Cli, output: CliOutput) -> Result<()> {
             Command::Plugin { action } => cmd::plugin::execute(action),
             Command::Remote { action } => cmd::remote::execute(action).await,
             Command::Message { action } => cmd::message::execute(action).await,
-            Command::Web { port, tls_cert, tls_key } => cmd::web::execute(port, tls_cert, tls_key).await,
+            Command::Web {
+                host,
+                port,
+                tls_cert,
+                tls_key,
+            } => cmd::web::execute(host, port, tls_cert, tls_key).await,
             Command::Completion { shell } => {
                 if output.is_json() {
                     bail!("`opengoose completion` prints shell scripts directly and does not support --json");
@@ -537,11 +546,13 @@ mod tests {
         let cli = Cli::parse_from(["opengoose", "web"]);
         match cli.command {
             Some(Command::Web {
+                host,
                 port,
                 tls_cert,
                 tls_key,
             }) => {
-                assert_eq!(port, 8080);
+                assert!(host.is_none());
+                assert!(port.is_none());
                 assert!(tls_cert.is_none());
                 assert!(tls_key.is_none());
             }
@@ -553,7 +564,18 @@ mod tests {
     fn parse_web_custom_port() {
         let cli = Cli::parse_from(["opengoose", "web", "--port", "3000"]);
         match cli.command {
-            Some(Command::Web { port, .. }) => assert_eq!(port, 3000),
+            Some(Command::Web { port, .. }) => assert_eq!(port, Some(3000)),
+            _ => panic!("expected Web command"),
+        }
+    }
+
+    #[test]
+    fn parse_web_custom_host() {
+        let cli = Cli::parse_from(["opengoose", "web", "--host", "0.0.0.0"]);
+        match cli.command {
+            Some(Command::Web { host, .. }) => {
+                assert_eq!(host, Some("0.0.0.0".parse().unwrap()));
+            }
             _ => panic!("expected Web command"),
         }
     }
@@ -563,6 +585,10 @@ mod tests {
         let cli = Cli::parse_from([
             "opengoose",
             "web",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8443",
             "--tls-cert",
             "/etc/ssl/cert.pem",
             "--tls-key",
@@ -570,8 +596,13 @@ mod tests {
         ]);
         match cli.command {
             Some(Command::Web {
-                tls_cert, tls_key, ..
+                host,
+                port,
+                tls_cert,
+                tls_key,
             }) => {
+                assert_eq!(host, Some("0.0.0.0".parse().unwrap()));
+                assert_eq!(port, Some(8443));
                 assert_eq!(tls_cert.unwrap().to_str().unwrap(), "/etc/ssl/cert.pem");
                 assert_eq!(tls_key.unwrap().to_str().unwrap(), "/etc/ssl/key.pem");
             }

--- a/crates/opengoose-cli/tests/auth_cli.rs
+++ b/crates/opengoose-cli/tests/auth_cli.rs
@@ -79,7 +79,7 @@ fn auth_list_json_reports_local_provider_ready() {
     let providers = body["providers"].as_array().unwrap();
     let local = providers
         .iter()
-        .find(|provider| provider["name"] == Value::from("local"))
+        .find(|provider| provider["name"] == "local")
         .expect("local provider should be listed");
     assert_eq!(local["display_name"], Value::from("Local Inference"));
     assert_eq!(local["auth"], Value::from("none"));

--- a/crates/opengoose-persistence/src/db.rs
+++ b/crates/opengoose-persistence/src/db.rs
@@ -9,6 +9,7 @@ use tracing::info;
 use crate::error::{PersistenceError, PersistenceResult};
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
+const DB_PATH_ENV_VAR: &str = "OPENGOOSE_DB_PATH";
 
 /// SQL literal for `datetime('now')` — shared across all stores.
 pub(crate) fn now_sql() -> diesel::expression::SqlLiteral<diesel::sql_types::Text> {
@@ -31,6 +32,8 @@ pub struct Database {
 
 impl Database {
     /// Open or create the database at `~/.opengoose/sessions.db`.
+    ///
+    /// When `OPENGOOSE_DB_PATH` is set to a non-empty value, that path wins.
     pub fn open() -> PersistenceResult<Self> {
         let path = Self::default_path()?;
         Self::open_at(path)
@@ -92,14 +95,55 @@ impl Database {
     }
 
     fn default_path() -> PersistenceResult<PathBuf> {
+        if let Some(path) = database_path_from_env() {
+            return Ok(path);
+        }
+
         let home = dirs::home_dir().ok_or(PersistenceError::NoHomeDir)?;
         Ok(home.join(".opengoose").join("sessions.db"))
     }
 }
 
+fn database_path_from_env() -> Option<PathBuf> {
+    let path = std::env::var_os(DB_PATH_ENV_VAR)?;
+    let path = path.to_string_lossy();
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(PathBuf::from(trimmed))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_db_path_env<T>(value: Option<&std::path::Path>, test: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let saved = std::env::var(DB_PATH_ENV_VAR).ok();
+
+        unsafe {
+            match value {
+                Some(path) => std::env::set_var(DB_PATH_ENV_VAR, path),
+                None => std::env::remove_var(DB_PATH_ENV_VAR),
+            }
+        }
+
+        let result = test();
+
+        unsafe {
+            match saved {
+                Some(path) => std::env::set_var(DB_PATH_ENV_VAR, path),
+                None => std::env::remove_var(DB_PATH_ENV_VAR),
+            }
+        }
+
+        result
+    }
 
     #[test]
     fn test_open_in_memory() {
@@ -138,6 +182,27 @@ mod tests {
             Ok(val)
         });
         assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_default_path_uses_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("custom").join("sessions.db");
+
+        with_db_path_env(Some(&path), || {
+            assert_eq!(Database::default_path().unwrap(), path);
+        });
+    }
+
+    #[test]
+    fn test_open_uses_env_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runtime").join("sessions.db");
+
+        with_db_path_env(Some(&path), || {
+            let _db = Database::open().unwrap();
+            assert!(path.exists());
+        });
     }
 
     /// Verify every table defined in schema.rs is created by migrations.

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -50,7 +50,6 @@ pub async fn serve(options: WebOptions) -> Result<()> {
         db: db.clone(),
         remote_registry: remote_state.registry.clone(),
         channel_metrics: api_state.channel_metrics.clone(),
-        event_bus: api_state.event_bus.clone(),
     };
     live::spawn_live_event_watcher(state.db.clone(), api_state.event_bus.clone());
 

--- a/crates/opengoose-web/src/routes/health.rs
+++ b/crates/opengoose-web/src/routes/health.rs
@@ -200,7 +200,6 @@ mod tests {
             db,
             remote_registry: RemoteAgentRegistry::new(RemoteConfig::default()),
             channel_metrics: ChannelMetricsStore::new(),
-            event_bus: opengoose_types::EventBus::new(256),
         }
     }
 

--- a/crates/opengoose-web/src/routes/pages.rs
+++ b/crates/opengoose-web/src/routes/pages.rs
@@ -692,7 +692,7 @@ mod tests {
     };
     use opengoose_teams::remote::{RemoteAgentRegistry, RemoteConfig};
     use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore};
-    use opengoose_types::{ChannelMetricsStore, EventBus, Platform, SessionKey};
+    use opengoose_types::{ChannelMetricsStore, Platform, SessionKey};
     use tower::ServiceExt;
 
     use super::*;
@@ -724,7 +724,6 @@ mod tests {
             db,
             remote_registry: RemoteAgentRegistry::new(RemoteConfig::default()),
             channel_metrics: ChannelMetricsStore::new(),
-            event_bus: EventBus::new(256),
         }
     }
 

--- a/crates/opengoose-web/src/server.rs
+++ b/crates/opengoose-web/src/server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use opengoose_persistence::Database;
 use opengoose_teams::remote::RemoteAgentRegistry;
-use opengoose_types::{ChannelMetricsStore, EventBus};
+use opengoose_types::ChannelMetricsStore;
 
 /// Configuration for the web dashboard server.
 #[derive(Debug, Clone)]
@@ -39,5 +39,4 @@ pub(crate) struct PageState {
     pub(crate) db: Arc<Database>,
     pub(crate) remote_registry: RemoteAgentRegistry,
     pub(crate) channel_metrics: ChannelMetricsStore,
-    pub(crate) event_bus: EventBus,
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  opengoose:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: opengoose:local
+    restart: unless-stopped
+    environment:
+      HOME: /var/lib/opengoose
+      OPENGOOSE_HOST: ${OPENGOOSE_HOST:-0.0.0.0}
+      OPENGOOSE_PORT: ${OPENGOOSE_PORT:-8080}
+      OPENGOOSE_DB_PATH: ${OPENGOOSE_DB_PATH:-/var/lib/opengoose/sessions.db}
+      GOOSE_DISABLE_KEYRING: ${GOOSE_DISABLE_KEYRING:-1}
+      RUST_LOG: ${RUST_LOG:-info}
+    ports:
+      - "${OPENGOOSE_PORT:-8080}:${OPENGOOSE_PORT:-8080}"
+    volumes:
+      - opengoose-data:/var/lib/opengoose
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -fsS http://127.0.0.1:${OPENGOOSE_PORT:-8080}/api/health/live >/dev/null",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+volumes:
+  opengoose-data:


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and `docker-compose.yml` for running `opengoose web` with a persistent data volume and health checks
- allow the web server bind host/port to be configured via CLI flags or `OPENGOOSE_HOST` / `OPENGOOSE_PORT`, and allow the SQLite path to be overridden with `OPENGOOSE_DB_PATH`
- document the production container workflow in `README.md` and fix workspace clippy warnings required to keep the full verification pass green

## Verification
- `cargo fmt --all`
- `CARGO_TARGET_DIR=target/verify cargo clippy --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=target/verify cargo test`
- `docker compose config`

## Paperclip
- [OPE-233](http://localhost:3131/OPE/issues/OPE-233)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
