### PR TITLE
feat: Add API keys page to the web dashboard [OPE-286]

### DIFF
--- a/crates/opengoose-web/src/data/api_keys.rs
+++ b/crates/opengoose-web/src/data/api_keys.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use opengoose_persistence::ApiKeyStore;
+
+use crate::data::{ApiKeyRowView, ApiKeysPageView, MetricCard};
+
+/// Build the dashboard view-model for API key management.
+pub fn load_api_keys_page(store: Arc<ApiKeyStore>) -> Result<ApiKeysPageView> {
+    let keys = store.list()?;
+    let used_count = keys.iter().filter(|key| key.last_used_at.is_some()).count();
+    let described_count = keys.iter().filter(|key| key.description.is_some()).count();
+    let never_used_count = keys.len().saturating_sub(used_count);
+
+    let summary = if keys.is_empty() {
+        "No shared credentials have been issued yet. Generate one here before connecting remote agents or authenticated API clients.".into()
+    } else if never_used_count == 0 {
+        format!(
+            "{} active credential(s). Every key has authenticated at least once, so usage timestamps are available for rotation planning.",
+            keys.len()
+        )
+    } else {
+        format!(
+            "{} active credential(s). {} have never been used, which makes it easier to spot stale bootstrap secrets before they spread.",
+            keys.len(),
+            never_used_count
+        )
+    };
+
+    let rows = keys
+        .into_iter()
+        .map(|key| {
+            let (usage_label, usage_tone, last_used_at) = match key.last_used_at {
+                Some(timestamp) => ("Used", "success", timestamp),
+                None => ("Never used", "neutral", "Never".into()),
+            };
+
+            ApiKeyRowView {
+                id: key.id,
+                description_label: key.description.unwrap_or_else(|| "No description".into()),
+                created_at: key.created_at,
+                last_used_at,
+                usage_label: usage_label.into(),
+                usage_tone,
+            }
+        })
+        .collect();
+
+    Ok(ApiKeysPageView {
+        mode_label: if used_count + never_used_count == 0 {
+            "No keys issued".into()
+        } else if described_count > 0 {
+            "Managed credentials".into()
+        } else if never_used_count > 0 {
+            "Bootstrap credentials".into()
+        } else {
+            "Active credentials".into()
+        },
+        mode_tone: if used_count + never_used_count == 0 {
+            "neutral"
+        } else if described_count > 0 {
+            "success"
+        } else if never_used_count > 0 {
+            "amber"
+        } else {
+            "success"
+        },
+        summary,
+        metrics: vec![
+            MetricCard {
+                label: "Active keys".into(),
+                value: (used_count + never_used_count).to_string(),
+                note: "Stored credentials that can still authenticate requests".into(),
+                tone: "cyan",
+            },
+            MetricCard {
+                label: "Used".into(),
+                value: used_count.to_string(),
+                note: "Keys with at least one successful authentication".into(),
+                tone: "sage",
+            },
+            MetricCard {
+                label: "Never used".into(),
+                value: never_used_count.to_string(),
+                note: "Fresh or stale keys that have no last-used timestamp yet".into(),
+                tone: "amber",
+            },
+            MetricCard {
+                label: "Described".into(),
+                value: described_count.to_string(),
+                note: "Keys carrying operator-provided ownership context".into(),
+                tone: "neutral",
+            },
+        ],
+        keys: rows,
+        notice: None,
+        generated_key: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opengoose_persistence::Database;
+
+    #[test]
+    fn load_api_keys_page_reports_empty_state() {
+        let store = Arc::new(ApiKeyStore::new(Arc::new(
+            Database::open_in_memory().expect("db should open"),
+        )));
+
+        let page = load_api_keys_page(store).expect("page should load");
+
+        assert_eq!(page.mode_label, "No keys issued");
+        assert!(page.keys.is_empty());
+    }
+
+    #[test]
+    fn load_api_keys_page_marks_used_and_unused_rows() {
+        let store = Arc::new(ApiKeyStore::new(Arc::new(
+            Database::open_in_memory().expect("db should open"),
+        )));
+        let seeded = store.generate(Some("remote")).expect("key should generate");
+        store.generate(None).expect("unused key should generate");
+        store
+            .validate(&seeded.plaintext)
+            .expect("validation should update last used");
+
+        let page = load_api_keys_page(store).expect("page should load");
+
+        assert_eq!(page.keys.len(), 2);
+        assert!(page.keys.iter().any(|key| key.usage_label == "Used"));
+        assert!(page.keys.iter().any(|key| key.usage_label == "Never used"));
+    }
+}

--- a/crates/opengoose-web/src/data/mod.rs
+++ b/crates/opengoose-web/src/data/mod.rs
@@ -1,4 +1,5 @@
 mod agents;
+mod api_keys;
 mod dashboard;
 mod queue;
 mod remote_agents;
@@ -13,6 +14,7 @@ mod views;
 mod workflows;
 
 pub use agents::load_agents_page;
+pub use api_keys::load_api_keys_page;
 pub use dashboard::load_dashboard;
 pub use opengoose_types::HealthResponse;
 pub use queue::load_queue_page;

--- a/crates/opengoose-web/src/data/views/api_keys.rs
+++ b/crates/opengoose-web/src/data/views/api_keys.rs
@@ -1,0 +1,49 @@
+use super::{MetricCard, Notice};
+
+/// A single API key row on the dashboard security table.
+#[derive(Clone)]
+pub struct ApiKeyRowView {
+    pub id: String,
+    pub description_label: String,
+    pub created_at: String,
+    pub last_used_at: String,
+    pub usage_label: String,
+    pub usage_tone: &'static str,
+}
+
+/// One-time plaintext reveal returned immediately after generation.
+#[derive(Clone)]
+pub struct GeneratedApiKeyView {
+    pub id: String,
+    pub plaintext: String,
+    pub description_label: String,
+}
+
+/// View-model for the API keys dashboard page.
+#[derive(Clone)]
+pub struct ApiKeysPageView {
+    pub mode_label: String,
+    pub mode_tone: &'static str,
+    pub summary: String,
+    pub metrics: Vec<MetricCard>,
+    pub keys: Vec<ApiKeyRowView>,
+    pub notice: Option<Notice>,
+    pub generated_key: Option<GeneratedApiKeyView>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_api_key_view_keeps_plaintext_and_description() {
+        let view = GeneratedApiKeyView {
+            id: "key-1".into(),
+            plaintext: "ogk_secret".into(),
+            description_label: "Remote agent".into(),
+        };
+
+        assert!(view.plaintext.starts_with("ogk_"));
+        assert_eq!(view.description_label, "Remote agent");
+    }
+}

--- a/crates/opengoose-web/src/data/views/mod.rs
+++ b/crates/opengoose-web/src/data/views/mod.rs
@@ -1,4 +1,5 @@
 mod agents;
+mod api_keys;
 mod automation;
 mod runs;
 mod sessions;
@@ -7,6 +8,7 @@ mod status;
 mod teams;
 
 pub use agents::*;
+pub use api_keys::*;
 pub use automation::*;
 pub use runs::*;
 pub use sessions::*;

--- a/crates/opengoose-web/src/lib.rs
+++ b/crates/opengoose-web/src/lib.rs
@@ -53,6 +53,7 @@ pub async fn serve(options: WebOptions) -> Result<()> {
     let api_state = AppState::new(db.clone())?;
     let state = PageState {
         db: db.clone(),
+        api_key_store: api_state.api_key_store.clone(),
         remote_registry: remote_state.registry.clone(),
         channel_metrics: api_state.channel_metrics.clone(),
         event_bus: api_state.event_bus.clone(),

--- a/crates/opengoose-web/src/routes/health.rs
+++ b/crates/opengoose-web/src/routes/health.rs
@@ -247,7 +247,7 @@ mod tests {
     use std::sync::Arc;
 
     use axum::response::Html;
-    use opengoose_persistence::Database;
+    use opengoose_persistence::{ApiKeyStore, Database};
     use opengoose_teams::remote::{RemoteAgentRegistry, RemoteConfig};
     use opengoose_types::ChannelMetricsStore;
 
@@ -255,6 +255,7 @@ mod tests {
 
     fn page_state(db: Arc<Database>) -> PageState {
         PageState {
+            api_key_store: Arc::new(ApiKeyStore::new(db.clone())),
             db,
             remote_registry: RemoteAgentRegistry::new(RemoteConfig::default()),
             channel_metrics: ChannelMetricsStore::new(),

--- a/crates/opengoose-web/src/routes/pages/api_keys.rs
+++ b/crates/opengoose-web/src/routes/pages/api_keys.rs
@@ -1,0 +1,108 @@
+use askama::Template;
+use axum::extract::{Form, State};
+use serde::Deserialize;
+
+use crate::data::{GeneratedApiKeyView, Notice, load_api_keys_page};
+use crate::routes::{WebResult, internal_error, render_template};
+use crate::server::PageState;
+
+#[derive(Deserialize)]
+pub(crate) struct ApiKeyActionForm {
+    pub(crate) intent: String,
+    pub(crate) description: Option<String>,
+    pub(crate) key_id: Option<String>,
+}
+
+pub(crate) async fn api_keys(State(state): State<PageState>) -> WebResult {
+    let page = load_api_keys_page(state.api_key_store).map_err(internal_error)?;
+    render_api_keys_page(page)
+}
+
+pub(crate) async fn api_key_action(
+    State(state): State<PageState>,
+    Form(form): Form<ApiKeyActionForm>,
+) -> WebResult {
+    let notice = match form.intent.as_str() {
+        "generate" => {
+            let description = form
+                .description
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty());
+            let generated = state
+                .api_key_store
+                .generate(description)
+                .map_err(|error| internal_error(error.into()))?;
+            let mut page = load_api_keys_page(state.api_key_store).map_err(internal_error)?;
+            let generated_id = generated.id.clone();
+            page.notice = Some(Notice {
+                text: format!("API key `{generated_id}` generated."),
+                tone: "success",
+            });
+            page.generated_key = Some(GeneratedApiKeyView {
+                id: generated.id,
+                plaintext: generated.plaintext,
+                description_label: generated
+                    .description
+                    .unwrap_or_else(|| "No description".into()),
+            });
+            return render_api_keys_page(page);
+        }
+        "revoke" => match form
+            .key_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            Some(key_id) => {
+                if state
+                    .api_key_store
+                    .revoke(key_id)
+                    .map_err(|error| internal_error(error.into()))?
+                {
+                    Notice {
+                        text: format!("API key `{key_id}` revoked."),
+                        tone: "success",
+                    }
+                } else {
+                    Notice {
+                        text: format!(
+                            "API key `{key_id}` was not found. It may have already been revoked."
+                        ),
+                        tone: "danger",
+                    }
+                }
+            }
+            None => Notice {
+                text: "Select an API key to revoke.".into(),
+                tone: "danger",
+            },
+        },
+        _ => {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                axum::response::Html("Unsupported API key action.".into()),
+            ));
+        }
+    };
+
+    let mut page = load_api_keys_page(state.api_key_store).map_err(internal_error)?;
+    page.notice = Some(notice);
+    render_api_keys_page(page)
+}
+
+fn render_api_keys_page(page: crate::data::ApiKeysPageView) -> WebResult {
+    render_template(&ApiKeysTemplate {
+        page_title: "API Keys",
+        current_nav: "api_keys",
+        page,
+    })
+}
+
+#[derive(Template)]
+#[template(path = "api_keys.html")]
+struct ApiKeysTemplate {
+    page_title: &'static str,
+    current_nav: &'static str,
+    page: crate::data::ApiKeysPageView,
+}

--- a/crates/opengoose-web/src/routes/pages/mod.rs
+++ b/crates/opengoose-web/src/routes/pages/mod.rs
@@ -3,6 +3,7 @@ use axum::routing::get;
 
 use crate::server::PageState;
 
+mod api_keys;
 mod catalog;
 mod catalog_forms;
 mod catalog_templates;
@@ -11,6 +12,7 @@ mod remote_agents;
 
 pub use dashboard::render_dashboard_live_partial;
 
+use api_keys::{api_key_action, api_keys};
 use catalog::{
     agents, queue, runs, schedule_action, schedules, session_action, sessions, sessions_events,
     team_save, teams, trigger_action, trigger_workflow_action, triggers, workflows,
@@ -26,6 +28,7 @@ pub(crate) fn router(state: PageState) -> Router {
         .route("/sessions/events", get(sessions_events))
         .route("/runs", get(runs))
         .route("/agents", get(agents))
+        .route("/api-keys", get(api_keys).post(api_key_action))
         .route("/remote-agents", get(remote_agents))
         .route("/remote-agents/events", get(remote_agents_events))
         .route(

--- a/crates/opengoose-web/src/routes/pages/tests.rs
+++ b/crates/opengoose-web/src/routes/pages/tests.rs
@@ -1,4 +1,5 @@
 mod action_handlers;
+mod api_keys;
 mod page_handlers;
 mod remote_agents;
 mod router;

--- a/crates/opengoose-web/src/routes/pages/tests/api_keys.rs
+++ b/crates/opengoose-web/src/routes/pages/tests/api_keys.rs
@@ -1,0 +1,90 @@
+use axum::extract::{Form, State};
+use axum::response::Html;
+use opengoose_persistence::ApiKeyStore;
+
+use super::super::api_keys::{ApiKeyActionForm, api_key_action, api_keys};
+use super::support::{page_state, test_db};
+
+#[tokio::test]
+async fn api_keys_handler_renders_empty_state() {
+    let Html(html) = api_keys(State(page_state(test_db())))
+        .await
+        .expect("handler should render");
+
+    assert!(html.contains("No API keys have been generated yet."));
+    assert!(html.contains("Generate a new API key"));
+    assert!(html.contains("aria-current=\"page\""));
+}
+
+#[tokio::test]
+async fn api_key_action_generate_reveals_plaintext_once() {
+    let db = test_db();
+
+    let Html(html) = api_key_action(
+        State(page_state(db.clone())),
+        Form(ApiKeyActionForm {
+            intent: "generate".into(),
+            description: Some("CI pipeline".into()),
+            key_id: None,
+        }),
+    )
+    .await
+    .expect("generate action should render");
+
+    assert!(html.contains("API key reveal"));
+    assert!(html.contains("Save this API key now"));
+    assert!(html.contains("ogk_"));
+    assert!(html.contains("CI pipeline"));
+    assert_eq!(
+        ApiKeyStore::new(db)
+            .list()
+            .expect("list should succeed")
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn api_key_action_revoke_removes_key() {
+    let db = test_db();
+    let seeded_key = ApiKeyStore::new(db.clone())
+        .generate(Some("remote-agent"))
+        .expect("key should seed");
+
+    let Html(html) = api_key_action(
+        State(page_state(db.clone())),
+        Form(ApiKeyActionForm {
+            intent: "revoke".into(),
+            description: None,
+            key_id: Some(seeded_key.id.clone()),
+        }),
+    )
+    .await
+    .expect("revoke action should render");
+
+    assert!(html.contains("revoked"));
+    assert!(html.contains("No API keys have been generated yet."));
+    assert!(
+        ApiKeyStore::new(db)
+            .list()
+            .expect("list should succeed")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn api_key_action_revoke_missing_key_renders_failure_notice() {
+    let Html(html) = api_key_action(
+        State(page_state(test_db())),
+        Form(ApiKeyActionForm {
+            intent: "revoke".into(),
+            description: None,
+            key_id: Some("missing-key".into()),
+        }),
+    )
+    .await
+    .expect("missing revoke should render");
+
+    assert!(html.contains("was not found"));
+    assert!(html.contains("No API keys have been generated yet."));
+}

--- a/crates/opengoose-web/src/routes/pages/tests/router.rs
+++ b/crates/opengoose-web/src/routes/pages/tests/router.rs
@@ -18,6 +18,7 @@ fn page_router_get_routes_return_expected_statuses() {
                 "/sessions",
                 "/runs",
                 "/agents",
+                "/api-keys",
                 "/remote-agents",
                 "/remote-agents/events",
                 "/workflows",
@@ -81,6 +82,20 @@ fn page_router_post_routes_return_expected_statuses() {
                 .await
                 .expect("team request should be handled");
             assert_eq!(team_response.status(), StatusCode::OK);
+
+            let api_key_response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/api-keys")
+                        .header("content-type", "application/x-www-form-urlencoded")
+                        .body(Body::from("intent=unsupported"))
+                        .unwrap(),
+                )
+                .await
+                .expect("api key request should be handled");
+            assert_eq!(api_key_response.status(), StatusCode::BAD_REQUEST);
 
             let trigger_response = app
                 .oneshot(

--- a/crates/opengoose-web/src/routes/pages/tests/support.rs
+++ b/crates/opengoose-web/src/routes/pages/tests/support.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use axum::body::to_bytes;
-use opengoose_persistence::{Database, OrchestrationStore, SessionStore};
+use opengoose_persistence::{ApiKeyStore, Database, OrchestrationStore, SessionStore};
 use opengoose_teams::remote::{RemoteAgentRegistry, RemoteConfig};
 use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition, TeamStore};
 use opengoose_types::{ChannelMetricsStore, EventBus, SessionKey};
@@ -39,6 +39,7 @@ pub(super) fn save_team(name: &str) {
 
 pub(super) fn page_state(db: Arc<Database>) -> PageState {
     PageState {
+        api_key_store: Arc::new(ApiKeyStore::new(db.clone())),
         db,
         remote_registry: RemoteAgentRegistry::new(RemoteConfig::default()),
         channel_metrics: ChannelMetricsStore::new(),

--- a/crates/opengoose-web/src/server.rs
+++ b/crates/opengoose-web/src/server.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use opengoose_persistence::Database;
+use opengoose_persistence::{ApiKeyStore, Database};
 use opengoose_teams::remote::RemoteAgentRegistry;
 use opengoose_types::{ChannelMetricsStore, EventBus};
 
@@ -37,6 +37,7 @@ impl Default for WebOptions {
 #[derive(Clone)]
 pub(crate) struct PageState {
     pub(crate) db: Arc<Database>,
+    pub(crate) api_key_store: Arc<ApiKeyStore>,
     pub(crate) remote_registry: RemoteAgentRegistry,
     pub(crate) channel_metrics: ChannelMetricsStore,
     #[allow(dead_code)]

--- a/crates/opengoose-web/templates/api_keys.html
+++ b/crates/opengoose-web/templates/api_keys.html
@@ -1,0 +1,149 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="hero-panel">
+  <div class="hero-copy">
+    <p class="eyebrow">API keys</p>
+    <h1>Issue, inspect, and revoke shared credentials without leaving the dashboard.</h1>
+    <p class="hero-text">{{ page.summary }}</p>
+  </div>
+  <div class="hero-status">
+    <p class="eyebrow">Credential policy</p>
+    <div class="live-chip-row">
+      <span class="chip tone-{{ page.mode_tone }}">{{ page.mode_label }}</span>
+      <span class="chip tone-cyan">Plaintext shown once</span>
+    </div>
+    <p>New secrets are returned only in the generation response below. Refreshing later will never reveal them again.</p>
+    <p class="heartbeat" aria-live="polite">Use descriptions and last-used timestamps to rotate stale credentials before they reach more workers.</p>
+  </div>
+</section>
+
+{% match page.notice %}
+{% when Some with (notice) %}
+<div class="notice tone-{{ notice.tone }}">{{ notice.text }}</div>
+{% when None %}
+{% endmatch %}
+
+{% match page.generated_key %}
+{% when Some with (generated) %}
+<section class="callout tone-success">
+  <p class="eyebrow">API key reveal</p>
+  <h2>Save this API key now</h2>
+  <p>This plaintext secret is only visible in this response. After you navigate away or refresh, OpenGoose cannot retrieve it again.</p>
+  <div class="editor-block">
+    <pre>{{ generated.plaintext }}</pre>
+  </div>
+  <dl class="stacked-meta">
+    <div class="stacked-meta-row">
+      <dt>Key ID</dt>
+      <dd>{{ generated.id }}</dd>
+    </div>
+    <div class="stacked-meta-row">
+      <dt>Description</dt>
+      <dd>{{ generated.description_label }}</dd>
+    </div>
+  </dl>
+</section>
+{% when None %}
+{% endmatch %}
+
+<section class="metric-grid compact-grid">
+  {% for metric in page.metrics %}
+  <article class="metric-card tone-{{ metric.tone }}">
+    <p class="metric-label">{{ metric.label }}</p>
+    <strong class="metric-value">{{ metric.value }}</strong>
+    <p class="metric-note">{{ metric.note }}</p>
+  </article>
+  {% endfor %}
+</section>
+
+<section class="split-grid">
+  <article class="panel">
+    <div class="panel-head">
+      <div>
+        <h2>Generate a new API key</h2>
+        <small>Create a shared credential for remote agents, automation, or authenticated API clients.</small>
+      </div>
+    </div>
+
+    <form class="editor-form" method="post" action="/api-keys">
+      <input type="hidden" name="intent" value="generate">
+      <label class="control-field">
+        <span>Description</span>
+        <input type="text" name="description" placeholder="CI pipeline, remote-builder-1, integration test">
+      </label>
+      <p class="surface-feedback">Descriptions are optional, but they make rotation and incident response much easier later.</p>
+      <button class="primary-button" type="submit">Generate key</button>
+    </form>
+  </article>
+
+  <article class="panel">
+    <div class="panel-head">
+      <div>
+        <h2>Operator notes</h2>
+        <small>Use the same stored credential metadata everywhere the dashboard expects a shared API key.</small>
+      </div>
+    </div>
+    <dl class="stacked-meta">
+      <div class="stacked-meta-row">
+        <dt>Remote agents</dt>
+        <dd>Use the plaintext key in the `api_key` field shown on the Remote Agents page.</dd>
+      </div>
+      <div class="stacked-meta-row">
+        <dt>Rotation</dt>
+        <dd>Generate a replacement key first, update clients, then revoke the compromised or stale credential.</dd>
+      </div>
+      <div class="stacked-meta-row">
+        <dt>Recovery</dt>
+        <dd>Plaintext is never stored after creation, so revocation is the only recovery path if a secret is lost.</dd>
+      </div>
+    </dl>
+  </article>
+</section>
+
+<section class="table-shell panel">
+  <div class="panel-head">
+    <div>
+      <h2>Issued keys</h2>
+      <small>Descriptions, creation times, and last-used timestamps help operators spot stale credentials quickly.</small>
+    </div>
+  </div>
+
+  {% if page.keys.len() > 0 %}
+  <div class="table-wrap">
+    <table aria-label="Issued API keys">
+      <thead>
+        <tr>
+          <th scope="col">Description</th>
+          <th scope="col">Key ID</th>
+          <th scope="col">Created</th>
+          <th scope="col">Last used</th>
+          <th scope="col">State</th>
+          <th scope="col">Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for key in page.keys %}
+        <tr data-table-row>
+          <td>{{ key.description_label }}</td>
+          <td><code>{{ key.id }}</code></td>
+          <td>{{ key.created_at }}</td>
+          <td>{{ key.last_used_at }}</td>
+          <td><span class="chip tone-{{ key.usage_tone }}">{{ key.usage_label }}</span></td>
+          <td>
+            <form class="inline-form" method="post" action="/api-keys">
+              <input type="hidden" name="intent" value="revoke">
+              <input type="hidden" name="key_id" value="{{ key.id }}">
+              <button class="secondary-button" type="submit">Revoke</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p class="empty-hint">No API keys have been generated yet. Create one above to authenticate remote agents and protected API clients.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/crates/opengoose-web/templates/base.html
+++ b/crates/opengoose-web/templates/base.html
@@ -35,6 +35,7 @@
         <a href="/sessions" class="nav-link{% if current_nav == "sessions" %} is-active{% endif %}" {% if current_nav == "sessions" %}aria-current="page"{% endif %}>Sessions</a>
         <a href="/runs" class="nav-link{% if current_nav == "runs" %} is-active{% endif %}" {% if current_nav == "runs" %}aria-current="page"{% endif %}>Runs</a>
         <a href="/agents" class="nav-link{% if current_nav == "agents" %} is-active{% endif %}" {% if current_nav == "agents" %}aria-current="page"{% endif %}>Agents</a>
+        <a href="/api-keys" class="nav-link{% if current_nav == "api_keys" %} is-active{% endif %}" {% if current_nav == "api_keys" %}aria-current="page"{% endif %}>API Keys</a>
         <a href="/remote-agents" class="nav-link{% if current_nav == "remote_agents" %} is-active{% endif %}" {% if current_nav == "remote_agents" %}aria-current="page"{% endif %}>Remote Agents</a>
         <a href="/workflows" class="nav-link{% if current_nav == "workflows" %} is-active{% endif %}" {% if current_nav == "workflows" %}aria-current="page"{% endif %}>Workflows</a>
         <a href="/schedules" class="nav-link{% if current_nav == "schedules" %} is-active{% endif %}" {% if current_nav == "schedules" %}aria-current="page"{% endif %}>Schedules</a>

--- a/docs/web-dashboard.md
+++ b/docs/web-dashboard.md
@@ -18,6 +18,7 @@ The dashboard stays server-rendered and adds live updates only where they help o
 - `Sessions`: conversation history with a searchable session rail and query-selected detail view.
 - `Runs`: orchestration status, work items, and broadcasts for a selected run.
 - `Agents`: installed agent profiles, extensions, skills, and YAML.
+- `API Keys`: generate shared credentials, inspect last-used metadata, and revoke compromised keys without leaving the dashboard.
 - `Teams`: editable team definitions with inline validation and save feedback.
 - `Queue`: searchable queue traffic with client-side filtering, sorting, and pagination.
 
@@ -47,6 +48,7 @@ The web layer stays intentionally split:
 - Live pages surface Datastar stream state directly in the hero status area.
 - SSE reconnects fall back to a slower reconciliation sweep so time-based labels keep moving even when the event stream is quiet.
 - Validation and save feedback stay server-rendered inside the selected detail pane.
+- API key generation reveals the plaintext secret exactly once in a server-rendered confirmation panel.
 
 ## Smoke check
 


### PR DESCRIPTION
## Summary
- add a new server-rendered `/api-keys` dashboard page with navigation, key metrics, empty state, and operator guidance
- support generate and revoke actions through the existing Askama page-route pattern, including one-time plaintext reveal and success/failure notices
- add page/data tests for the new surface and refresh `docs/web-dashboard.md`

## Verification
- cargo build
- cargo fmt --all
- cargo clippy --all-targets
- cargo test

## Paperclip
- [OPE-286](http://localhost:3131/OPE/issues/OPE-286)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
