### PR TITLE
perf: enable mmap_size PRAGMA for memory-mapped SQLite reads (128 MiB)

### DIFF
--- a/crates/opengoose-persistence/src/db.rs
+++ b/crates/opengoose-persistence/src/db.rs
@@ -88,6 +88,10 @@ impl Database {
         diesel::sql_query("PRAGMA cache_size = -8000").execute(conn)?;
         // Keep temporary tables in memory instead of on-disk temp files.
         diesel::sql_query("PRAGMA temp_store = MEMORY").execute(conn)?;
+        // Enable memory-mapped I/O for up to 128 MiB of the database file.
+        // mmap reads bypass the kernel's read(2) syscall path, reducing syscall
+        // overhead for repeated page accesses. Safe to use alongside WAL mode.
+        diesel::sql_query("PRAGMA mmap_size = 134217728").execute(conn)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Enables SQLite memory-mapped I/O with 128 MiB mmap_size PRAGMA
- Improves read performance for large database files

## Test plan
- [x] Compiles cleanly
- [ ] CI quality gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
