### PR TITLE
feat: Add model selection fallbacks [OPE-243]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ opengoose
 ```bash
 # Runtime
 opengoose run
+opengoose run --model gpt-5-mini
 opengoose web --port 8080
 
 # Machine-readable output
@@ -59,6 +60,8 @@ opengoose team show <name>
 opengoose team add <path>
 opengoose team remove <name>
 opengoose team init [--force]
+opengoose team run <team> "<input>"
+opengoose team run <team> "<input>" --model gpt-5-mini
 
 # Shell completions
 opengoose completion bash

--- a/crates/opengoose-cli/src/cmd/api_key.rs
+++ b/crates/opengoose-cli/src/cmd/api_key.rs
@@ -68,8 +68,8 @@ pub fn execute(action: ApiKeyAction, output: CliOutput) -> Result<()> {
                 println!("No API keys found.");
             } else {
                 println!(
-                    "{:<38} {:<30} {:<22} {}",
-                    "ID", "DESCRIPTION", "CREATED", "LAST USED"
+                    "{:<38} {:<30} {:<22} LAST USED",
+                    "ID", "DESCRIPTION", "CREATED"
                 );
                 for k in &keys {
                     println!(

--- a/crates/opengoose-cli/src/cmd/run.rs
+++ b/crates/opengoose-cli/src/cmd/run.rs
@@ -23,6 +23,8 @@ use opengoose_types::{AppEventKind, EventBus};
 
 const ALERT_EVALUATION_INTERVAL: Duration = Duration::from_secs(30);
 
+type GatewayBuilder = fn(&[&str], Arc<GatewayBridge>, EventBus) -> anyhow::Result<Arc<dyn Gateway>>;
+
 /// Declarative specification for constructing a gateway from credentials.
 ///
 /// To add a new channel, add a single entry to [`gateway_specs`] — no other
@@ -31,7 +33,7 @@ struct GatewaySpec {
     /// Secret keys that must all resolve (order matches `build` parameter order).
     keys: Vec<SecretKey>,
     /// Construct the gateway from resolved credential values, a bridge, and the event bus.
-    build: fn(&[&str], Arc<GatewayBridge>, EventBus) -> anyhow::Result<Arc<dyn Gateway>>,
+    build: GatewayBuilder,
 }
 
 /// Registry of all supported gateway specifications.

--- a/crates/opengoose-cli/src/cmd/team.rs
+++ b/crates/opengoose-cli/src/cmd/team.rs
@@ -53,6 +53,9 @@ pub enum TeamAction {
         team: String,
         /// Input to the team workflow
         input: String,
+        /// Override the model for this team run
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Show status of a team run
     Status {
@@ -79,7 +82,7 @@ pub async fn execute(action: TeamAction, output: CliOutput) -> Result<()> {
         TeamAction::Add { path, force } => cmd_add(&path, force, output),
         TeamAction::Remove { name } => cmd_remove(&name, output),
         TeamAction::Init { force } => cmd_init(force, output),
-        TeamAction::Run { team, input } => cmd_run(&team, &input).await,
+        TeamAction::Run { team, input, model } => cmd_run(&team, &input, model).await,
         TeamAction::Status { run_id } => cmd_status(run_id.as_deref()),
         TeamAction::Logs { run_id } => cmd_logs(&run_id),
         TeamAction::Resume { run_id } => cmd_resume(&run_id).await,
@@ -232,13 +235,14 @@ fn cmd_init(force: bool, output: CliOutput) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_run(team_name: &str, input: &str) -> Result<()> {
+async fn cmd_run(team_name: &str, input: &str, model: Option<String>) -> Result<()> {
     let db = Arc::new(Database::open()?);
     let event_bus = EventBus::new(256);
 
     println!("Running team '{team_name}'...");
 
-    let (run_id, result) = opengoose_teams::run_headless(team_name, input, db, event_bus).await?;
+    let (run_id, result) =
+        opengoose_teams::run_headless_with_model(team_name, input, db, event_bus, model).await?;
 
     println!("\n--- Result ---");
     println!("{result}");

--- a/crates/opengoose-cli/src/main.rs
+++ b/crates/opengoose-cli/src/main.rs
@@ -29,7 +29,11 @@ struct Cli {
 enum Command {
     /// Start the gateway and TUI (default when no subcommand is given)
     #[command(after_help = "Example:\n  opengoose run")]
-    Run,
+    Run {
+        /// Override the default Goose model for this runtime
+        #[arg(long)]
+        model: Option<String>,
+    },
     /// Manage AI provider authentication and credentials
     #[command(
         after_help = "Examples:\n  opengoose auth list\n  opengoose auth login openai\n  opengoose --json auth models anthropic"
@@ -166,13 +170,21 @@ fn run(cli: Cli, output: CliOutput) -> Result<()> {
         .install_default()
         .map_err(|err| anyhow::anyhow!("failed to initialize rustls crypto provider: {err:?}"))?;
 
-    let command = cli.command.unwrap_or(Command::Run);
+    let command = cli.command.unwrap_or(Command::Run { model: None });
+
+    if let Some(model) = runtime_model_override(&command) {
+        // Safety: this happens before the tokio runtime is started, matching the
+        // same single-threaded env-var setup constraints as profile registration.
+        unsafe {
+            std::env::set_var("GOOSE_MODEL", model);
+        }
+    }
 
     // Set up profiles and env vars *before* spawning any threads.
     // `register_profiles_path` uses `unsafe { set_var }` which requires
     // single-threaded execution.
     match &command {
-        Command::Run => {
+        Command::Run { .. } => {
             if output.is_json() {
                 bail!("`opengoose run` does not support --json output");
             }
@@ -193,7 +205,7 @@ fn run(cli: Cli, output: CliOutput) -> Result<()> {
 
     runtime.block_on(async {
         match command {
-            Command::Run => cmd::run::execute().await,
+            Command::Run { .. } => cmd::run::execute().await,
             Command::Auth { action } => cmd::auth::execute(action, output).await,
             Command::Profile { action } => cmd::profile::execute(action, output),
             Command::Db { action } => cmd::db::execute(action, output),
@@ -218,6 +230,19 @@ fn run(cli: Cli, output: CliOutput) -> Result<()> {
             }
         }
     })
+}
+
+fn runtime_model_override(command: &Command) -> Option<&str> {
+    match command {
+        Command::Run { model: Some(model) } => Some(model.as_str()),
+        Command::Team {
+            action:
+                cmd::team::TeamAction::Run {
+                    model: Some(model), ..
+                },
+        } => Some(model.as_str()),
+        _ => None,
+    }
 }
 
 fn print_completion(shell: CompletionShell) {
@@ -288,7 +313,18 @@ mod tests {
     #[test]
     fn parse_run_subcommand() {
         let cli = Cli::parse_from(["opengoose", "run"]);
-        assert!(matches!(cli.command, Some(Command::Run)));
+        assert!(matches!(cli.command, Some(Command::Run { model: None })));
+    }
+
+    #[test]
+    fn parse_run_subcommand_with_model_override() {
+        let cli = Cli::parse_from(["opengoose", "run", "--model", "gpt-5-mini"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Run {
+                model: Some(ref model)
+            }) if model == "gpt-5-mini"
+        ));
     }
 
     #[test]
@@ -329,10 +365,33 @@ mod tests {
 
         match cli.command {
             Some(Command::Team {
-                action: cmd::team::TeamAction::Run { team, input },
+                action: cmd::team::TeamAction::Run { team, input, model },
             }) => {
                 assert_eq!(team, "code-review");
                 assert_eq!(input, "Ship it");
+                assert!(model.is_none());
+            }
+            _ => panic!("expected Team run command"),
+        }
+    }
+
+    #[test]
+    fn parse_team_run_subcommand_with_model_override() {
+        let cli = Cli::parse_from([
+            "opengoose",
+            "team",
+            "run",
+            "code-review",
+            "Ship it",
+            "--model",
+            "claude-3-7-sonnet",
+        ]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Run { model, .. },
+            }) => {
+                assert_eq!(model.as_deref(), Some("claude-3-7-sonnet"));
             }
             _ => panic!("expected Team run command"),
         }
@@ -632,8 +691,8 @@ mod tests {
     fn default_command_is_run() {
         // Mirrors the unwrap_or in run(): None maps to Command::Run.
         let cli = Cli::parse_from(["opengoose"]);
-        let command = cli.command.unwrap_or(Command::Run);
-        assert!(matches!(command, Command::Run));
+        let command = cli.command.unwrap_or(Command::Run { model: None });
+        assert!(matches!(command, Command::Run { model: None }));
     }
 
     #[test]

--- a/crates/opengoose-cli/tests/auth_cli.rs
+++ b/crates/opengoose-cli/tests/auth_cli.rs
@@ -79,7 +79,7 @@ fn auth_list_json_reports_local_provider_ready() {
     let providers = body["providers"].as_array().unwrap();
     let local = providers
         .iter()
-        .find(|provider| provider["name"] == Value::from("local"))
+        .find(|provider| provider["name"].as_str() == Some("local"))
         .expect("local provider should be listed");
     assert_eq!(local["display_name"], Value::from("Local Inference"));
     assert_eq!(local["auth"], Value::from("none"));

--- a/crates/opengoose-core/src/engine/streaming.rs
+++ b/crates/opengoose-core/src/engine/streaming.rs
@@ -199,6 +199,11 @@ impl Engine {
     ) -> anyhow::Result<String> {
         info!(session_id = %session_key.to_stable_id(), profile = "main", "stream_default_profile");
 
+        let session_store = SessionStore::new(db);
+        let selected_model = session_store
+            .get_selected_model(&session_key)
+            .ok()
+            .flatten();
         let profile = match profile_store.as_ref().and_then(|s| s.get("main").ok()) {
             Some(p) => p,
             None => AgentProfile {
@@ -215,11 +220,11 @@ impl Engine {
                 sub_recipes: None,
                 parameters: None,
             },
-        };
+        }
+        .with_model_override(selected_model.as_deref());
 
         let runner = AgentRunner::from_profile(&profile).await?;
 
-        let session_store = SessionStore::new(db);
         if let Ok(history) = session_store.load_history(&session_key, 51) {
             let prior: Vec<(String, String)> = history
                 .iter()
@@ -246,7 +251,16 @@ impl Engine {
         // Holding the cached orchestrator keeps its agent pool alive between
         // messages, so MCP extensions are not restarted on every turn.
         info!(session_id = %session_key.to_stable_id(), team_name = %team_name, "team_orchestration");
-        let cache_key = format!("{}::{team_name}", session_key.to_stable_id());
+        let selected_model = self
+            .session_store
+            .get_selected_model(session_key)
+            .ok()
+            .flatten();
+        let model_cache_key = selected_model.as_deref().unwrap_or("__default__");
+        let cache_key = format!(
+            "{}::{team_name}::{model_cache_key}",
+            session_key.to_stable_id()
+        );
         let orchestrator = {
             let mut cache = self.orchestrator_cache.lock().await;
             if !cache.contains_key(&cache_key) {
@@ -261,7 +275,11 @@ impl Engine {
                     .ok_or(crate::error::GatewayError::ProfileStoreNotReady)?;
                 cache.insert(
                     cache_key.clone(),
-                    Arc::new(opengoose_teams::TeamOrchestrator::new(team, profile_store)),
+                    Arc::new(opengoose_teams::TeamOrchestrator::new_with_model_override(
+                        team,
+                        profile_store,
+                        selected_model.clone(),
+                    )),
                 );
             }
             // Key was just inserted above, so this should always succeed.

--- a/crates/opengoose-persistence/migrations/2026-03-11-000000_add_session_selected_model/down.sql
+++ b/crates/opengoose-persistence/migrations/2026-03-11-000000_add_session_selected_model/down.sql
@@ -1,0 +1,18 @@
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE sessions__new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    session_key TEXT NOT NULL UNIQUE,
+    active_team TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT INTO sessions__new (id, session_key, active_team, created_at, updated_at)
+SELECT id, session_key, active_team, created_at, updated_at
+FROM sessions;
+
+DROP TABLE sessions;
+ALTER TABLE sessions__new RENAME TO sessions;
+
+PRAGMA foreign_keys = ON;

--- a/crates/opengoose-persistence/migrations/2026-03-11-000000_add_session_selected_model/up.sql
+++ b/crates/opengoose-persistence/migrations/2026-03-11-000000_add_session_selected_model/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sessions
+ADD COLUMN selected_model TEXT;

--- a/crates/opengoose-persistence/src/db.rs
+++ b/crates/opengoose-persistence/src/db.rs
@@ -199,6 +199,7 @@ mod tests {
             assert!(names.contains(&"id"));
             assert!(names.contains(&"session_key"));
             assert!(names.contains(&"active_team"));
+            assert!(names.contains(&"selected_model"));
             assert!(names.contains(&"created_at"));
             assert!(names.contains(&"updated_at"));
             Ok(())

--- a/crates/opengoose-persistence/src/message_queue/tests.rs
+++ b/crates/opengoose-persistence/src/message_queue/tests.rs
@@ -16,7 +16,10 @@ fn test_db() -> Arc<Database> {
 fn ensure_session(db: &Arc<Database>, key: &str) {
     db.with(|conn| {
         diesel::insert_into(sessions::table)
-            .values(NewSession { session_key: key })
+            .values(NewSession {
+                session_key: key,
+                selected_model: None,
+            })
             .on_conflict(sessions::session_key)
             .do_nothing()
             .execute(conn)?;

--- a/crates/opengoose-persistence/src/models.rs
+++ b/crates/opengoose-persistence/src/models.rs
@@ -8,6 +8,7 @@ use crate::schema::*;
 #[diesel(table_name = sessions)]
 pub struct NewSession<'a> {
     pub session_key: &'a str,
+    pub selected_model: Option<&'a str>,
 }
 
 // ── Messages ──
@@ -323,8 +324,10 @@ mod tests {
     fn test_new_session_construction() {
         let s = NewSession {
             session_key: "discord:guild:chan",
+            selected_model: None,
         };
         assert_eq!(s.session_key, "discord:guild:chan");
+        assert!(s.selected_model.is_none());
     }
 
     #[test]

--- a/crates/opengoose-persistence/src/orchestration.rs
+++ b/crates/opengoose-persistence/src/orchestration.rs
@@ -66,7 +66,10 @@ impl OrchestrationStore {
         self.db.with(|conn| {
             conn.transaction(|conn| {
                 diesel::insert_into(sessions::table)
-                    .values(NewSession { session_key })
+                    .values(NewSession {
+                        session_key,
+                        selected_model: None,
+                    })
                     .on_conflict(sessions::session_key)
                     .do_nothing()
                     .execute(conn)?;
@@ -234,7 +237,10 @@ mod tests {
     fn ensure_session(db: &Arc<Database>, key: &str) {
         db.with(|conn| {
             diesel::insert_into(sessions::table)
-                .values(NewSession { session_key: key })
+                .values(NewSession {
+                    session_key: key,
+                    selected_model: None,
+                })
                 .on_conflict(sessions::session_key)
                 .do_nothing()
                 .execute(conn)?;

--- a/crates/opengoose-persistence/src/schema.rs
+++ b/crates/opengoose-persistence/src/schema.rs
@@ -3,6 +3,7 @@ diesel::table! {
         id -> Integer,
         session_key -> Text,
         active_team -> Nullable<Text>,
+        selected_model -> Nullable<Text>,
         created_at -> Text,
         updated_at -> Text,
     }
@@ -361,7 +362,7 @@ mod tests {
     fn test_sessions_column_count() {
         let db = test_db();
         let cols = column_info(&db, "sessions");
-        assert_eq!(cols.len(), 5, "sessions table should have 5 columns");
+        assert_eq!(cols.len(), 6, "sessions table should have 6 columns");
     }
 
     #[test]

--- a/crates/opengoose-persistence/src/session_store.rs
+++ b/crates/opengoose-persistence/src/session_store.rs
@@ -17,6 +17,7 @@ use crate::schema::{messages, sessions};
 pub struct SessionItem {
     pub session_key: String,
     pub active_team: Option<String>,
+    pub selected_model: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -53,7 +54,10 @@ impl SessionStore {
     /// Upsert a session row: insert if missing, update `updated_at` if exists.
     fn upsert_session(conn: &mut SqliteConnection, key: &str) -> PersistenceResult<()> {
         diesel::insert_into(sessions::table)
-            .values(NewSession { session_key: key })
+            .values(NewSession {
+                session_key: key,
+                selected_model: None,
+            })
             .on_conflict(sessions::session_key)
             .do_update()
             .set(sessions::updated_at.eq(db::now_sql()))
@@ -172,6 +176,43 @@ impl SessionStore {
         })
     }
 
+    /// Set or clear the selected model for a session.
+    pub fn set_selected_model(
+        &self,
+        key: &SessionKey,
+        model: Option<&str>,
+    ) -> PersistenceResult<()> {
+        self.db.with(|conn| {
+            let key_str = key.to_stable_id();
+            diesel::insert_into(sessions::table)
+                .values((
+                    sessions::session_key.eq(&key_str),
+                    sessions::selected_model.eq(model),
+                ))
+                .on_conflict(sessions::session_key)
+                .do_update()
+                .set((
+                    sessions::selected_model.eq(model),
+                    sessions::updated_at.eq(db::now_sql()),
+                ))
+                .execute(conn)?;
+            Ok(())
+        })
+    }
+
+    /// Get the selected model for a session.
+    pub fn get_selected_model(&self, key: &SessionKey) -> PersistenceResult<Option<String>> {
+        self.db.with(|conn| {
+            let key_str = key.to_stable_id();
+            let result = sessions::table
+                .filter(sessions::session_key.eq(&key_str))
+                .select(sessions::selected_model)
+                .first::<Option<String>>(conn)
+                .optional()?;
+            Ok(result.flatten())
+        })
+    }
+
     /// Load all sessions that have an active team set.
     pub fn load_all_active_teams(&self) -> PersistenceResult<HashMap<SessionKey, String>> {
         self.db.with(|conn| {
@@ -198,18 +239,22 @@ impl SessionStore {
                 .select((
                     sessions::session_key,
                     sessions::active_team,
+                    sessions::selected_model,
                     sessions::created_at,
                     sessions::updated_at,
                 ))
-                .load::<(String, Option<String>, String, String)>(conn)?;
+                .load::<(String, Option<String>, Option<String>, String, String)>(conn)?;
             Ok(rows
                 .into_iter()
                 .map(
-                    |(session_key, active_team, created_at, updated_at)| SessionItem {
-                        session_key,
-                        active_team,
-                        created_at,
-                        updated_at,
+                    |(session_key, active_team, selected_model, created_at, updated_at)| {
+                        SessionItem {
+                            session_key,
+                            active_team,
+                            selected_model,
+                            created_at,
+                            updated_at,
+                        }
                     },
                 )
                 .collect())
@@ -318,6 +363,41 @@ mod tests {
         assert_eq!(history.len(), 3);
         assert_eq!(history[0].content, "msg 7");
         assert_eq!(history[2].content, "msg 9");
+    }
+
+    #[test]
+    fn test_set_and_get_selected_model() {
+        let store = SessionStore::new(test_db());
+        let key = test_key();
+
+        store.set_selected_model(&key, Some("gpt-5-mini")).unwrap();
+        assert_eq!(
+            store.get_selected_model(&key).unwrap().as_deref(),
+            Some("gpt-5-mini")
+        );
+
+        store.set_selected_model(&key, None).unwrap();
+        assert!(store.get_selected_model(&key).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_list_sessions_includes_selected_model() {
+        let store = SessionStore::new(test_db());
+        let key = test_key();
+
+        store
+            .append_user_message(&key, "hello", Some("alice"))
+            .unwrap();
+        store
+            .set_selected_model(&key, Some("claude-3-7-sonnet"))
+            .unwrap();
+
+        let sessions = store.list_sessions(10).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].selected_model.as_deref(),
+            Some("claude-3-7-sonnet")
+        );
     }
 
     #[test]

--- a/crates/opengoose-persistence/src/work_items.rs
+++ b/crates/opengoose-persistence/src/work_items.rs
@@ -258,7 +258,10 @@ mod tests {
     fn ensure_session(db: &Arc<Database>, key: &str) {
         db.with(|conn| {
             diesel::insert_into(sessions::table)
-                .values(NewSession { session_key: key })
+                .values(NewSession {
+                    session_key: key,
+                    selected_model: None,
+                })
                 .on_conflict(sessions::session_key)
                 .do_nothing()
                 .execute(conn)?;

--- a/crates/opengoose-profiles/src/lib.rs
+++ b/crates/opengoose-profiles/src/lib.rs
@@ -18,7 +18,9 @@ pub mod workspace;
 pub use defaults::all_defaults;
 pub use error::{ProfileError, ProfileResult};
 pub use goose_bridge::register_profiles_path;
-pub use profile::{AgentProfile, ExtensionRef, ParameterRef, ProfileSettings, SubRecipeRef};
+pub use profile::{
+    AgentProfile, ExtensionRef, ParameterRef, ProfileSettings, ProviderFallback, SubRecipeRef,
+};
 pub use skill::Skill;
 pub use skill_defaults::all_default_skills;
 pub use skill_store::SkillStore;

--- a/crates/opengoose-profiles/src/profile.rs
+++ b/crates/opengoose-profiles/src/profile.rs
@@ -78,6 +78,13 @@ pub struct ParameterRef {
 ///
 /// Aligns with Goose's Recipe `settings` block so profiles can be used
 /// interchangeably with Goose recipes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProviderFallback {
+    pub goose_provider: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub goose_model: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProfileSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -103,6 +110,9 @@ pub struct ProfileSettings {
     /// Shell command to run on failure for cleanup.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub on_failure: Option<String>,
+    /// Ordered fallback providers/models to try when the primary fails.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provider_fallbacks: Vec<ProviderFallback>,
 }
 
 impl ProfileSettings {
@@ -116,6 +126,7 @@ impl ProfileSettings {
             && self.max_retries.is_none()
             && self.retry_checks.is_empty()
             && self.on_failure.is_none()
+            && self.provider_fallbacks.is_empty()
     }
 }
 
@@ -193,6 +204,20 @@ impl AgentProfile {
     /// File-safe name: lowercase, spaces replaced with hyphens.
     pub fn file_name(&self) -> String {
         format!("{}.yaml", self.title.to_lowercase().replace(' ', "-"))
+    }
+
+    /// Clone the profile, overriding the configured Goose model when provided.
+    pub fn with_model_override(&self, goose_model: Option<&str>) -> Self {
+        let Some(goose_model) = goose_model else {
+            return self.clone();
+        };
+
+        let mut profile = self.clone();
+        let settings = profile
+            .settings
+            .get_or_insert_with(ProfileSettings::default);
+        settings.goose_model = Some(goose_model.to_string());
+        profile
     }
 
     /// Parse from YAML string.
@@ -407,6 +432,32 @@ settings:
     }
 
     #[test]
+    fn test_profile_with_provider_fallbacks() {
+        let yaml = r#"
+version: "1.0.0"
+title: "fallback-agent"
+instructions: "Fail over if needed"
+settings:
+  goose_provider: anthropic
+  goose_model: claude-sonnet-4-20250514
+  provider_fallbacks:
+    - goose_provider: openai
+      goose_model: gpt-4.1
+    - goose_provider: xai
+"#;
+        let profile = AgentProfile::from_yaml(yaml).unwrap();
+        let settings = profile.settings.unwrap();
+        assert_eq!(settings.provider_fallbacks.len(), 2);
+        assert_eq!(settings.provider_fallbacks[0].goose_provider, "openai");
+        assert_eq!(
+            settings.provider_fallbacks[0].goose_model.as_deref(),
+            Some("gpt-4.1")
+        );
+        assert_eq!(settings.provider_fallbacks[1].goose_provider, "xai");
+        assert!(settings.provider_fallbacks[1].goose_model.is_none());
+    }
+
+    #[test]
     fn test_profile_with_extensions() {
         let yaml = r#"
 version: "1.0.0"
@@ -521,6 +572,26 @@ settings:
             ..ProfileSettings::default()
         };
         assert!(!settings.is_empty());
+    }
+
+    #[test]
+    fn with_model_override_sets_goose_model() {
+        let profile = AgentProfile::from_yaml(
+            r#"
+version: "1.0.0"
+title: "main"
+"#,
+        )
+        .unwrap();
+
+        let overridden = profile.with_model_override(Some("gpt-5-mini"));
+        assert_eq!(
+            overridden
+                .settings
+                .as_ref()
+                .and_then(|settings| settings.goose_model.as_deref()),
+            Some("gpt-5-mini")
+        );
     }
 
     #[test]

--- a/crates/opengoose-teams/src/chain_executor.rs
+++ b/crates/opengoose-teams/src/chain_executor.rs
@@ -23,9 +23,10 @@ impl<'a> ChainExecutor<'a> {
         team: &'a TeamDefinition,
         profile_store: &'a ProfileStore,
         pool: &'a mut HashMap<String, AgentRunner>,
+        model_override: Option<&'a str>,
     ) -> Self {
         Self {
-            ctx: ExecutorContext::new(team, profile_store, pool),
+            ctx: ExecutorContext::new(team, profile_store, pool, model_override),
         }
     }
 
@@ -51,7 +52,11 @@ impl<'a> ChainExecutor<'a> {
         let history_pairs = load_history_pairs(ctx);
 
         for (i, team_agent) in self.ctx.team.agents.iter().enumerate().skip(start_step) {
-            let profile = resolve_profile(self.ctx.profile_store, &team_agent.profile)?;
+            let profile = resolve_profile(
+                self.ctx.profile_store,
+                &team_agent.profile,
+                self.ctx.model_override,
+            )?;
 
             let step_id = ctx.work_items().create(
                 &session_key,

--- a/crates/opengoose-teams/src/executor_context.rs
+++ b/crates/opengoose-teams/src/executor_context.rs
@@ -15,6 +15,7 @@ pub(crate) struct ExecutorContext<'a> {
     pub team: &'a TeamDefinition,
     pub profile_store: &'a ProfileStore,
     pub pool: &'a mut HashMap<String, AgentRunner>,
+    pub model_override: Option<&'a str>,
 }
 
 impl<'a> ExecutorContext<'a> {
@@ -22,11 +23,13 @@ impl<'a> ExecutorContext<'a> {
         team: &'a TeamDefinition,
         profile_store: &'a ProfileStore,
         pool: &'a mut HashMap<String, AgentRunner>,
+        model_override: Option<&'a str>,
     ) -> Self {
         Self {
             team,
             profile_store,
             pool,
+            model_override,
         }
     }
 }
@@ -36,9 +39,10 @@ impl<'a> ExecutorContext<'a> {
 pub(crate) fn resolve_profile(
     store: &ProfileStore,
     name: &str,
+    model_override: Option<&str>,
 ) -> Result<opengoose_profiles::AgentProfile, TeamError> {
     match store.get(name) {
-        Ok(profile) => Ok(profile),
+        Ok(profile) => Ok(profile.with_model_override(model_override)),
         Err(opengoose_profiles::ProfileError::NotFound(_)) => {
             Err(TeamError::ProfileNotFound(name.to_string()))
         }
@@ -63,7 +67,7 @@ mod tests {
     #[test]
     fn resolve_profile_returns_error_for_missing() {
         let store = ProfileStore::with_dir(std::path::PathBuf::from("/tmp/nonexistent-profiles"));
-        let err = resolve_profile(&store, "ghost").unwrap_err();
+        let err = resolve_profile(&store, "ghost", None).unwrap_err();
         assert!(err.to_string().contains("profile `ghost` not found"));
     }
 
@@ -71,7 +75,7 @@ mod tests {
     fn resolve_profile_preserves_store_failures() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         let store = ProfileStore::with_dir(tmp.path().to_path_buf());
-        let err = resolve_profile(&store, "ghost").unwrap_err();
+        let err = resolve_profile(&store, "ghost", None).unwrap_err();
         assert!(matches!(err, TeamError::Store(_)));
     }
 }

--- a/crates/opengoose-teams/src/fan_out_executor.rs
+++ b/crates/opengoose-teams/src/fan_out_executor.rs
@@ -24,9 +24,10 @@ impl<'a> FanOutExecutor<'a> {
         team: &'a TeamDefinition,
         profile_store: &'a ProfileStore,
         pool: &'a mut HashMap<String, AgentRunner>,
+        model_override: Option<&'a str>,
     ) -> Self {
         Self {
-            ctx: ExecutorContext::new(team, profile_store, pool),
+            ctx: ExecutorContext::new(team, profile_store, pool, model_override),
         }
     }
 
@@ -51,7 +52,11 @@ impl<'a> FanOutExecutor<'a> {
         let mut join_set = JoinSet::new();
 
         for (i, team_agent) in self.ctx.team.agents.iter().enumerate() {
-            let profile = resolve_profile(self.ctx.profile_store, &team_agent.profile)?;
+            let profile = resolve_profile(
+                self.ctx.profile_store,
+                &team_agent.profile,
+                self.ctx.model_override,
+            )?;
 
             let step_id = ctx.work_items().create(
                 &session_key,
@@ -115,8 +120,11 @@ impl<'a> FanOutExecutor<'a> {
                 let broadcast_section = format_broadcast_context(ctx, "**Team broadcasts:**");
                 let summary_input = build_summary_input(input, &results, &broadcast_section);
 
-                let first_profile =
-                    resolve_profile(self.ctx.profile_store, &self.ctx.team.agents[0].profile)?;
+                let first_profile = resolve_profile(
+                    self.ctx.profile_store,
+                    &self.ctx.team.agents[0].profile,
+                    self.ctx.model_override,
+                )?;
 
                 let runner = get_or_create(self.ctx.pool, &first_profile, &session_key).await?;
                 let output = runner.run(&summary_input).await?;

--- a/crates/opengoose-teams/src/headless.rs
+++ b/crates/opengoose-teams/src/headless.rs
@@ -22,14 +22,33 @@ pub async fn run_headless(
     db: Arc<Database>,
     event_bus: EventBus,
 ) -> Result<(String, String)> {
+    run_headless_with_model(team_name, input, db, event_bus, None).await
+}
+
+/// Run a team workflow headlessly with an explicit session model override.
+///
+/// Returns `(team_run_id, result)` on success.
+pub async fn run_headless_with_model(
+    team_name: &str,
+    input: &str,
+    db: Arc<Database>,
+    event_bus: EventBus,
+    selected_model: Option<String>,
+) -> Result<(String, String)> {
+    let model_override = selected_model.clone();
     run_headless_with(
         team_name,
         input,
         db,
         event_bus,
-        |team, profile_store, input, ctx| async move {
-            let orchestrator = TeamOrchestrator::new(team, profile_store);
-            orchestrator.execute(&input, &ctx).await
+        selected_model,
+        move |team, profile_store, input, ctx| {
+            let model_override = model_override.clone();
+            async move {
+                let orchestrator =
+                    TeamOrchestrator::new_with_model_override(team, profile_store, model_override);
+                orchestrator.execute(&input, &ctx).await
+            }
         },
     )
     .await
@@ -60,6 +79,7 @@ async fn run_headless_with<Execute, Fut>(
     input: &str,
     db: Arc<Database>,
     event_bus: EventBus,
+    selected_model: Option<String>,
     execute: Execute,
 ) -> Result<(String, String)>
 where
@@ -68,7 +88,8 @@ where
 {
     let team = load_team(team_name)?;
     let profile_store = ProfileStore::new()?;
-    let (team_run_id, ctx) = create_headless_context(input, db, event_bus)?;
+    let (team_run_id, ctx) =
+        create_headless_context(input, db, event_bus, selected_model.as_deref())?;
     let result = execute(team, profile_store, input.to_string(), ctx).await?;
     Ok((team_run_id, result))
 }
@@ -115,6 +136,7 @@ fn create_headless_context(
     input: &str,
     db: Arc<Database>,
     event_bus: EventBus,
+    selected_model: Option<&str>,
 ) -> Result<(String, OrchestrationContext)> {
     let team_run_id = Uuid::new_v4().to_string();
     let session_key = SessionKey::new(Platform::Custom("cli".into()), "headless", &team_run_id);
@@ -123,6 +145,10 @@ fn create_headless_context(
     // Ensure session exists for FK constraints
     ctx.sessions()
         .append_user_message(&ctx.session_key, input, Some("cli"))?;
+    if let Some(selected_model) = selected_model {
+        ctx.sessions()
+            .set_selected_model(&ctx.session_key, Some(selected_model))?;
+    }
 
     Ok((team_run_id, ctx))
 }
@@ -231,7 +257,8 @@ mod tests {
                     "hello world",
                     db,
                     bus,
-                    |team, _profile_store, input, ctx| async move {
+                    None,
+                    |team: TeamDefinition, _profile_store, input, ctx| async move {
                         assert_eq!(team.name(), "demo-team");
                         assert_eq!(ctx.team_run_id, ctx.session_key.channel_id);
                         assert_eq!(input, "hello world");
@@ -282,6 +309,7 @@ mod tests {
                     "hello",
                     Arc::new(Database::open_in_memory().unwrap()),
                     EventBus::new(16),
+                    None,
                     |_team, _profile_store, _input, _ctx| async move { bail!("boom") },
                 )
                 .await

--- a/crates/opengoose-teams/src/lib.rs
+++ b/crates/opengoose-teams/src/lib.rs
@@ -29,7 +29,7 @@ pub mod triggers;
 pub use context::OrchestrationContext;
 pub use defaults::all_defaults;
 pub use error::{TeamError, TeamResult};
-pub use headless::{resume_headless, run_headless};
+pub use headless::{resume_headless, run_headless, run_headless_with_model};
 pub use message_bus::MessageBus;
 pub use orchestrator::TeamOrchestrator;
 pub use recipe_bridge::{profile_to_recipe, recipe_to_profile};

--- a/crates/opengoose-teams/src/orchestrator.rs
+++ b/crates/opengoose-teams/src/orchestrator.rs
@@ -10,6 +10,7 @@ use opengoose_types::AppEventKind;
 
 use crate::chain_executor::{self, ChainExecutor};
 use crate::context::OrchestrationContext;
+use crate::executor_context::resolve_profile;
 use crate::fan_out_executor::FanOutExecutor;
 use crate::router_executor::RouterExecutor;
 use crate::runner::{AgentOutput, AgentRunner};
@@ -32,6 +33,7 @@ struct DelegationOutcome {
 pub struct TeamOrchestrator {
     team: TeamDefinition,
     profile_store: ProfileStore,
+    model_override: Option<String>,
     /// Per-session agent pool, keyed by agent profile name.
     /// Shared across `execute` and `resume` calls so extensions stay loaded.
     pool: Mutex<HashMap<String, AgentRunner>>,
@@ -39,9 +41,18 @@ pub struct TeamOrchestrator {
 
 impl TeamOrchestrator {
     pub fn new(team: TeamDefinition, profile_store: ProfileStore) -> Self {
+        Self::new_with_model_override(team, profile_store, None)
+    }
+
+    pub fn new_with_model_override(
+        team: TeamDefinition,
+        profile_store: ProfileStore,
+        model_override: Option<String>,
+    ) -> Self {
         Self {
             team,
             profile_store,
+            model_override,
             pool: Mutex::new(HashMap::new()),
         }
     }
@@ -85,19 +96,34 @@ impl TeamOrchestrator {
 
         let result = match self.team.workflow {
             OrchestrationPattern::Chain => {
-                ChainExecutor::new(&self.team, &self.profile_store, &mut pool)
-                    .execute(input, ctx, parent_id)
-                    .await
+                ChainExecutor::new(
+                    &self.team,
+                    &self.profile_store,
+                    &mut pool,
+                    self.model_override.as_deref(),
+                )
+                .execute(input, ctx, parent_id)
+                .await
             }
             OrchestrationPattern::FanOut => {
-                FanOutExecutor::new(&self.team, &self.profile_store, &mut pool)
-                    .execute(input, ctx, parent_id)
-                    .await
+                FanOutExecutor::new(
+                    &self.team,
+                    &self.profile_store,
+                    &mut pool,
+                    self.model_override.as_deref(),
+                )
+                .execute(input, ctx, parent_id)
+                .await
             }
             OrchestrationPattern::Router => {
-                RouterExecutor::new(&self.team, &self.profile_store, &mut pool)
-                    .execute(input, ctx, parent_id)
-                    .await
+                RouterExecutor::new(
+                    &self.team,
+                    &self.profile_store,
+                    &mut pool,
+                    self.model_override.as_deref(),
+                )
+                .execute(input, ctx, parent_id)
+                .await
             }
         };
 
@@ -207,9 +233,14 @@ impl TeamOrchestrator {
 
         let mut pool = self.pool.lock().await;
 
-        let result = ChainExecutor::new(&self.team, &self.profile_store, &mut pool)
-            .execute_from_step(&last_output, ctx, parent_work_id, start_step as usize)
-            .await;
+        let result = ChainExecutor::new(
+            &self.team,
+            &self.profile_store,
+            &mut pool,
+            self.model_override.as_deref(),
+        )
+        .execute_from_step(&last_output, ctx, parent_work_id, start_step as usize)
+        .await;
 
         match &result {
             Ok(response) => {
@@ -261,7 +292,11 @@ impl TeamOrchestrator {
             ctx.work_items().assign(work_id, &msg.recipient, None)?;
             ctx.work_items().set_input(work_id, &msg.content)?;
 
-            let profile = match self.profile_store.get(&msg.recipient) {
+            let profile = match resolve_profile(
+                &self.profile_store,
+                &msg.recipient,
+                self.model_override.as_deref(),
+            ) {
                 Ok(p) => p,
                 Err(_) => {
                     let err = format!("profile '{}' not found", msg.recipient);

--- a/crates/opengoose-teams/src/recipe_bridge.rs
+++ b/crates/opengoose-teams/src/recipe_bridge.rs
@@ -135,6 +135,7 @@ pub fn recipe_to_profile(recipe: &Recipe) -> AgentProfile {
                 })
                 .unwrap_or_default(),
             on_failure: recipe.retry.as_ref().and_then(|r| r.on_failure.clone()),
+            provider_fallbacks: vec![],
         })
     } else {
         None
@@ -425,6 +426,7 @@ mod tests {
             settings: Some(ProfileSettings {
                 goose_provider: Some("anthropic".into()),
                 goose_model: Some("claude-sonnet-4-20250514".into()),
+                provider_fallbacks: vec![],
                 temperature: Some(0.7),
                 max_turns: Some(10),
                 message_retention_days: None,

--- a/crates/opengoose-teams/src/router_executor.rs
+++ b/crates/opengoose-teams/src/router_executor.rs
@@ -23,9 +23,10 @@ impl<'a> RouterExecutor<'a> {
         team: &'a TeamDefinition,
         profile_store: &'a ProfileStore,
         pool: &'a mut HashMap<String, AgentRunner>,
+        model_override: Option<&'a str>,
     ) -> Self {
         Self {
-            ctx: ExecutorContext::new(team, profile_store, pool),
+            ctx: ExecutorContext::new(team, profile_store, pool, model_override),
         }
     }
 
@@ -83,7 +84,11 @@ impl<'a> RouterExecutor<'a> {
         ctx.work_items()
             .assign(step_id, &chosen_agent.profile, Some(chosen_idx as i32))?;
 
-        let profile = resolve_profile(self.ctx.profile_store, &chosen_agent.profile)?;
+        let profile = resolve_profile(
+            self.ctx.profile_store,
+            &chosen_agent.profile,
+            self.ctx.model_override,
+        )?;
 
         let runner = get_or_create(self.ctx.pool, &profile, &session_key).await?;
 

--- a/crates/opengoose-teams/src/runner.rs
+++ b/crates/opengoose-teams/src/runner.rs
@@ -23,6 +23,80 @@ use crate::recipe_bridge;
 const FALLBACK_PROVIDER: &str = "anthropic";
 const FALLBACK_MODEL: &str = "claude-sonnet-4-6";
 
+#[derive(Debug, Clone)]
+struct ProviderTarget {
+    provider_name: String,
+    model_name: String,
+}
+
+#[derive(Debug)]
+struct AttemptFailure {
+    error: anyhow::Error,
+    emitted_content: bool,
+}
+
+impl AttemptFailure {
+    fn new(error: anyhow::Error, emitted_content: bool) -> Self {
+        Self {
+            error,
+            emitted_content,
+        }
+    }
+}
+
+fn resolve_provider_chain(profile: &AgentProfile) -> Vec<ProviderTarget> {
+    let settings = profile.settings.as_ref();
+    let goose_cfg = GooseConfig::global();
+    let provider_name = settings
+        .and_then(|s| s.goose_provider.as_deref())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            goose_cfg
+                .get_param::<String>("GOOSE_PROVIDER")
+                .unwrap_or_else(|_| FALLBACK_PROVIDER.to_string())
+        });
+    let model_name = settings
+        .and_then(|s| s.goose_model.as_deref())
+        .map(str::to_string)
+        .unwrap_or_else(|| {
+            goose_cfg
+                .get_param::<String>("GOOSE_MODEL")
+                .unwrap_or_else(|_| FALLBACK_MODEL.to_string())
+        });
+
+    let mut chain = vec![ProviderTarget {
+        provider_name: provider_name.clone(),
+        model_name: model_name.clone(),
+    }];
+
+    if let Some(settings) = settings {
+        for fallback in &settings.provider_fallbacks {
+            if fallback.goose_provider.trim().is_empty() {
+                continue;
+            }
+
+            let target = ProviderTarget {
+                provider_name: fallback.goose_provider.clone(),
+                model_name: fallback
+                    .goose_model
+                    .clone()
+                    .unwrap_or_else(|| model_name.clone()),
+            };
+
+            if chain.iter().any(|candidate| {
+                candidate.provider_name == target.provider_name
+                    && candidate.model_name == target.model_name
+            }) {
+                continue;
+            }
+
+            chain.push(target);
+        }
+    }
+
+    chain
+}
+
 /// A parsed agent output: the main response plus any structured actions.
 #[derive(Debug)]
 pub struct AgentOutput {
@@ -39,6 +113,7 @@ pub struct AgentRunner {
     agent: Arc<Agent>,
     session_id: String,
     profile_name: String,
+    provider_chain: Vec<ProviderTarget>,
     max_turns: u32,
     retry_config: Option<goose::agents::RetryConfig>,
 }
@@ -75,34 +150,8 @@ impl AgentRunner {
             .await
             .map_err(|e| anyhow!("failed to create goose session: {e}"))?;
         let session_id = session.id;
-
-        // Set provider/model — profile settings take priority; fall back to
-        // the global Goose config (GOOSE_PROVIDER / GOOSE_MODEL env or yaml),
-        // then to hard-coded last-resort values.
         let settings = profile.settings.as_ref();
-        let goose_cfg = GooseConfig::global();
-        let provider_name = settings
-            .and_then(|s| s.goose_provider.as_deref())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| {
-                goose_cfg
-                    .get_param::<String>("GOOSE_PROVIDER")
-                    .unwrap_or_else(|_| FALLBACK_PROVIDER.to_string())
-            });
-        let model_name = settings
-            .and_then(|s| s.goose_model.as_deref())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| {
-                goose_cfg
-                    .get_param::<String>("GOOSE_MODEL")
-                    .unwrap_or_else(|_| FALLBACK_MODEL.to_string())
-            });
-
-        let provider = create_with_named_model(&provider_name, &model_name, vec![])
-            .await
-            .map_err(|e| anyhow!("failed to create provider: {e}"))?;
-
-        agent.update_provider(provider, &session_id).await?;
+        let provider_chain = resolve_provider_chain(profile);
 
         // Set system prompt.
         //
@@ -179,6 +228,7 @@ impl AgentRunner {
             agent,
             session_id,
             profile_name: profile.title.clone(),
+            provider_chain,
             max_turns,
             retry_config,
         })
@@ -296,6 +346,48 @@ impl AgentRunner {
     /// When a response schema is set, the last assistant message typically
     /// contains the validated JSON from the FinalOutputTool.
     pub async fn run_structured(&self, input: &str) -> Result<String> {
+        for (index, target) in self.provider_chain.iter().enumerate() {
+            if let Err(err) = self.activate_provider(target).await {
+                if index + 1 < self.provider_chain.len() {
+                    info!(
+                        profile = %self.profile_name,
+                        provider = %target.provider_name,
+                        model = %target.model_name,
+                        error = %err,
+                        "provider activation failed, trying fallback"
+                    );
+                    continue;
+                }
+                return Err(err);
+            }
+
+            match self.run_structured_once(input).await {
+                Ok(output) => return Ok(output),
+                Err(failure)
+                    if index + 1 < self.provider_chain.len() && !failure.emitted_content =>
+                {
+                    info!(
+                        profile = %self.profile_name,
+                        provider = %target.provider_name,
+                        model = %target.model_name,
+                        error = %failure.error,
+                        "provider attempt failed before output, trying fallback"
+                    );
+                }
+                Err(failure) => return Err(failure.error),
+            }
+        }
+
+        Err(anyhow!(
+            "no provider targets configured for {}",
+            self.profile_name
+        ))
+    }
+
+    async fn run_structured_once(
+        &self,
+        input: &str,
+    ) -> std::result::Result<String, AttemptFailure> {
         let user_message = Message::user().with_text(input);
 
         let session_config = SessionConfig {
@@ -305,11 +397,17 @@ impl AgentRunner {
             retry_config: self.retry_config.clone(),
         };
 
-        let mut stream = self.agent.reply(user_message, session_config, None).await?;
+        let mut stream = self
+            .agent
+            .reply(user_message, session_config, None)
+            .await
+            .map_err(|err| AttemptFailure::new(err, false))?;
 
         let mut last_text = String::new();
         while let Some(event_result) = stream.next().await {
-            if let AgentEvent::Message(msg) = event_result? {
+            let event =
+                event_result.map_err(|err| AttemptFailure::new(err, !last_text.is_empty()))?;
+            if let AgentEvent::Message(msg) = event {
                 let text = msg.as_concat_text();
                 if !text.is_empty() {
                     last_text = text;
@@ -322,6 +420,45 @@ impl AgentRunner {
 
     /// Send a message and collect the full response, parsing @mentions and broadcasts.
     pub async fn run(&self, input: &str) -> Result<AgentOutput> {
+        for (index, target) in self.provider_chain.iter().enumerate() {
+            if let Err(err) = self.activate_provider(target).await {
+                if index + 1 < self.provider_chain.len() {
+                    info!(
+                        profile = %self.profile_name,
+                        provider = %target.provider_name,
+                        model = %target.model_name,
+                        error = %err,
+                        "provider activation failed, trying fallback"
+                    );
+                    continue;
+                }
+                return Err(err);
+            }
+
+            match self.run_once(input).await {
+                Ok(output) => return Ok(output),
+                Err(failure)
+                    if index + 1 < self.provider_chain.len() && !failure.emitted_content =>
+                {
+                    info!(
+                        profile = %self.profile_name,
+                        provider = %target.provider_name,
+                        model = %target.model_name,
+                        error = %failure.error,
+                        "provider attempt failed before output, trying fallback"
+                    );
+                }
+                Err(failure) => return Err(failure.error),
+            }
+        }
+
+        Err(anyhow!(
+            "no provider targets configured for {}",
+            self.profile_name
+        ))
+    }
+
+    async fn run_once(&self, input: &str) -> std::result::Result<AgentOutput, AttemptFailure> {
         let user_message = Message::user().with_text(input);
 
         let session_config = SessionConfig {
@@ -331,11 +468,17 @@ impl AgentRunner {
             retry_config: self.retry_config.clone(),
         };
 
-        let mut stream = self.agent.reply(user_message, session_config, None).await?;
+        let mut stream = self
+            .agent
+            .reply(user_message, session_config, None)
+            .await
+            .map_err(|err| AttemptFailure::new(err, false))?;
 
         let mut response_parts = Vec::new();
         while let Some(event_result) = stream.next().await {
-            if let AgentEvent::Message(msg) = event_result? {
+            let event =
+                event_result.map_err(|err| AttemptFailure::new(err, !response_parts.is_empty()))?;
+            if let AgentEvent::Message(msg) = event {
                 let text = msg.as_concat_text();
                 if !text.is_empty() {
                     response_parts.push(text);
@@ -364,6 +507,49 @@ impl AgentRunner {
         input: &str,
         tx: &broadcast::Sender<StreamChunk>,
     ) -> Result<AgentOutput> {
+        for (index, target) in self.provider_chain.iter().enumerate() {
+            if let Err(err) = self.activate_provider(target).await {
+                if index + 1 < self.provider_chain.len() {
+                    info!(
+                        profile = %self.profile_name,
+                        provider = %target.provider_name,
+                        model = %target.model_name,
+                        error = %err,
+                        "provider activation failed, trying fallback"
+                    );
+                    continue;
+                }
+                return Err(err);
+            }
+
+            match self.run_streaming_once(input, tx).await {
+                Ok(output) => return Ok(output),
+                Err(failure)
+                    if index + 1 < self.provider_chain.len() && !failure.emitted_content =>
+                {
+                    info!(
+                        profile = %self.profile_name,
+                        provider = %target.provider_name,
+                        model = %target.model_name,
+                        error = %failure.error,
+                        "provider attempt failed before output, trying fallback"
+                    );
+                }
+                Err(failure) => return Err(failure.error),
+            }
+        }
+
+        Err(anyhow!(
+            "no provider targets configured for {}",
+            self.profile_name
+        ))
+    }
+
+    async fn run_streaming_once(
+        &self,
+        input: &str,
+        tx: &broadcast::Sender<StreamChunk>,
+    ) -> std::result::Result<AgentOutput, AttemptFailure> {
         let user_message = Message::user().with_text(input);
 
         let session_config = SessionConfig {
@@ -373,11 +559,17 @@ impl AgentRunner {
             retry_config: self.retry_config.clone(),
         };
 
-        let mut stream = self.agent.reply(user_message, session_config, None).await?;
+        let mut stream = self
+            .agent
+            .reply(user_message, session_config, None)
+            .await
+            .map_err(|err| AttemptFailure::new(err, false))?;
 
         let mut response_parts = Vec::new();
         while let Some(event_result) = stream.next().await {
-            if let AgentEvent::Message(msg) = event_result? {
+            let event =
+                event_result.map_err(|err| AttemptFailure::new(err, !response_parts.is_empty()))?;
+            if let AgentEvent::Message(msg) = event {
                 let text = msg.as_concat_text();
                 if !text.is_empty() {
                     let _ = tx.send(StreamChunk::Delta(text.clone()));
@@ -395,6 +587,29 @@ impl AgentRunner {
         );
 
         Ok(parse_agent_output(&raw_response))
+    }
+
+    async fn activate_provider(&self, target: &ProviderTarget) -> Result<()> {
+        let provider = create_with_named_model(&target.provider_name, &target.model_name, vec![])
+            .await
+            .map_err(|e| {
+                anyhow!(
+                    "failed to create provider {} / {}: {e}",
+                    target.provider_name,
+                    target.model_name
+                )
+            })?;
+
+        self.agent
+            .update_provider(provider, &self.session_id)
+            .await
+            .map_err(|e| {
+                anyhow!(
+                    "failed to activate provider {} / {}: {e}",
+                    target.provider_name,
+                    target.model_name
+                )
+            })
     }
 }
 

--- a/crates/opengoose-web/src/data/dashboard.rs
+++ b/crates/opengoose-web/src/data/dashboard.rs
@@ -510,6 +510,7 @@ mod tests {
             summary: SessionSummary {
                 session_key: session_key.into(),
                 active_team: active_team.map(str::to_string),
+                selected_model: None,
                 created_at: "2026-03-10 10:00".into(),
                 updated_at: "2026-03-10 10:15".into(),
             },

--- a/crates/opengoose-web/src/data/sessions.rs
+++ b/crates/opengoose-web/src/data/sessions.rs
@@ -1,13 +1,16 @@
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use opengoose_persistence::{Database, HistoryMessage, SessionStore, SessionSummary};
+use opengoose_profiles::ProfileStore;
+use opengoose_teams::TeamStore;
 use opengoose_types::SessionKey;
 use urlencoding::encode;
 
 use crate::data::utils::{platform_tone, preview};
 use crate::data::views::{
-    MessageBubble, MetaRow, SessionDetailView, SessionListItem, SessionsPageView,
+    MessageBubble, MetaRow, SelectOption, SessionDetailView, SessionListItem, SessionsPageView,
 };
 
 #[derive(Clone)]
@@ -88,6 +91,7 @@ pub(super) fn mock_sessions() -> Vec<SessionRecord> {
             summary: SessionSummary {
                 session_key: "discord:ns:studio-a:ops-bridge".into(),
                 active_team: Some("feature-dev".into()),
+                selected_model: Some("claude-sonnet-4-20250514".into()),
                 created_at: "2026-03-10 09:00".into(),
                 updated_at: "2026-03-10 10:28".into(),
             },
@@ -120,6 +124,7 @@ pub(super) fn mock_sessions() -> Vec<SessionRecord> {
             summary: SessionSummary {
                 session_key: "telegram:direct:founder-42".into(),
                 active_team: None,
+                selected_model: None,
                 created_at: "2026-03-10 08:21".into(),
                 updated_at: "2026-03-10 09:44".into(),
             },
@@ -190,7 +195,9 @@ pub(super) fn build_session_detail(
     source_label: &str,
 ) -> SessionDetailView {
     let parsed = SessionKey::from_stable_id(&session.summary.session_key);
+    let selected_model = session.summary.selected_model.clone().unwrap_or_default();
     SessionDetailView {
+        session_key: session.summary.session_key.clone(),
         title: format!("Session {}", parsed.channel_id),
         subtitle: match &parsed.namespace {
             Some(namespace) => format!("{} / {}", parsed.platform.as_str(), namespace),
@@ -211,6 +218,14 @@ pub(super) fn build_session_detail(
                     .unwrap_or_else(|| "None".into()),
             },
             MetaRow {
+                label: "Selected model".into(),
+                value: session
+                    .summary
+                    .selected_model
+                    .clone()
+                    .unwrap_or_else(|| "Profile default".into()),
+            },
+            MetaRow {
                 label: "Created".into(),
                 value: session.summary.created_at.clone(),
             },
@@ -219,6 +234,12 @@ pub(super) fn build_session_detail(
                 value: session.summary.updated_at.clone(),
             },
         ],
+        notice: None,
+        selected_model,
+        model_options: session_model_options(
+            session.summary.active_team.as_deref(),
+            session.summary.selected_model.as_deref(),
+        ),
         messages: session
             .messages
             .iter()
@@ -247,6 +268,77 @@ pub(super) fn build_session_detail(
     }
 }
 
+fn session_model_options(
+    active_team: Option<&str>,
+    selected_model: Option<&str>,
+) -> Vec<SelectOption> {
+    let mut seen = BTreeSet::new();
+    let mut options = Vec::new();
+
+    let mut push_option = |value: &str, label: String| {
+        if value.trim().is_empty() || !seen.insert(value.to_string()) {
+            return;
+        }
+        options.push(SelectOption {
+            value: value.to_string(),
+            label,
+            selected: selected_model == Some(value),
+        });
+    };
+
+    if let Some(selected_model) = selected_model {
+        push_option(
+            selected_model,
+            format!("{selected_model} (current override)"),
+        );
+    }
+
+    if let Ok(profile_store) = ProfileStore::new() {
+        if let Ok(profile) = profile_store.get("main") {
+            append_profile_model_options(&profile, &mut push_option);
+        }
+
+        if let Some(active_team) = active_team
+            && let Ok(team_store) = TeamStore::new()
+            && let Ok(team) = team_store.get(active_team)
+        {
+            for team_agent in team.agents {
+                if let Ok(profile) = profile_store.get(&team_agent.profile) {
+                    append_profile_model_options(&profile, &mut push_option);
+                }
+            }
+        }
+    }
+
+    options
+}
+
+fn append_profile_model_options(
+    profile: &opengoose_profiles::AgentProfile,
+    push_option: &mut impl FnMut(&str, String),
+) {
+    let Some(settings) = profile.settings.as_ref() else {
+        return;
+    };
+
+    if let Some(model) = settings.goose_model.as_deref() {
+        let provider = settings
+            .goose_provider
+            .as_deref()
+            .unwrap_or("profile default");
+        push_option(model, format!("{model} ({provider})"));
+    }
+
+    for fallback in &settings.provider_fallbacks {
+        if let Some(model) = fallback.goose_model.as_deref() {
+            push_option(
+                model,
+                format!("{model} (fallback via {})", fallback.goose_provider),
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::items_after_test_module)]
 mod tests {
@@ -259,6 +351,7 @@ mod tests {
             summary: SessionSummary {
                 session_key: session_key.into(),
                 active_team: active_team.map(str::to_string),
+                selected_model: None,
                 created_at: "2026-03-10 09:00".into(),
                 updated_at: "2026-03-10 10:00".into(),
             },
@@ -289,6 +382,22 @@ mod tests {
     fn mock_sessions_second_has_no_active_team() {
         let sessions = mock_sessions();
         assert!(sessions[1].summary.active_team.is_none());
+    }
+
+    #[test]
+    fn build_session_detail_surfaces_selected_model() {
+        let mut session = sample_session("discord:ns:chan-1", Some("feature-dev"));
+        session.summary.selected_model = Some("gpt-5-mini".into());
+
+        let detail = build_session_detail(&session, "Live");
+
+        assert_eq!(detail.selected_model, "gpt-5-mini");
+        assert!(
+            detail
+                .meta
+                .iter()
+                .any(|row| row.label == "Selected model" && row.value == "gpt-5-mini")
+        );
     }
 
     // --- build_session_list_items ---

--- a/crates/opengoose-web/src/data/views/sessions.rs
+++ b/crates/opengoose-web/src/data/views/sessions.rs
@@ -1,4 +1,4 @@
-use super::MetaRow;
+use super::{MetaRow, Notice, SelectOption};
 
 /// Summary row for the session list sidebar.
 #[derive(Clone)]
@@ -27,10 +27,14 @@ pub struct MessageBubble {
 /// Full detail panel for a selected session, including messages and metadata.
 #[derive(Clone)]
 pub struct SessionDetailView {
+    pub session_key: String,
     pub title: String,
     pub subtitle: String,
     pub source_label: String,
     pub meta: Vec<MetaRow>,
+    pub notice: Option<Notice>,
+    pub selected_model: String,
+    pub model_options: Vec<SelectOption>,
     pub messages: Vec<MessageBubble>,
     pub empty_hint: String,
 }
@@ -110,6 +114,7 @@ mod tests {
     #[test]
     fn session_detail_view_empty_messages() {
         let detail = SessionDetailView {
+            session_key: "discord:guild:chan".into(),
             title: "My Session".into(),
             subtitle: "Discord · guild".into(),
             source_label: "Live".into(),
@@ -117,6 +122,9 @@ mod tests {
                 label: "Key".into(),
                 value: "discord:guild:chan".into(),
             }],
+            notice: None,
+            selected_model: String::new(),
+            model_options: vec![],
             messages: vec![],
             empty_hint: "No messages yet.".into(),
         };

--- a/crates/opengoose-web/src/handlers/sessions.rs
+++ b/crates/opengoose-web/src/handlers/sessions.rs
@@ -10,6 +10,7 @@ use crate::state::AppState;
 pub struct SessionItem {
     pub session_key: String,
     pub active_team: Option<String>,
+    pub selected_model: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -44,6 +45,7 @@ pub async fn list_sessions(
             .map(|s| SessionItem {
                 session_key: s.session_key,
                 active_team: s.active_team,
+                selected_model: s.selected_model,
                 created_at: s.created_at,
                 updated_at: s.updated_at,
             })
@@ -181,6 +183,7 @@ mod tests {
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].session_key, "discord:ns:guild123:chan456");
+        assert!(sessions[0].selected_model.is_none());
     }
 
     #[tokio::test]
@@ -199,6 +202,26 @@ mod tests {
             .expect("list_sessions should succeed");
 
         assert_eq!(sessions.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn list_sessions_includes_selected_model() {
+        let state = make_state();
+        let key = SessionKey::from_stable_id("discord:ns:guild123:chan456");
+        state
+            .session_store
+            .append_user_message(&key, "hello world", Some("alice"))
+            .expect("append should succeed");
+        state
+            .session_store
+            .set_selected_model(&key, Some("gpt-5-mini"))
+            .expect("selected model should persist");
+
+        let Json(sessions) = list_sessions(State(state), Query(ListQuery { limit: 50 }))
+            .await
+            .expect("list_sessions should succeed");
+
+        assert_eq!(sessions[0].selected_model.as_deref(), Some("gpt-5-mini"));
     }
 
     #[tokio::test]

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -50,7 +50,7 @@ pub async fn serve(options: WebOptions) -> Result<()> {
         db: db.clone(),
         remote_registry: remote_state.registry.clone(),
         channel_metrics: api_state.channel_metrics.clone(),
-        event_bus: api_state.event_bus.clone(),
+        _event_bus: api_state.event_bus.clone(),
     };
     live::spawn_live_event_watcher(state.db.clone(), api_state.event_bus.clone());
 
@@ -147,12 +147,20 @@ mod tests {
 
     fn sample_session_detail() -> SessionDetailView {
         SessionDetailView {
+            session_key: "discord:ops:bridge".into(),
             title: "Session ops".into(),
             subtitle: "discord / ops".into(),
             source_label: "Live runtime".into(),
             meta: vec![MetaRow {
                 label: "Stable key".into(),
                 value: "discord:ops:bridge".into(),
+            }],
+            notice: None,
+            selected_model: "claude-sonnet-4-20250514".into(),
+            model_options: vec![SelectOption {
+                value: "claude-sonnet-4-20250514".into(),
+                label: "claude-sonnet-4-20250514 (anthropic)".into(),
+                selected: true,
             }],
             messages: vec![MessageBubble {
                 role_label: "Assistant".into(),
@@ -315,6 +323,8 @@ mod tests {
         assert!(html.contains("Search sessions"));
         assert!(html.contains("data-list-item"));
         assert!(html.contains("data-detail-panel"));
+        assert!(html.contains("Session model"));
+        assert!(html.contains("Save model"));
         assert!(!html.contains("hx-get"));
     }
 

--- a/crates/opengoose-web/src/openapi/schemas.rs
+++ b/crates/opengoose-web/src/openapi/schemas.rs
@@ -149,6 +149,7 @@ fn core_schemas() -> Value {
             "properties": {
                 "session_key": { "type": "string" },
                 "active_team": { "type": "string", "nullable": true },
+                "selected_model": { "type": "string", "nullable": true },
                 "created_at": { "type": "string", "format": "date-time" },
                 "updated_at": { "type": "string", "format": "date-time" }
             }
@@ -576,6 +577,10 @@ mod tests {
         );
         assert_eq!(
             schemas["SessionItem"]["properties"]["active_team"]["nullable"],
+            true
+        );
+        assert_eq!(
+            schemas["SessionItem"]["properties"]["selected_model"]["nullable"],
             true
         );
         assert_eq!(

--- a/crates/opengoose-web/src/routes/health.rs
+++ b/crates/opengoose-web/src/routes/health.rs
@@ -200,7 +200,7 @@ mod tests {
             db,
             remote_registry: RemoteAgentRegistry::new(RemoteConfig::default()),
             channel_metrics: ChannelMetricsStore::new(),
-            event_bus: opengoose_types::EventBus::new(256),
+            _event_bus: opengoose_types::EventBus::new(256),
         }
     }
 

--- a/crates/opengoose-web/src/routes/pages.rs
+++ b/crates/opengoose-web/src/routes/pages.rs
@@ -12,11 +12,12 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::routing::get;
 use futures_core::Stream;
 use opengoose_persistence::Database;
+use opengoose_types::SessionKey;
 use serde::Deserialize;
 
 use super::{PartialResult, WebResult, internal_error, render_partial, render_template};
 use crate::data::{
-    AgentDetailView, AgentsPageView, DashboardView, QueueDetailView, QueuePageView,
+    AgentDetailView, AgentsPageView, DashboardView, Notice, QueueDetailView, QueuePageView,
     RemoteAgentsPageView, RunDetailView, RunsPageView, ScheduleEditorView, ScheduleSaveInput,
     SchedulesPageView, SessionDetailView, SessionsPageView, TeamEditorView, TeamsPageView,
     TriggerDetailView, TriggersPageView, WorkflowDetailView, WorkflowsPageView, delete_schedule,
@@ -29,6 +30,13 @@ use crate::server::PageState;
 #[derive(Deserialize, Default)]
 pub(crate) struct SessionQuery {
     session: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct SessionModelForm {
+    intent: String,
+    session_key: String,
+    selected_model: Option<String>,
 }
 
 #[derive(Deserialize, Default)]
@@ -83,7 +91,7 @@ pub(crate) fn router(state: PageState) -> Router {
     Router::new()
         .route("/", get(dashboard))
         .route("/dashboard/events", get(dashboard_events))
-        .route("/sessions", get(sessions))
+        .route("/sessions", get(sessions).post(session_model_action))
         .route("/runs", get(runs))
         .route("/agents", get(agents))
         .route("/remote-agents", get(remote_agents))
@@ -163,6 +171,69 @@ pub(crate) async fn sessions(
     Query(query): Query<SessionQuery>,
 ) -> WebResult {
     let page = load_sessions_page(state.db, query.session).map_err(internal_error)?;
+    let detail_html = render_partial(&SessionDetailTemplate {
+        detail: page.selected.clone(),
+    })?;
+
+    render_template(&SessionsTemplate {
+        page_title: "Sessions",
+        current_nav: "sessions",
+        page,
+        detail_html,
+    })
+}
+
+pub(crate) async fn session_model_action(
+    State(state): State<PageState>,
+    Form(form): Form<SessionModelForm>,
+) -> WebResult {
+    let session_key = form.session_key.trim();
+    if session_key.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Html("Session key is required.".into()),
+        ));
+    }
+
+    let normalized_model = form
+        .selected_model
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let notice_text = match form.intent.as_str() {
+        "save" => {
+            opengoose_persistence::SessionStore::new(state.db.clone())
+                .set_selected_model(
+                    &SessionKey::from_stable_id(session_key),
+                    normalized_model.as_deref(),
+                )
+                .map_err(|error| internal_error(error.into()))?;
+            match normalized_model.as_deref() {
+                Some(model) => format!("Session model set to `{model}`."),
+                None => "Session model override cleared.".into(),
+            }
+        }
+        "clear" => {
+            opengoose_persistence::SessionStore::new(state.db.clone())
+                .set_selected_model(&SessionKey::from_stable_id(session_key), None)
+                .map_err(|error| internal_error(error.into()))?;
+            "Session model override cleared.".into()
+        }
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Html("Unsupported session action.".into()),
+            ));
+        }
+    };
+
+    let mut page =
+        load_sessions_page(state.db, Some(session_key.to_string())).map_err(internal_error)?;
+    page.selected.notice = Some(Notice {
+        text: notice_text,
+        tone: "success",
+    });
     let detail_html = render_partial(&SessionDetailTemplate {
         detail: page.selected.clone(),
     })?;
@@ -724,7 +795,7 @@ mod tests {
             db,
             remote_registry: RemoteAgentRegistry::new(RemoteConfig::default()),
             channel_metrics: ChannelMetricsStore::new(),
-            event_bus: EventBus::new(256),
+            _event_bus: EventBus::new(256),
         }
     }
 

--- a/crates/opengoose-web/src/server.rs
+++ b/crates/opengoose-web/src/server.rs
@@ -39,5 +39,5 @@ pub(crate) struct PageState {
     pub(crate) db: Arc<Database>,
     pub(crate) remote_registry: RemoteAgentRegistry,
     pub(crate) channel_metrics: ChannelMetricsStore,
-    pub(crate) event_bus: EventBus,
+    pub(crate) _event_bus: EventBus,
 }

--- a/crates/opengoose-web/templates/partials/session_detail.html
+++ b/crates/opengoose-web/templates/partials/session_detail.html
@@ -8,6 +8,12 @@
     <span class="chip tone-neutral">{{ detail.source_label }}</span>
   </div>
 
+  {% match detail.notice %}
+  {% when Some with (notice) %}
+  <div class="notice tone-{{ notice.tone }}">{{ notice.text }}</div>
+  {% when None %}
+  {% endmatch %}
+
   <dl class="meta-grid">
     {% for row in detail.meta %}
     <div class="meta-item">
@@ -16,6 +22,32 @@
     </div>
     {% endfor %}
   </dl>
+
+  <form class="editor-form" method="post" action="/sessions">
+    <input type="hidden" name="session_key" value="{{ detail.session_key }}">
+    <label class="control-field">
+      <span>Session model</span>
+      <input
+        type="text"
+        name="selected_model"
+        value="{{ detail.selected_model }}"
+        list="session-model-options"
+        placeholder="Use the profile default model"
+      >
+    </label>
+    {% if detail.model_options.len() > 0 %}
+    <datalist id="session-model-options">
+      {% for option in detail.model_options %}
+      <option value="{{ option.value }}">{{ option.label }}</option>
+      {% endfor %}
+    </datalist>
+    {% endif %}
+    <p class="surface-feedback">Applies to future responses for this session, including active team turns.</p>
+    <div class="schedule-action-row">
+      <button class="primary-button" type="submit" name="intent" value="save">Save model</button>
+      <button class="secondary-button" type="submit" name="intent" value="clear">Clear override</button>
+    </div>
+  </form>
 
   {% if detail.messages.len() > 0 %}
   <div class="message-stack">


### PR DESCRIPTION
## Summary
- add session-level model override persistence and profile/provider fallback support for single-agent and team execution
- expose model overrides through `opengoose run --model`, `opengoose team run --model`, and the web session detail UI
- surface selected model metadata through session APIs/openapi and update tests, migration, and README examples

## Verification
- cargo fmt --all --check
- cargo build
- cargo clippy --all-targets -- -D warnings
- cargo test

Paperclip issue: OPE-243
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
