### PR TITLE
feat: add remote reconnect replay resume [OPE-276]

### DIFF
--- a/crates/opengoose-cli/src/cmd/remote.rs
+++ b/crates/opengoose-cli/src/cmd/remote.rs
@@ -1,9 +1,17 @@
 use anyhow::{Result, bail};
 use clap::Subcommand;
 use serde::Deserialize;
+use std::time::Duration;
 
 /// Default base URL for the OpenGoose web server.
 const DEFAULT_BASE: &str = "http://127.0.0.1:8080";
+const CLIENT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(25);
+const MAX_RECONNECT_BACKOFF_SECS: u64 = 5;
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+type WsWrite = futures_util::stream::SplitSink<WsStream, tokio_tungstenite::tungstenite::Message>;
+type WsRead = futures_util::stream::SplitStream<WsStream>;
 
 #[derive(Subcommand)]
 /// Subcommands for `opengoose remote`.
@@ -44,6 +52,29 @@ struct RemoteAgentInfo {
     last_heartbeat_secs: u64,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConnectMode {
+    Fresh,
+    Resume { last_event_id: u64 },
+}
+
+struct SessionConnection {
+    read: WsRead,
+    write: WsWrite,
+    replayed_events: u64,
+}
+
+#[derive(Debug)]
+enum ConnectFailure {
+    Retryable(anyhow::Error),
+    Terminal(anyhow::Error),
+}
+
+enum SessionOutcome {
+    Exit,
+    Reconnect { reason: String },
+}
+
 /// Dispatch and execute the selected remote subcommand.
 pub async fn execute(action: RemoteAction) -> Result<()> {
     match action {
@@ -55,140 +86,392 @@ pub async fn execute(action: RemoteAction) -> Result<()> {
 
 /// Connect to an OpenGoose server as a remote agent via WebSocket.
 async fn cmd_connect(url: &str, api_key: Option<&str>, agent_name: &str) -> Result<()> {
-    use futures_util::{SinkExt, StreamExt};
-    use opengoose_teams::remote::ProtocolMessage;
-    use tokio_tungstenite::tungstenite::Message;
-
-    // Build the WebSocket URL for the connect endpoint.
-    let ws_url = if url.ends_with("/api/agents/connect") {
-        url.to_string()
-    } else {
-        format!("{}/api/agents/connect", url.trim_end_matches('/'))
-    };
-
-    println!("Connecting to {} as '{}'...", ws_url, agent_name);
-
-    let (ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to connect to {}: {}", ws_url, e))?;
-
-    let (mut write, mut read) = ws_stream.split();
-
-    // Send handshake.
-    let handshake = ProtocolMessage::Handshake {
-        agent_name: agent_name.to_string(),
-        api_key: api_key.unwrap_or("").to_string(),
-        capabilities: vec![],
-    };
-    let json = serde_json::to_string(&handshake)?;
-    write.send(Message::Text(json.into())).await?;
-
-    // Wait for handshake acknowledgement.
-    let ack_msg = read
-        .next()
-        .await
-        .ok_or_else(|| anyhow::anyhow!("connection closed during handshake"))??;
-
-    let ack_text = ack_msg
-        .to_text()
-        .map_err(|e| anyhow::anyhow!("non-text handshake response: {}", e))?;
-
-    let ack: ProtocolMessage = serde_json::from_str(ack_text)?;
-    match ack {
-        ProtocolMessage::HandshakeAck { success: true, .. } => {
-            println!("Connected successfully as '{}'.", agent_name);
-        }
-        ProtocolMessage::HandshakeAck {
-            success: false,
-            error,
-            ..
-        } => {
-            bail!(
-                "handshake rejected: {}",
-                error.unwrap_or_else(|| "unknown error".into())
-            );
-        }
-        _ => bail!("unexpected handshake response"),
-    }
-
-    println!("Listening for messages (press Ctrl+C to disconnect)...");
-
-    // Main loop: receive messages and respond to heartbeats.
-    let mut heartbeat_timer = tokio::time::interval(std::time::Duration::from_secs(25));
-    heartbeat_timer.tick().await;
+    let ws_url = build_connect_url(url);
+    let mut connect_mode = ConnectMode::Fresh;
+    let mut last_seen_event_id = 0_u64;
+    let mut reconnect_attempt = 0_u32;
 
     loop {
-        tokio::select! {
-            msg = read.next() => {
-                match msg {
-                    Some(Ok(Message::Text(text))) => {
-                        match serde_json::from_str::<ProtocolMessage>(&text) {
-                            Ok(ProtocolMessage::Heartbeat { .. }) => {
-                                let hb = ProtocolMessage::Heartbeat {
-                                    timestamp: std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map(|d| d.as_secs())
-                                        .unwrap_or(0),
-                                };
-                                let json = serde_json::to_string(&hb)?;
-                                write.send(Message::Text(json.into())).await?;
-                            }
-                            Ok(ProtocolMessage::MessageRelay { from, payload, .. }) => {
-                                println!("[message from {}] {}", from, payload);
-                            }
-                            Ok(ProtocolMessage::Broadcast { from, channel, payload }) => {
-                                println!("[broadcast {}@{}] {}", from, channel, payload);
-                            }
-                            Ok(ProtocolMessage::Disconnect { reason }) => {
-                                println!("Server disconnected: {}", reason);
-                                break;
-                            }
-                            Ok(ProtocolMessage::Error { message }) => {
-                                eprintln!("Server error: {}", message);
-                            }
-                            Ok(_) => {}
-                            Err(e) => {
-                                eprintln!("Invalid message: {}", e);
-                            }
-                        }
-                    }
-                    Some(Ok(Message::Close(_))) | None => {
-                        println!("Connection closed.");
-                        break;
-                    }
-                    Some(Ok(_)) => {} // skip binary/ping/pong
-                    Some(Err(e)) => {
-                        eprintln!("WebSocket error: {}", e);
-                        break;
-                    }
-                }
+        match connect_mode {
+            ConnectMode::Fresh => {
+                println!("Connecting to {} as '{}'...", ws_url, agent_name);
             }
-            _ = heartbeat_timer.tick() => {
-                let hb = ProtocolMessage::Heartbeat {
-                    timestamp: std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0),
-                };
-                let json = serde_json::to_string(&hb)?;
-                if write.send(Message::Text(json.into())).await.is_err() {
-                    println!("Connection lost.");
+            ConnectMode::Resume { last_event_id } => {
+                println!(
+                    "Reconnecting to {} as '{}' from event #{}...",
+                    ws_url, agent_name, last_event_id
+                );
+            }
+        }
+
+        let session = match connect_session(&ws_url, api_key, agent_name, connect_mode).await {
+            Ok(session) => session,
+            Err(ConnectFailure::Retryable(err))
+                if matches!(connect_mode, ConnectMode::Resume { .. }) =>
+            {
+                eprintln!(
+                    "Reconnect attempt {} failed: {}",
+                    reconnect_attempt.saturating_add(1),
+                    err
+                );
+                let delay = reconnect_delay(reconnect_attempt);
+                reconnect_attempt = reconnect_attempt.saturating_add(1);
+                if !wait_before_reconnect(delay, last_seen_event_id).await {
                     break;
                 }
+                continue;
             }
-            _ = tokio::signal::ctrl_c() => {
-                println!("\nDisconnecting...");
-                let disc = ProtocolMessage::Disconnect {
-                    reason: "user interrupt".into(),
+            Err(ConnectFailure::Retryable(err)) | Err(ConnectFailure::Terminal(err)) => {
+                return Err(err);
+            }
+        };
+
+        reconnect_attempt = 0;
+        match connect_mode {
+            ConnectMode::Fresh => println!("Connected successfully as '{}'.", agent_name),
+            ConnectMode::Resume { .. } => println!(
+                "Resumed as '{}' with {} replayed event(s).",
+                agent_name, session.replayed_events
+            ),
+        }
+        println!("Listening for messages (press Ctrl+C to disconnect)...");
+
+        let mut pending_replayed_events = session.replayed_events;
+        match run_connected_session(
+            session.read,
+            session.write,
+            &mut last_seen_event_id,
+            &mut pending_replayed_events,
+        )
+        .await?
+        {
+            SessionOutcome::Exit => break,
+            SessionOutcome::Reconnect { reason } => {
+                println!("Connection lost: {}", reason);
+                connect_mode = ConnectMode::Resume {
+                    last_event_id: last_seen_event_id,
                 };
-                let json = serde_json::to_string(&disc)?;
-                let _ = write.send(Message::Text(json.into())).await;
-                break;
+                let delay = reconnect_delay(reconnect_attempt);
+                reconnect_attempt = reconnect_attempt.saturating_add(1);
+                if !wait_before_reconnect(delay, last_seen_event_id).await {
+                    break;
+                }
             }
         }
     }
 
     Ok(())
+}
+
+fn build_connect_url(url: &str) -> String {
+    if url.ends_with("/api/agents/connect") {
+        url.to_string()
+    } else {
+        format!("{}/api/agents/connect", url.trim_end_matches('/'))
+    }
+}
+
+fn reconnect_delay(attempt: u32) -> Duration {
+    Duration::from_secs((1_u64 << attempt.min(3)).min(MAX_RECONNECT_BACKOFF_SECS))
+}
+
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn heartbeat_message() -> opengoose_teams::remote::ProtocolMessage {
+    opengoose_teams::remote::ProtocolMessage::Heartbeat {
+        timestamp: now_unix_secs(),
+    }
+}
+
+fn is_replayable_message(message: &opengoose_teams::remote::ProtocolMessage) -> bool {
+    matches!(
+        message,
+        opengoose_teams::remote::ProtocolMessage::MessageRelay { .. }
+            | opengoose_teams::remote::ProtocolMessage::Broadcast { .. }
+            | opengoose_teams::remote::ProtocolMessage::Disconnect { .. }
+    )
+}
+
+fn record_replayable_event(
+    last_seen_event_id: &mut u64,
+    message: &opengoose_teams::remote::ProtocolMessage,
+) -> Option<u64> {
+    if is_replayable_message(message) {
+        *last_seen_event_id = last_seen_event_id.saturating_add(1);
+        Some(*last_seen_event_id)
+    } else {
+        None
+    }
+}
+
+fn next_delivery_label(pending_replayed_events: &mut u64) -> &'static str {
+    if *pending_replayed_events > 0 {
+        *pending_replayed_events -= 1;
+        "replay"
+    } else {
+        "live"
+    }
+}
+
+async fn send_protocol(
+    write: &mut WsWrite,
+    message: &opengoose_teams::remote::ProtocolMessage,
+) -> Result<()> {
+    use futures_util::SinkExt;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let json = serde_json::to_string(message)?;
+    write.send(Message::Text(json.into())).await?;
+    Ok(())
+}
+
+async fn recv_protocol(
+    read: &mut WsRead,
+    phase: &str,
+) -> std::result::Result<opengoose_teams::remote::ProtocolMessage, ConnectFailure> {
+    use futures_util::StreamExt;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let message = match read.next().await {
+        Some(Ok(message)) => message,
+        Some(Err(err)) => {
+            return Err(ConnectFailure::Retryable(anyhow::anyhow!(
+                "websocket error during {phase}: {err}"
+            )));
+        }
+        None => {
+            return Err(ConnectFailure::Retryable(anyhow::anyhow!(
+                "connection closed during {phase}"
+            )));
+        }
+    };
+
+    let text = match message {
+        Message::Text(text) => text,
+        Message::Close(_) => {
+            return Err(ConnectFailure::Retryable(anyhow::anyhow!(
+                "connection closed during {phase}"
+            )));
+        }
+        other => {
+            return Err(ConnectFailure::Terminal(anyhow::anyhow!(
+                "unexpected {phase} response: {other:?}"
+            )));
+        }
+    };
+
+    serde_json::from_str(&text)
+        .map_err(|err| ConnectFailure::Terminal(anyhow::anyhow!("invalid {phase} response: {err}")))
+}
+
+async fn connect_session(
+    ws_url: &str,
+    api_key: Option<&str>,
+    agent_name: &str,
+    connect_mode: ConnectMode,
+) -> std::result::Result<SessionConnection, ConnectFailure> {
+    use futures_util::StreamExt;
+
+    let (ws_stream, _) = tokio_tungstenite::connect_async(ws_url)
+        .await
+        .map_err(|err| {
+            ConnectFailure::Retryable(anyhow::anyhow!("failed to connect to {}: {}", ws_url, err))
+        })?;
+
+    let (mut write, mut read) = ws_stream.split();
+    send_protocol(
+        &mut write,
+        &opengoose_teams::remote::ProtocolMessage::Handshake {
+            agent_name: agent_name.to_string(),
+            api_key: api_key.unwrap_or("").to_string(),
+            capabilities: vec![],
+        },
+    )
+    .await
+    .map_err(|err| ConnectFailure::Retryable(anyhow::anyhow!("failed to send handshake: {err}")))?;
+
+    let ack = recv_protocol(&mut read, "handshake").await?;
+    match ack {
+        opengoose_teams::remote::ProtocolMessage::HandshakeAck { success: true, .. } => {}
+        opengoose_teams::remote::ProtocolMessage::HandshakeAck {
+            success: false,
+            error,
+            ..
+        } => {
+            return Err(ConnectFailure::Terminal(anyhow::anyhow!(
+                "handshake rejected: {}",
+                error.unwrap_or_else(|| "unknown error".into())
+            )));
+        }
+        _ => {
+            return Err(ConnectFailure::Terminal(anyhow::anyhow!(
+                "unexpected handshake response"
+            )));
+        }
+    }
+
+    let mut replayed_events = 0;
+    if let ConnectMode::Resume { last_event_id } = connect_mode {
+        send_protocol(
+            &mut write,
+            &opengoose_teams::remote::ProtocolMessage::Reconnect { last_event_id },
+        )
+        .await
+        .map_err(|err| {
+            ConnectFailure::Retryable(anyhow::anyhow!("failed to send reconnect request: {err}"))
+        })?;
+
+        let ack = recv_protocol(&mut read, "reconnect").await?;
+        match ack {
+            opengoose_teams::remote::ProtocolMessage::ReconnectAck {
+                success: true,
+                replayed_events: count,
+            } => {
+                replayed_events = count;
+            }
+            opengoose_teams::remote::ProtocolMessage::ReconnectAck { success: false, .. } => {
+                return Err(ConnectFailure::Terminal(anyhow::anyhow!(
+                    "resume rejected: replay window unavailable after event #{}",
+                    last_event_id
+                )));
+            }
+            _ => {
+                return Err(ConnectFailure::Terminal(anyhow::anyhow!(
+                    "unexpected reconnect response"
+                )));
+            }
+        }
+    }
+
+    Ok(SessionConnection {
+        read,
+        write,
+        replayed_events,
+    })
+}
+
+async fn run_connected_session(
+    mut read: WsRead,
+    mut write: WsWrite,
+    last_seen_event_id: &mut u64,
+    pending_replayed_events: &mut u64,
+) -> Result<SessionOutcome> {
+    use futures_util::StreamExt;
+    use opengoose_teams::remote::ProtocolMessage;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let mut heartbeat_timer = tokio::time::interval(CLIENT_HEARTBEAT_INTERVAL);
+    heartbeat_timer.tick().await;
+
+    loop {
+        tokio::select! {
+            message = read.next() => {
+                match message {
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<ProtocolMessage>(&text) {
+                            Ok(message) => {
+                                let event_id = record_replayable_event(last_seen_event_id, &message);
+                                let delivery_label = event_id.map(|_| next_delivery_label(pending_replayed_events));
+                                match message {
+                                    ProtocolMessage::Heartbeat { .. } => {
+                                        send_protocol(&mut write, &heartbeat_message()).await?;
+                                    }
+                                    ProtocolMessage::MessageRelay { from, payload, .. } => {
+                                        let event_id = event_id.expect("relay events should have an id");
+                                        println!(
+                                            "[{} relay #{} from {}] {}",
+                                            delivery_label.unwrap_or("live"),
+                                            event_id,
+                                            from,
+                                            payload
+                                        );
+                                    }
+                                    ProtocolMessage::Broadcast { from, channel, payload } => {
+                                        let event_id = event_id.expect("broadcast events should have an id");
+                                        println!(
+                                            "[{} broadcast #{} {}@{}] {}",
+                                            delivery_label.unwrap_or("live"),
+                                            event_id,
+                                            from,
+                                            channel,
+                                            payload
+                                        );
+                                    }
+                                    ProtocolMessage::Disconnect { reason } => {
+                                        let event_id = event_id.expect("disconnect events should have an id");
+                                        println!(
+                                            "[{} disconnect #{}] Server disconnected: {}",
+                                            delivery_label.unwrap_or("live"),
+                                            event_id,
+                                            reason
+                                        );
+                                        return Ok(SessionOutcome::Exit);
+                                    }
+                                    ProtocolMessage::Error { message } => {
+                                        eprintln!("Server error: {}", message);
+                                    }
+                                    ProtocolMessage::Handshake { .. }
+                                    | ProtocolMessage::HandshakeAck { .. }
+                                    | ProtocolMessage::Reconnect { .. }
+                                    | ProtocolMessage::ReconnectAck { .. } => {}
+                                }
+                            }
+                            Err(err) => eprintln!("Invalid message: {}", err),
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        return Ok(SessionOutcome::Reconnect {
+                            reason: "connection closed".into(),
+                        });
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(err)) => {
+                        return Ok(SessionOutcome::Reconnect {
+                            reason: format!("websocket error: {}", err),
+                        });
+                    }
+                }
+            }
+            _ = heartbeat_timer.tick() => {
+                if send_protocol(&mut write, &heartbeat_message()).await.is_err() {
+                    return Ok(SessionOutcome::Reconnect {
+                        reason: "heartbeat send failed".into(),
+                    });
+                }
+            }
+            _ = tokio::signal::ctrl_c() => {
+                println!("\nDisconnecting...");
+                let _ = send_protocol(
+                    &mut write,
+                    &ProtocolMessage::Disconnect {
+                        reason: "user interrupt".into(),
+                    },
+                )
+                .await;
+                return Ok(SessionOutcome::Exit);
+            }
+        }
+    }
+}
+
+async fn wait_before_reconnect(delay: Duration, last_seen_event_id: u64) -> bool {
+    println!(
+        "Retrying reconnect in {}s from event #{} (press Ctrl+C to stop)...",
+        delay.as_secs(),
+        last_seen_event_id
+    );
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => true,
+        _ = tokio::signal::ctrl_c() => {
+            println!("\nStopping reconnect attempts.");
+            false
+        }
+    }
 }
 
 async fn cmd_list(base_url: &str) -> Result<()> {
@@ -269,6 +552,11 @@ fn format_duration(secs: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::{SinkExt, StreamExt};
+    use opengoose_teams::remote::ProtocolMessage;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::tungstenite::Message;
 
     #[test]
     fn format_duration_seconds() {
@@ -294,36 +582,26 @@ mod tests {
 
     #[test]
     fn ws_url_appends_connect_path_when_not_present() {
-        // Replicate the URL construction logic from cmd_connect
-        let url = "ws://localhost:8080";
-        let ws_url = if url.ends_with("/api/agents/connect") {
-            url.to_string()
-        } else {
-            format!("{}/api/agents/connect", url.trim_end_matches('/'))
-        };
-        assert_eq!(ws_url, "ws://localhost:8080/api/agents/connect");
+        assert_eq!(
+            build_connect_url("ws://localhost:8080"),
+            "ws://localhost:8080/api/agents/connect"
+        );
     }
 
     #[test]
     fn ws_url_preserves_full_connect_path() {
-        let url = "ws://localhost:8080/api/agents/connect";
-        let ws_url = if url.ends_with("/api/agents/connect") {
-            url.to_string()
-        } else {
-            format!("{}/api/agents/connect", url.trim_end_matches('/'))
-        };
-        assert_eq!(ws_url, "ws://localhost:8080/api/agents/connect");
+        assert_eq!(
+            build_connect_url("ws://localhost:8080/api/agents/connect"),
+            "ws://localhost:8080/api/agents/connect"
+        );
     }
 
     #[test]
     fn ws_url_trims_trailing_slash_before_appending() {
-        let url = "ws://localhost:8080/";
-        let ws_url = if url.ends_with("/api/agents/connect") {
-            url.to_string()
-        } else {
-            format!("{}/api/agents/connect", url.trim_end_matches('/'))
-        };
-        assert_eq!(ws_url, "ws://localhost:8080/api/agents/connect");
+        assert_eq!(
+            build_connect_url("ws://localhost:8080/"),
+            "ws://localhost:8080/api/agents/connect"
+        );
     }
 
     #[test]
@@ -384,36 +662,218 @@ mod tests {
 
     #[test]
     fn wss_url_appends_connect_path() {
-        // wss:// (TLS) URLs should have the connect path appended the same way
-        // as plain ws:// URLs. tokio-tungstenite handles WSS transparently.
-        let url = "wss://example.com:8443";
-        let ws_url = if url.ends_with("/api/agents/connect") {
-            url.to_string()
-        } else {
-            format!("{}/api/agents/connect", url.trim_end_matches('/'))
-        };
-        assert_eq!(ws_url, "wss://example.com:8443/api/agents/connect");
+        assert_eq!(
+            build_connect_url("wss://example.com:8443"),
+            "wss://example.com:8443/api/agents/connect"
+        );
     }
 
     #[test]
     fn wss_url_preserves_full_connect_path() {
-        let url = "wss://example.com:8443/api/agents/connect";
-        let ws_url = if url.ends_with("/api/agents/connect") {
-            url.to_string()
-        } else {
-            format!("{}/api/agents/connect", url.trim_end_matches('/'))
-        };
-        assert_eq!(ws_url, "wss://example.com:8443/api/agents/connect");
+        assert_eq!(
+            build_connect_url("wss://example.com:8443/api/agents/connect"),
+            "wss://example.com:8443/api/agents/connect"
+        );
     }
 
     #[test]
     fn wss_url_trims_trailing_slash_before_appending() {
-        let url = "wss://example.com:8443/";
-        let ws_url = if url.ends_with("/api/agents/connect") {
-            url.to_string()
-        } else {
-            format!("{}/api/agents/connect", url.trim_end_matches('/'))
+        assert_eq!(
+            build_connect_url("wss://example.com:8443/"),
+            "wss://example.com:8443/api/agents/connect"
+        );
+    }
+
+    #[test]
+    fn reconnect_delay_caps_after_backoff_growth() {
+        assert_eq!(reconnect_delay(0), Duration::from_secs(1));
+        assert_eq!(reconnect_delay(1), Duration::from_secs(2));
+        assert_eq!(reconnect_delay(2), Duration::from_secs(4));
+        assert_eq!(reconnect_delay(3), Duration::from_secs(5));
+        assert_eq!(reconnect_delay(8), Duration::from_secs(5));
+    }
+
+    #[test]
+    fn record_replayable_event_only_counts_replayable_messages() {
+        let mut last_seen_event_id = 0;
+
+        assert_eq!(
+            record_replayable_event(
+                &mut last_seen_event_id,
+                &ProtocolMessage::MessageRelay {
+                    from: "a".into(),
+                    to: "b".into(),
+                    payload: "hello".into(),
+                },
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            record_replayable_event(
+                &mut last_seen_event_id,
+                &ProtocolMessage::Heartbeat { timestamp: 0 },
+            ),
+            None
+        );
+        assert_eq!(
+            record_replayable_event(
+                &mut last_seen_event_id,
+                &ProtocolMessage::Broadcast {
+                    from: "ops".into(),
+                    channel: "alerts".into(),
+                    payload: "hi".into(),
+                },
+            ),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn next_delivery_label_consumes_pending_replays() {
+        let mut pending = 2;
+        assert_eq!(next_delivery_label(&mut pending), "replay");
+        assert_eq!(next_delivery_label(&mut pending), "replay");
+        assert_eq!(next_delivery_label(&mut pending), "live");
+        assert_eq!(pending, 0);
+    }
+
+    async fn recv_protocol_message(
+        socket: &mut tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>,
+    ) -> ProtocolMessage {
+        let message = socket
+            .next()
+            .await
+            .expect("socket should yield a message")
+            .expect("socket message should be valid");
+        let text = message.into_text().expect("message should be text");
+        serde_json::from_str(&text).expect("message should deserialize")
+    }
+
+    #[tokio::test]
+    async fn connect_session_sends_reconnect_request_with_last_seen_event_id() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+
+            match recv_protocol_message(&mut socket).await {
+                ProtocolMessage::Handshake {
+                    agent_name,
+                    api_key,
+                    capabilities,
+                } => {
+                    assert_eq!(agent_name, "resume-agent");
+                    assert_eq!(api_key, "secret");
+                    assert!(capabilities.is_empty());
+                }
+                other => panic!("expected handshake, got {other:?}"),
+            }
+
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&ProtocolMessage::HandshakeAck {
+                        success: true,
+                        error: None,
+                    })
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+
+            match recv_protocol_message(&mut socket).await {
+                ProtocolMessage::Reconnect { last_event_id } => {
+                    assert_eq!(last_event_id, 7);
+                }
+                other => panic!("expected reconnect, got {other:?}"),
+            }
+
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&ProtocolMessage::ReconnectAck {
+                        success: true,
+                        replayed_events: 2,
+                    })
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let session = connect_session(
+            &build_connect_url(&format!("ws://{}", addr)),
+            Some("secret"),
+            "resume-agent",
+            ConnectMode::Resume { last_event_id: 7 },
+        )
+        .await
+        .expect("resume handshake should succeed");
+
+        assert_eq!(session.replayed_events, 2);
+        drop(session);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_session_returns_terminal_error_when_resume_is_rejected() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+
+            let _ = recv_protocol_message(&mut socket).await;
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&ProtocolMessage::HandshakeAck {
+                        success: true,
+                        error: None,
+                    })
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+
+            let _ = recv_protocol_message(&mut socket).await;
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&ProtocolMessage::ReconnectAck {
+                        success: false,
+                        replayed_events: 0,
+                    })
+                    .unwrap()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let err = match connect_session(
+            &build_connect_url(&format!("ws://{}", addr)),
+            None,
+            "resume-agent",
+            ConnectMode::Resume { last_event_id: 3 },
+        )
+        .await
+        {
+            Ok(_) => panic!("resume rejection should be terminal"),
+            Err(err) => err,
         };
-        assert_eq!(ws_url, "wss://example.com:8443/api/agents/connect");
+
+        match err {
+            ConnectFailure::Terminal(err) => {
+                assert!(err.to_string().contains("resume rejected"));
+            }
+            ConnectFailure::Retryable(err) => {
+                panic!("expected terminal error, got retryable: {err}");
+            }
+        }
+
+        server.await.unwrap();
     }
 }

--- a/crates/opengoose-teams/src/remote.rs
+++ b/crates/opengoose-teams/src/remote.rs
@@ -7,7 +7,7 @@
 /// - **Heartbeat**: periodic keep-alive to detect disconnections
 /// - **Message relay**: forward messages between local and remote agents
 /// - **Reconnect**: client reconnects after a drop with last-seen event ID
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -61,7 +61,7 @@ pub enum ProtocolMessage {
     /// Server → Client: reconnect acknowledgement.
     ReconnectAck {
         success: bool,
-        /// Number of events replayed since last_event_id (0 if no replay buffer).
+        /// Number of buffered outbound events replayed since `last_event_id`.
         replayed_events: u64,
     },
 }
@@ -133,6 +133,8 @@ pub struct RemoteConfig {
     pub heartbeat_timeout_secs: u64,
     /// Simple API key validation (in production, use JWT or similar).
     pub api_keys: Vec<String>,
+    /// Maximum replayable outbound events retained per remote agent.
+    pub replay_buffer_capacity: usize,
 }
 
 impl Default for RemoteConfig {
@@ -141,8 +143,56 @@ impl Default for RemoteConfig {
             heartbeat_interval_secs: 30,
             heartbeat_timeout_secs: 90,
             api_keys: Vec::new(),
+            replay_buffer_capacity: 128,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+struct ReplayEvent {
+    event_id: u64,
+    message: ProtocolMessage,
+}
+
+#[derive(Debug)]
+struct AgentTransport {
+    tx: Option<tokio::sync::mpsc::UnboundedSender<ProtocolMessage>>,
+    next_event_id: u64,
+    replay_buffer: VecDeque<ReplayEvent>,
+}
+
+impl AgentTransport {
+    fn new(tx: tokio::sync::mpsc::UnboundedSender<ProtocolMessage>) -> Self {
+        Self {
+            tx: Some(tx),
+            next_event_id: 1,
+            replay_buffer: VecDeque::new(),
+        }
+    }
+
+    fn attach(&mut self, tx: tokio::sync::mpsc::UnboundedSender<ProtocolMessage>) {
+        self.tx = Some(tx);
+    }
+
+    fn detach(&mut self) {
+        self.tx = None;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplayResult {
+    Replayed(u64),
+    BufferMiss,
+    Unavailable,
+}
+
+fn should_buffer_for_replay(message: &ProtocolMessage) -> bool {
+    matches!(
+        message,
+        ProtocolMessage::MessageRelay { .. }
+            | ProtocolMessage::Broadcast { .. }
+            | ProtocolMessage::Disconnect { .. }
+    )
 }
 
 /// Central registry for all connected remote agents.
@@ -153,8 +203,8 @@ pub struct RemoteAgentRegistry {
     agents: Arc<RwLock<HashMap<String, RemoteAgent>>>,
     config: Arc<RemoteConfig>,
     /// Channel for sending messages to remote agents.
-    /// Key: agent name, Value: sender half of an unbounded channel.
-    outbound: Arc<Mutex<HashMap<String, tokio::sync::mpsc::UnboundedSender<ProtocolMessage>>>>,
+    /// Key: agent name, Value: live sender and replay state.
+    outbound: Arc<Mutex<HashMap<String, AgentTransport>>>,
     /// Total number of agents that have connected since startup.
     total_connects: Arc<AtomicU64>,
     /// Total number of agents that have disconnected since startup.
@@ -191,10 +241,31 @@ impl RemoteAgentRegistry {
         endpoint: String,
         tx: tokio::sync::mpsc::UnboundedSender<ProtocolMessage>,
     ) -> Result<(), String> {
-        let agents = self.agents.read().await;
-        if agents.contains_key(&name) {
-            return Err(format!("agent '{}' is already connected", name));
+        let mut agents = self.agents.write().await;
+        let mut outbound = self.outbound.lock().await;
+
+        if let Some(agent) = agents.get_mut(&name) {
+            match outbound.get_mut(&name) {
+                Some(transport) if transport.tx.is_none() => {
+                    transport.attach(tx);
+                    agent.capabilities = capabilities;
+                    agent.endpoint = endpoint;
+                    agent.last_heartbeat = Instant::now();
+                    agent.connection_state = ConnectionState::Connected;
+                    return Ok(());
+                }
+                Some(_) => return Err(format!("agent '{}' is already connected", name)),
+                None => {
+                    outbound.insert(name.clone(), AgentTransport::new(tx));
+                    agent.capabilities = capabilities;
+                    agent.endpoint = endpoint;
+                    agent.last_heartbeat = Instant::now();
+                    agent.connection_state = ConnectionState::Connected;
+                    return Ok(());
+                }
+            }
         }
+        drop(outbound);
         drop(agents);
 
         let now = Instant::now();
@@ -208,7 +279,10 @@ impl RemoteAgentRegistry {
         };
 
         self.agents.write().await.insert(name.clone(), agent);
-        self.outbound.lock().await.insert(name, tx);
+        self.outbound
+            .lock()
+            .await
+            .insert(name, AgentTransport::new(tx));
         self.total_connects.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
@@ -230,16 +304,131 @@ impl RemoteAgentRegistry {
         }
     }
 
+    /// Detach the live transport for an agent while preserving replay state.
+    ///
+    /// Used when the socket drops unexpectedly and the client may reconnect.
+    pub async fn detach_connection(&self, name: &str) -> bool {
+        let detached = {
+            let mut outbound = self.outbound.lock().await;
+            let Some(transport) = outbound.get_mut(name) else {
+                return false;
+            };
+            transport.detach();
+            true
+        };
+
+        if detached && let Some(agent) = self.agents.write().await.get_mut(name) {
+            agent.connection_state = ConnectionState::Reconnecting;
+            agent.last_heartbeat = Instant::now();
+        }
+
+        detached
+    }
+
+    /// Remove an agent only if it is still detached when the reconnect grace expires.
+    pub async fn unregister_if_detached(&self, name: &str) -> bool {
+        let should_remove = {
+            let outbound = self.outbound.lock().await;
+            matches!(outbound.get(name), Some(transport) if transport.tx.is_none())
+        };
+
+        if should_remove {
+            self.unregister(name).await;
+        }
+
+        should_remove
+    }
+
     /// Send a protocol message to a specific remote agent.
     ///
-    /// Returns `true` if the message was sent, `false` if the agent is not connected.
+    /// Returns `true` if the message was delivered immediately or buffered for replay.
     pub async fn send_to(&self, name: &str, msg: ProtocolMessage) -> bool {
-        let outbound = self.outbound.lock().await;
-        if let Some(tx) = outbound.get(name) {
-            tx.send(msg).is_ok()
-        } else {
-            false
+        let bufferable = should_buffer_for_replay(&msg);
+        let mut should_mark_reconnecting = false;
+
+        let accepted = {
+            let mut outbound = self.outbound.lock().await;
+            let Some(transport) = outbound.get_mut(name) else {
+                return false;
+            };
+
+            if bufferable {
+                let event_id = transport.next_event_id;
+                transport.next_event_id = transport.next_event_id.saturating_add(1);
+                transport.replay_buffer.push_back(ReplayEvent {
+                    event_id,
+                    message: msg.clone(),
+                });
+
+                while transport.replay_buffer.len() > self.config.replay_buffer_capacity {
+                    transport.replay_buffer.pop_front();
+                }
+            }
+
+            match transport.tx.as_ref() {
+                Some(tx) => {
+                    if tx.send(msg).is_ok() {
+                        true
+                    } else {
+                        transport.detach();
+                        should_mark_reconnecting = true;
+                        bufferable
+                    }
+                }
+                None => bufferable,
+            }
+        };
+
+        if should_mark_reconnecting {
+            self.mark_reconnecting(name).await;
         }
+
+        accepted
+    }
+
+    /// Re-enqueue buffered outbound events newer than `last_event_id`.
+    pub async fn replay_since(&self, name: &str, last_event_id: u64) -> ReplayResult {
+        let mut outbound = self.outbound.lock().await;
+        let Some(transport) = outbound.get_mut(name) else {
+            return ReplayResult::Unavailable;
+        };
+
+        let Some(tx) = transport.tx.as_ref() else {
+            return ReplayResult::Unavailable;
+        };
+
+        let newest_event_id = transport.next_event_id.saturating_sub(1);
+        if last_event_id > newest_event_id {
+            return ReplayResult::BufferMiss;
+        }
+        if last_event_id == newest_event_id {
+            return ReplayResult::Replayed(0);
+        }
+
+        let Some(oldest_event_id) = transport.replay_buffer.front().map(|event| event.event_id)
+        else {
+            return ReplayResult::BufferMiss;
+        };
+        if last_event_id.saturating_add(1) < oldest_event_id {
+            return ReplayResult::BufferMiss;
+        }
+
+        let replayable: Vec<ProtocolMessage> = transport
+            .replay_buffer
+            .iter()
+            .filter(|event| event.event_id > last_event_id)
+            .map(|event| event.message.clone())
+            .collect();
+
+        let replayed_events = replayable.len() as u64;
+        for message in replayable {
+            if tx.send(message).is_err() {
+                transport.detach();
+                return ReplayResult::Unavailable;
+            }
+        }
+
+        ReplayResult::Replayed(replayed_events)
     }
 
     /// List all currently connected remote agents.
@@ -352,6 +541,7 @@ mod tests {
             heartbeat_interval_secs: 5,
             heartbeat_timeout_secs: 15,
             api_keys: vec!["test-key-123".to_string()],
+            replay_buffer_capacity: 8,
         }
     }
 
@@ -502,6 +692,186 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn replay_since_reenqueues_buffered_message_relays() {
+        let reg = RemoteAgentRegistry::new(RemoteConfig {
+            replay_buffer_capacity: 4,
+            ..test_config()
+        });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        reg.register("replay-agent".into(), vec![], "ws://replay".into(), tx)
+            .await
+            .unwrap();
+
+        assert!(
+            reg.send_to(
+                "replay-agent",
+                ProtocolMessage::MessageRelay {
+                    from: "local".into(),
+                    to: "replay-agent".into(),
+                    payload: "first".into(),
+                },
+            )
+            .await
+        );
+        assert!(
+            reg.send_to(
+                "replay-agent",
+                ProtocolMessage::MessageRelay {
+                    from: "local".into(),
+                    to: "replay-agent".into(),
+                    payload: "second".into(),
+                },
+            )
+            .await
+        );
+
+        let _ = rx.recv().await.expect("first delivery should exist");
+        let _ = rx.recv().await.expect("second delivery should exist");
+
+        assert_eq!(
+            reg.replay_since("replay-agent", 1).await,
+            ReplayResult::Replayed(1)
+        );
+
+        match rx.recv().await.expect("replayed delivery should exist") {
+            ProtocolMessage::MessageRelay { payload, .. } => assert_eq!(payload, "second"),
+            other => panic!("expected replayed relay, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_since_reenqueues_buffered_disconnects() {
+        let reg = RemoteAgentRegistry::new(RemoteConfig {
+            replay_buffer_capacity: 4,
+            ..test_config()
+        });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        reg.register(
+            "disconnect-agent".into(),
+            vec![],
+            "ws://disconnect".into(),
+            tx,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reg.send_to(
+                "disconnect-agent",
+                ProtocolMessage::Disconnect {
+                    reason: "server shutdown".into(),
+                },
+            )
+            .await
+        );
+
+        let _ = rx.recv().await.expect("initial disconnect should exist");
+
+        assert_eq!(
+            reg.replay_since("disconnect-agent", 0).await,
+            ReplayResult::Replayed(1)
+        );
+
+        match rx.recv().await.expect("replayed disconnect should exist") {
+            ProtocolMessage::Disconnect { reason } => assert_eq!(reason, "server shutdown"),
+            other => panic!("expected replayed disconnect, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_since_reenqueues_buffered_broadcasts() {
+        let reg = RemoteAgentRegistry::new(RemoteConfig {
+            replay_buffer_capacity: 4,
+            ..test_config()
+        });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        reg.register(
+            "broadcast-agent".into(),
+            vec![],
+            "ws://broadcast".into(),
+            tx,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            reg.send_to(
+                "broadcast-agent",
+                ProtocolMessage::Broadcast {
+                    from: "ops".into(),
+                    channel: "alerts".into(),
+                    payload: "rotate credentials".into(),
+                },
+            )
+            .await
+        );
+
+        let _ = rx.recv().await.expect("initial broadcast should exist");
+
+        assert_eq!(
+            reg.replay_since("broadcast-agent", 0).await,
+            ReplayResult::Replayed(1)
+        );
+
+        match rx.recv().await.expect("replayed broadcast should exist") {
+            ProtocolMessage::Broadcast {
+                from,
+                channel,
+                payload,
+            } => {
+                assert_eq!(from, "ops");
+                assert_eq!(channel, "alerts");
+                assert_eq!(payload, "rotate credentials");
+            }
+            other => panic!("expected replayed broadcast, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_since_returns_buffer_miss_for_evicted_history() {
+        let reg = RemoteAgentRegistry::new(RemoteConfig {
+            replay_buffer_capacity: 2,
+            ..test_config()
+        });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        reg.register("window-agent".into(), vec![], "ws://window".into(), tx)
+            .await
+            .unwrap();
+
+        for payload in ["one", "two", "three"] {
+            assert!(
+                reg.send_to(
+                    "window-agent",
+                    ProtocolMessage::MessageRelay {
+                        from: "local".into(),
+                        to: "window-agent".into(),
+                        payload: payload.into(),
+                    },
+                )
+                .await
+            );
+        }
+
+        for _ in 0..3 {
+            let _ = rx.recv().await.expect("initial delivery should exist");
+        }
+
+        assert_eq!(
+            reg.replay_since("window-agent", 0).await,
+            ReplayResult::BufferMiss
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_since_returns_unavailable_for_unknown_agent() {
+        let reg = RemoteAgentRegistry::new(test_config());
+        assert_eq!(
+            reg.replay_since("ghost", 0).await,
+            ReplayResult::Unavailable
+        );
+    }
+
+    #[tokio::test]
     async fn send_to_disconnected_returns_false() {
         let reg = RemoteAgentRegistry::new(test_config());
         let msg = ProtocolMessage::Heartbeat { timestamp: 0 };
@@ -528,6 +898,7 @@ mod tests {
             heartbeat_interval_secs: 30,
             heartbeat_timeout_secs: 90,
             api_keys: vec![],
+            replay_buffer_capacity: 64,
         };
         let reg = RemoteAgentRegistry::new(config);
         assert_eq!(reg.heartbeat_interval(), Duration::from_secs(30));
@@ -836,6 +1207,88 @@ mod tests {
 
         let msg = ProtocolMessage::Heartbeat { timestamp: 1 };
         assert!(!reg.send_to("dropped", msg).await);
+    }
+
+    #[tokio::test]
+    async fn register_reconnects_detached_agent_and_replays_buffered_events() {
+        let reg = RemoteAgentRegistry::new(RemoteConfig {
+            replay_buffer_capacity: 4,
+            ..test_config()
+        });
+        let (tx1, mut rx1) = tokio::sync::mpsc::unbounded_channel();
+        reg.register("resume-agent".into(), vec![], "ws://one".into(), tx1)
+            .await
+            .unwrap();
+
+        assert!(
+            reg.send_to(
+                "resume-agent",
+                ProtocolMessage::MessageRelay {
+                    from: "local".into(),
+                    to: "resume-agent".into(),
+                    payload: "first".into(),
+                },
+            )
+            .await
+        );
+        assert!(
+            reg.send_to(
+                "resume-agent",
+                ProtocolMessage::MessageRelay {
+                    from: "local".into(),
+                    to: "resume-agent".into(),
+                    payload: "second".into(),
+                },
+            )
+            .await
+        );
+        let _ = rx1.recv().await.expect("first delivery should exist");
+        let _ = rx1.recv().await.expect("second delivery should exist");
+
+        assert!(reg.detach_connection("resume-agent").await);
+
+        assert!(
+            reg.send_to(
+                "resume-agent",
+                ProtocolMessage::Broadcast {
+                    from: "ops".into(),
+                    channel: "alerts".into(),
+                    payload: "buffered".into(),
+                },
+            )
+            .await
+        );
+
+        let (tx2, mut rx2) = tokio::sync::mpsc::unbounded_channel();
+        reg.register("resume-agent".into(), vec![], "ws://two".into(), tx2)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            reg.replay_since("resume-agent", 2).await,
+            ReplayResult::Replayed(1)
+        );
+
+        match rx2.recv().await.expect("replayed broadcast should exist") {
+            ProtocolMessage::Broadcast { payload, .. } => assert_eq!(payload, "buffered"),
+            other => panic!("expected replayed broadcast, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn unregister_if_detached_only_removes_detached_agents() {
+        let reg = RemoteAgentRegistry::new(test_config());
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        reg.register("live-agent".into(), vec![], "ws://live".into(), tx)
+            .await
+            .unwrap();
+
+        assert!(!reg.unregister_if_detached("live-agent").await);
+        assert!(reg.is_connected("live-agent").await);
+
+        assert!(reg.detach_connection("live-agent").await);
+        assert!(reg.unregister_if_detached("live-agent").await);
+        assert!(!reg.is_connected("live-agent").await);
     }
 
     #[tokio::test]

--- a/crates/opengoose-web/src/handlers/remote_agents.rs
+++ b/crates/opengoose-web/src/handlers/remote_agents.rs
@@ -13,7 +13,9 @@ use std::time::Instant;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
-use opengoose_teams::remote::{ConnectionMetrics, ProtocolMessage, RemoteAgentRegistry};
+use opengoose_teams::remote::{
+    ConnectionMetrics, ProtocolMessage, RemoteAgentRegistry, ReplayResult,
+};
 
 /// Shared state for the remote agent gateway.
 #[derive(Clone)]
@@ -89,6 +91,12 @@ pub struct RemoteAgentInfo {
     pub connected_secs: u64,
     /// Seconds since the last heartbeat was received.
     pub last_heartbeat_secs: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionDirective {
+    Continue,
+    GracefulDisconnect,
 }
 
 /// Handle a single WebSocket connection for the remote agent protocol.
@@ -192,6 +200,7 @@ async fn handle_connection(
 
     // Track when we last received a pong (or first connected).
     let mut last_pong = Instant::now();
+    let mut disconnect_directive = ConnectionDirective::Continue;
 
     loop {
         tokio::select! {
@@ -199,8 +208,12 @@ async fn handle_connection(
             msg = socket.recv() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
-                        if !handle_incoming(&state, &name, &text, &mut socket).await {
-                            break;
+                        match handle_incoming(&state, &name, &text, &mut socket).await {
+                            ConnectionDirective::Continue => {}
+                            ConnectionDirective::GracefulDisconnect => {
+                                disconnect_directive = ConnectionDirective::GracefulDisconnect;
+                                break;
+                            }
                         }
                     }
                     Some(Ok(Message::Pong(_))) => {
@@ -259,22 +272,41 @@ async fn handle_connection(
         }
     }
 
-    // Cleanup on disconnect.
-    state.registry.unregister(&name).await;
-    info!(%name, "remote agent unregistered");
+    match disconnect_directive {
+        ConnectionDirective::GracefulDisconnect => {
+            state.registry.unregister(&name).await;
+            info!(%name, "remote agent unregistered");
+        }
+        ConnectionDirective::Continue => {
+            if state.registry.detach_connection(&name).await {
+                let registry = state.registry.clone();
+                let reconnect_name = name.clone();
+                tokio::spawn(async move {
+                    tokio::time::sleep(heartbeat_timeout).await;
+                    if registry.unregister_if_detached(&reconnect_name).await {
+                        info!(name = %reconnect_name, "remote agent expired after reconnect grace period");
+                    }
+                });
+                info!(%name, "remote agent detached, waiting for reconnect");
+            } else {
+                state.registry.unregister(&name).await;
+                info!(%name, "remote agent unregistered");
+            }
+        }
+    }
 }
 
-/// Handle an incoming protocol message. Returns false if the connection should close.
+/// Handle an incoming protocol message.
 async fn handle_incoming(
     state: &RemoteGatewayState,
     name: &str,
     text: &str,
     socket: &mut WebSocket,
-) -> bool {
+) -> ConnectionDirective {
     match serde_json::from_str::<ProtocolMessage>(text) {
         Ok(ProtocolMessage::Heartbeat { .. }) => {
             state.registry.touch_heartbeat(name).await;
-            true
+            ConnectionDirective::Continue
         }
         Ok(ProtocolMessage::MessageRelay { from, to, payload }) => {
             let relay = ProtocolMessage::MessageRelay {
@@ -291,31 +323,22 @@ async fn handle_incoming(
                 )
                 .await;
             }
-            true
+            ConnectionDirective::Continue
         }
         Ok(ProtocolMessage::Reconnect { last_event_id }) => {
             info!(%name, %last_event_id, "remote agent reconnecting");
-            state.registry.mark_reconnecting(name).await;
-            // No replay buffer — acknowledge immediately and mark connected.
-            state.registry.mark_connected(name).await;
-            let _ = send_protocol(
-                socket,
-                &ProtocolMessage::ReconnectAck {
-                    success: true,
-                    replayed_events: 0,
-                },
-            )
-            .await;
-            true
+            let ack = reconnect_ack(&state.registry, name, last_event_id).await;
+            let _ = send_protocol(socket, &ack).await;
+            ConnectionDirective::Continue
         }
         Ok(ProtocolMessage::Disconnect { reason }) => {
             info!(%name, %reason, "remote agent disconnecting");
-            false
+            ConnectionDirective::GracefulDisconnect
         }
-        Ok(_) => true, // ignore unexpected message types
+        Ok(_) => ConnectionDirective::Continue, // ignore unexpected message types
         Err(e) => {
             warn!(%name, error = %e, "invalid protocol message");
-            true
+            ConnectionDirective::Continue
         }
     }
 }
@@ -353,6 +376,28 @@ async fn send_protocol(socket: &mut WebSocket, msg: &ProtocolMessage) -> Result<
     socket.send(Message::Text(json.into())).await
 }
 
+async fn reconnect_ack(
+    registry: &RemoteAgentRegistry,
+    name: &str,
+    last_event_id: u64,
+) -> ProtocolMessage {
+    registry.mark_reconnecting(name).await;
+
+    let ack = match registry.replay_since(name, last_event_id).await {
+        ReplayResult::Replayed(replayed_events) => ProtocolMessage::ReconnectAck {
+            success: true,
+            replayed_events,
+        },
+        ReplayResult::BufferMiss | ReplayResult::Unavailable => ProtocolMessage::ReconnectAck {
+            success: false,
+            replayed_events: 0,
+        },
+    };
+
+    registry.mark_connected(name).await;
+    ack
+}
+
 /// GET /api/health/gateways — remote agent gateway connection health and metrics.
 pub async fn gateway_health(
     State(state): State<std::sync::Arc<RemoteGatewayState>>,
@@ -367,9 +412,9 @@ mod tests {
     use axum::extract::{Path, State};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
-    use opengoose_teams::remote::{RemoteAgentRegistry, RemoteConfig};
+    use opengoose_teams::remote::{ProtocolMessage, RemoteAgentRegistry, RemoteConfig};
 
-    use super::{RemoteGatewayState, disconnect_remote, list_remote};
+    use super::{RemoteGatewayState, disconnect_remote, list_remote, reconnect_ack};
 
     fn make_state(config: RemoteConfig) -> Arc<RemoteGatewayState> {
         Arc::new(RemoteGatewayState {
@@ -500,6 +545,138 @@ mod tests {
         assert_eq!(metrics.active_connections, 0);
         assert_eq!(metrics.total_connects, 1);
         assert_eq!(metrics.total_disconnects, 1);
+    }
+
+    #[tokio::test]
+    async fn reconnect_ack_reports_replayed_event_count() {
+        let state = make_state(RemoteConfig {
+            replay_buffer_capacity: 4,
+            ..RemoteConfig::default()
+        });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        state
+            .registry
+            .register("replay-agent".into(), vec![], "ws://replay".into(), tx)
+            .await
+            .unwrap();
+
+        assert!(
+            state
+                .registry
+                .send_to(
+                    "replay-agent",
+                    ProtocolMessage::MessageRelay {
+                        from: "local".into(),
+                        to: "replay-agent".into(),
+                        payload: "first".into(),
+                    },
+                )
+                .await
+        );
+        assert!(
+            state
+                .registry
+                .send_to(
+                    "replay-agent",
+                    ProtocolMessage::MessageRelay {
+                        from: "local".into(),
+                        to: "replay-agent".into(),
+                        payload: "second".into(),
+                    },
+                )
+                .await
+        );
+
+        let _ = rx
+            .recv()
+            .await
+            .expect("initial first delivery should exist");
+        let _ = rx
+            .recv()
+            .await
+            .expect("initial second delivery should exist");
+
+        match reconnect_ack(&state.registry, "replay-agent", 1).await {
+            ProtocolMessage::ReconnectAck {
+                success,
+                replayed_events,
+            } => {
+                assert!(success);
+                assert_eq!(replayed_events, 1);
+            }
+            other => panic!("expected reconnect ack, got {other:?}"),
+        }
+
+        match rx.recv().await.expect("replayed delivery should exist") {
+            ProtocolMessage::MessageRelay { payload, .. } => assert_eq!(payload, "second"),
+            other => panic!("expected replayed relay, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reconnect_ack_fails_when_replay_window_is_truncated() {
+        let state = make_state(RemoteConfig {
+            replay_buffer_capacity: 1,
+            ..RemoteConfig::default()
+        });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        state
+            .registry
+            .register("window-agent".into(), vec![], "ws://window".into(), tx)
+            .await
+            .unwrap();
+
+        for payload in ["one", "two"] {
+            assert!(
+                state
+                    .registry
+                    .send_to(
+                        "window-agent",
+                        ProtocolMessage::MessageRelay {
+                            from: "local".into(),
+                            to: "window-agent".into(),
+                            payload: payload.into(),
+                        },
+                    )
+                    .await
+            );
+        }
+
+        let _ = rx
+            .recv()
+            .await
+            .expect("initial first delivery should exist");
+        let _ = rx
+            .recv()
+            .await
+            .expect("initial second delivery should exist");
+
+        match reconnect_ack(&state.registry, "window-agent", 0).await {
+            ProtocolMessage::ReconnectAck {
+                success,
+                replayed_events,
+            } => {
+                assert!(!success);
+                assert_eq!(replayed_events, 0);
+            }
+            other => panic!("expected reconnect ack, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reconnect_ack_fails_for_unknown_agent() {
+        let state = make_state(RemoteConfig::default());
+
+        match reconnect_ack(&state.registry, "ghost", 0).await {
+            ProtocolMessage::ReconnectAck {
+                success,
+                replayed_events,
+            } => {
+                assert!(!success);
+                assert_eq!(replayed_events, 0);
+            }
+            other => panic!("expected reconnect ack, got {other:?}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- retain buffered outbound remote events across unexpected socket drops and allow reconnect reattachment
- teach opengoose remote connect to track replay cursors, send reconnect requests, and label replayed versus live events
- add targeted protocol, handler, and CLI tests for resume and replay behavior

## Verification
- cargo test -p opengoose-teams --lib
- cargo test -p opengoose-web remote_agents --lib
- cargo test -p opengoose-cli remote --bin opengoose
- cargo clippy -p opengoose-teams -p opengoose-web -p opengoose-cli --all-targets -- -D warnings

Paperclip issue: OPE-276

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
