### PR TITLE
test: add web middleware edge-case coverage [OPE-246]

### DIFF
--- a/crates/opengoose-web/src/middleware/auth.rs
+++ b/crates/opengoose-web/src/middleware/auth.rs
@@ -110,7 +110,7 @@ mod tests {
 
     use axum::Router;
     use axum::body::Body;
-    use axum::http::Request;
+    use axum::http::{HeaderValue, Request};
     use axum::routing::get;
     use opengoose_persistence::Database;
     use tower::ServiceExt;
@@ -129,6 +129,7 @@ mod tests {
         let app = Router::new()
             .route("/api/test", get(|| async { "ok" }))
             .route("/api/health", get(|| async { "healthy" }))
+            .route("/api/healthcheck", get(|| async { "protected" }))
             .route("/api/openapi.json", get(|| async { "{}" }))
             .route("/api/docs", get(|| async { "docs" }))
             .layer(AuthLayer::new(store.clone()));
@@ -146,6 +147,21 @@ mod tests {
                 resp.status(),
                 StatusCode::OK,
                 "public path {path} should not require auth"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn bypass_like_public_paths_still_require_auth() {
+        let (app, _store) = test_app();
+
+        for path in ["/api/healthcheck"] {
+            let req = Request::builder().uri(path).body(Body::empty()).unwrap();
+            let resp = app.clone().oneshot(req).await.unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::UNAUTHORIZED,
+                "{path} should not bypass auth",
             );
         }
     }
@@ -192,6 +208,21 @@ mod tests {
         let req = Request::builder()
             .uri("/api/test")
             .header("authorization", "Basic dXNlcjpwYXNz")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn rejects_authorization_header_with_invalid_bytes() {
+        let (app, _store) = test_app();
+        let req = Request::builder()
+            .uri("/api/test")
+            .header(
+                "authorization",
+                HeaderValue::from_bytes(b"Bearer \xFFtoken").unwrap(),
+            )
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();

--- a/crates/opengoose-web/src/middleware/rate_limit.rs
+++ b/crates/opengoose-web/src/middleware/rate_limit.rs
@@ -217,6 +217,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn zero_window_never_blocks_requests() {
+        let app = test_app(1, 0);
+        let addr: SocketAddr = "10.0.0.6:1111".parse().unwrap();
+
+        for _ in 0..3 {
+            let resp = app.clone().oneshot(make_request(addr)).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(
+                resp.headers()
+                    .get("X-RateLimit-Remaining")
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+                "0"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn separate_limits_per_ip() {
         let app = test_app(1, 60);
         let addr_a: SocketAddr = "10.0.0.3:1000".parse().unwrap();
@@ -255,6 +274,34 @@ mod tests {
             .parse()
             .unwrap();
         assert!(retry > 0 && retry <= 121);
+    }
+
+    #[test]
+    fn expired_entries_are_evicted_before_enforcing_limit() {
+        let config = RateLimitConfig {
+            max_requests: 2,
+            window: Duration::from_secs(10),
+        };
+        let limiter = SlidingWindowRateLimiter::new(config.clone());
+        let start = Instant::now();
+
+        assert_eq!(
+            limiter.check_key_with_config("10.0.0.7", &config, start),
+            (1, None)
+        );
+        assert_eq!(
+            limiter.check_key_with_config("10.0.0.7", &config, start + Duration::from_secs(5)),
+            (0, None)
+        );
+
+        assert_eq!(
+            limiter.check_key_with_config("10.0.0.7", &config, start + Duration::from_secs(11)),
+            (0, None)
+        );
+        assert_eq!(
+            limiter.check_key_with_config("10.0.0.7", &config, start + Duration::from_secs(11)),
+            (0, Some(5))
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add auth middleware coverage for exact public-path matching and invalid authorization header bytes
- add rate-limit coverage for zero-window behavior and expired entry eviction

## Verification
- cargo build
- cargo clippy --all-targets
- cargo test
- cargo build (clean main-based worktree)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
