### PR TITLE
Redact sensitive data in Debug output for event history

### DIFF
--- a/crates/opengoose-persistence/src/event_store.rs
+++ b/crates/opengoose-persistence/src/event_store.rs
@@ -15,7 +15,7 @@ use crate::schema::event_history;
 pub const DEFAULT_EVENT_RETENTION_DAYS: u32 = 30;
 const DEFAULT_HISTORY_LIMIT: i64 = 50;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct EventHistoryEntry {
     pub id: i32,
     pub event_kind: String,
@@ -23,6 +23,19 @@ pub struct EventHistoryEntry {
     pub source_gateway: Option<String>,
     pub session_key: Option<String>,
     pub payload: serde_json::Value,
+}
+
+impl std::fmt::Debug for EventHistoryEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventHistoryEntry")
+            .field("id", &self.id)
+            .field("event_kind", &self.event_kind)
+            .field("timestamp", &self.timestamp)
+            .field("source_gateway", &self.source_gateway)
+            .field("session_key", &"<redacted>")
+            .field("payload", &"<redacted>")
+            .finish()
+    }
 }
 
 impl TryFrom<EventHistoryRow> for EventHistoryEntry {

--- a/crates/opengoose-persistence/src/models.rs
+++ b/crates/opengoose-persistence/src/models.rs
@@ -166,7 +166,7 @@ pub struct NewAlertHistory<'a> {
 
 // ── Event History ──
 
-#[derive(Queryable, Selectable, Clone, Debug)]
+#[derive(Queryable, Selectable, Clone)]
 #[diesel(table_name = event_history)]
 pub struct EventHistoryRow {
     pub id: i32,
@@ -175,6 +175,19 @@ pub struct EventHistoryRow {
     pub source_gateway: Option<String>,
     pub session_key: Option<String>,
     pub payload: String,
+}
+
+impl std::fmt::Debug for EventHistoryRow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventHistoryRow")
+            .field("id", &self.id)
+            .field("event_kind", &self.event_kind)
+            .field("timestamp", &self.timestamp)
+            .field("source_gateway", &self.source_gateway)
+            .field("session_key", &"<redacted>")
+            .field("payload", &"<redacted>")
+            .finish()
+    }
 }
 
 #[derive(Insertable)]

--- a/crates/opengoose-web/src/handlers/webhooks.rs
+++ b/crates/opengoose-web/src/handlers/webhooks.rs
@@ -231,6 +231,9 @@ mod tests {
     use crate::handlers::test_support::make_state;
     use crate::state::AppState;
 
+    /// Test-only HMAC secret — never used outside of unit tests.
+    const TEST_HMAC_SECRET: &str = "test-only-hmac-secret";
+
     fn router(state: AppState) -> Router {
         Router::new()
             .route("/api/webhooks/{*path}", post(receive_webhook))
@@ -374,7 +377,7 @@ mod tests {
             .create(
                 "signed-hook",
                 "webhook_received",
-                r#"{"path":"/signed","hmac_secret":"sig-secret"}"#,
+                &format!(r#"{{"path":"/signed","hmac_secret":"{TEST_HMAC_SECRET}"}}"#),
                 "my-team",
                 "",
             )
@@ -383,7 +386,7 @@ mod tests {
         let app = router(state);
         let timestamp = Utc::now().timestamp().to_string();
         let body = r#"{"event":"push"}"#;
-        let signature = signed_signature("sig-secret", &timestamp, body.as_bytes());
+        let signature = signed_signature(TEST_HMAC_SECRET, &timestamp, body.as_bytes());
 
         let req = Request::builder()
             .method("POST")
@@ -405,7 +408,7 @@ mod tests {
             .create(
                 "signed-hook",
                 "webhook_received",
-                r#"{"path":"/signed","hmac_secret":"sig-secret"}"#,
+                &format!(r#"{{"path":"/signed","hmac_secret":"{TEST_HMAC_SECRET}"}}"#),
                 "my-team",
                 "",
             )
@@ -435,7 +438,7 @@ mod tests {
             .create(
                 "signed-hook",
                 "webhook_received",
-                r#"{"path":"/signed","hmac_secret":"sig-secret","timestamp_tolerance_secs":10}"#,
+                &format!(r#"{{"path":"/signed","hmac_secret":"{TEST_HMAC_SECRET}","timestamp_tolerance_secs":10}}"#),
                 "my-team",
                 "",
             )
@@ -444,7 +447,7 @@ mod tests {
         let app = router(state);
         let timestamp = (Utc::now().timestamp() - 60).to_string();
         let body = r#"{"event":"push"}"#;
-        let signature = signed_signature("sig-secret", &timestamp, body.as_bytes());
+        let signature = signed_signature(TEST_HMAC_SECRET, &timestamp, body.as_bytes());
 
         let req = Request::builder()
             .method("POST")
@@ -466,7 +469,7 @@ mod tests {
             .create(
                 "signed-hook",
                 "webhook_received",
-                r#"{"path":"/signed","hmac_secret":"sig-secret"}"#,
+                &format!(r#"{{"path":"/signed","hmac_secret":"{TEST_HMAC_SECRET}"}}"#),
                 "my-team",
                 "",
             )


### PR DESCRIPTION
## Summary
This PR implements custom `Debug` trait implementations for event history structures to redact sensitive information (session keys and payloads) when logging or debugging, improving security by preventing accidental exposure of sensitive data in logs and debug output.

## Key Changes
- **EventHistoryEntry & EventHistoryRow**: Removed derive `Debug` and implemented custom `Debug` trait that redacts `session_key` and `payload` fields while preserving other diagnostic information
- **Test constants**: Introduced `TEST_HMAC_SECRET` constant in webhook tests to centralize test-only credentials and improve maintainability
- **Test updates**: Updated webhook handler tests to use the new `TEST_HMAC_SECRET` constant instead of hardcoded secret strings

## Implementation Details
- Custom `Debug` implementations use `debug_struct()` to maintain readable output format while replacing sensitive field values with `"<redacted>"` placeholders
- The redaction applies to both the ORM model (`EventHistoryRow`) and the domain model (`EventHistoryEntry`)
- Test constant is properly documented as test-only to prevent accidental production use

https://claude.ai/code/session_01U6hzyurTYaKmA8GGJeyeUM
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
