### PR TITLE
test(cli): add e2e integration tests for session workflow [OPE-266]

### DIFF
--- a/crates/opengoose-cli/tests/e2e_session_workflow.rs
+++ b/crates/opengoose-cli/tests/e2e_session_workflow.rs
@@ -52,7 +52,12 @@ fn directed_message_creates_session_and_persists() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "frontend", "--to", "backend",
+            "message",
+            "send",
+            "--from",
+            "frontend",
+            "--to",
+            "backend",
             "deploy request",
         ],
     );
@@ -76,7 +81,12 @@ fn channel_message_creates_session_and_persists() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "ops-bot", "--channel", "alerts",
+            "message",
+            "send",
+            "--from",
+            "ops-bot",
+            "--channel",
+            "alerts",
             "disk usage 90%",
         ],
     );
@@ -141,11 +151,7 @@ fn message_list_filters_by_agent() {
         ],
     );
 
-    let list = run_cli(
-        &home,
-        &goose_root,
-        &["message", "list", "--agent", "bob"],
-    );
+    let list = run_cli(&home, &goose_root, &["message", "list", "--agent", "bob"]);
     assert!(list.status.success());
     let list_stdout = stdout(&list);
     assert!(list_stdout.contains("msg1"));
@@ -160,7 +166,12 @@ fn message_list_filters_by_channel() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "bot", "--channel", "ops",
+            "message",
+            "send",
+            "--from",
+            "bot",
+            "--channel",
+            "ops",
             "ops alert",
         ],
     );
@@ -168,16 +179,17 @@ fn message_list_filters_by_channel() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "bot", "--channel", "dev",
+            "message",
+            "send",
+            "--from",
+            "bot",
+            "--channel",
+            "dev",
             "dev update",
         ],
     );
 
-    let list = run_cli(
-        &home,
-        &goose_root,
-        &["message", "list", "--channel", "ops"],
-    );
+    let list = run_cli(&home, &goose_root, &["message", "list", "--channel", "ops"]);
     assert!(list.status.success());
     let list_stdout = stdout(&list);
     assert!(list_stdout.contains("ops alert"));
@@ -194,16 +206,14 @@ fn pending_messages_workflow_end_to_end() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "frontend", "--to", "backend",
-            "task 1",
+            "message", "send", "--from", "frontend", "--to", "backend", "task 1",
         ],
     );
     run_cli(
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "monitor", "--to", "backend",
-            "task 2",
+            "message", "send", "--from", "monitor", "--to", "backend", "task 2",
         ],
     );
 
@@ -251,7 +261,10 @@ fn session_store_conversation_round_trip() {
     assert_eq!(history[0].content, "What is Rust?");
     assert_eq!(history[0].author.as_deref(), Some("alice"));
     assert_eq!(history[1].role, "assistant");
-    assert_eq!(history[1].content, "Rust is a systems programming language.");
+    assert_eq!(
+        history[1].content,
+        "Rust is a systems programming language."
+    );
     assert_eq!(history[1].author.as_deref(), Some("goose"));
     assert_eq!(history[2].role, "user");
     assert_eq!(history[3].role, "assistant");
@@ -379,7 +392,12 @@ fn full_cli_message_and_persistence_workflow() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "frontend", "--to", "backend",
+            "message",
+            "send",
+            "--from",
+            "frontend",
+            "--to",
+            "backend",
             "please process order #42",
         ],
     );
@@ -389,7 +407,12 @@ fn full_cli_message_and_persistence_workflow() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "backend", "--to", "frontend",
+            "message",
+            "send",
+            "--from",
+            "backend",
+            "--to",
+            "frontend",
             "order #42 processed",
         ],
     );
@@ -400,7 +423,12 @@ fn full_cli_message_and_persistence_workflow() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "backend", "--channel", "status",
+            "message",
+            "send",
+            "--from",
+            "backend",
+            "--channel",
+            "status",
             "order #42 complete",
         ],
     );
@@ -456,16 +484,30 @@ fn custom_session_key_isolates_messages() {
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "a", "--to", "b",
-            "--session", "session-alpha", "alpha msg",
+            "message",
+            "send",
+            "--from",
+            "a",
+            "--to",
+            "b",
+            "--session",
+            "session-alpha",
+            "alpha msg",
         ],
     );
     run_cli(
         &home,
         &goose_root,
         &[
-            "message", "send", "--from", "a", "--to", "b",
-            "--session", "session-beta", "beta msg",
+            "message",
+            "send",
+            "--from",
+            "a",
+            "--to",
+            "b",
+            "--session",
+            "session-beta",
+            "beta msg",
         ],
     );
 


### PR DESCRIPTION
## Summary
- Adds 15 end-to-end integration tests covering the full CLI → Core → Persistence workflow
- Tests session creation (via message send), message listing/filtering, pending messages, conversation history, multi-session isolation, active team lifecycle, custom session keys, and cleanup retention
- All 15 new tests pass alongside existing 341 tests with zero regressions

## Test plan
- [x] All 15 new e2e tests pass (`cargo test --test e2e_session_workflow`)
- [x] All existing CLI tests pass (`cargo test -p opengoose-cli` — 356 total)
- [x] No new dependencies required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
