### PR TITLE
feat: Decompose schedule detail templates [OPE-309]

### DIFF
--- a/crates/opengoose-web/src/tests/template_render.rs
+++ b/crates/opengoose-web/src/tests/template_render.rs
@@ -136,6 +136,33 @@ fn sample_schedule_detail() -> ScheduleEditorView {
     }
 }
 
+fn sample_new_schedule_detail() -> ScheduleEditorView {
+    ScheduleEditorView {
+        title: "New schedule".into(),
+        subtitle: "Create a cron-driven workflow handoff from the dashboard.".into(),
+        source_label: "Live schedule store".into(),
+        original_name: "__new__".into(),
+        name: String::new(),
+        cron_expression: String::new(),
+        team_name: String::new(),
+        input: "{}".into(),
+        enabled: false,
+        is_new: true,
+        name_locked: false,
+        meta: vec![MetaRow {
+            label: "Next fire".into(),
+            value: "Pending cron validation".into(),
+        }],
+        team_options: vec![],
+        history: vec![],
+        history_hint: "No matching runs found for this schedule yet.".into(),
+        notice: None,
+        save_label: "Create schedule".into(),
+        toggle_label: "Enable schedule".into(),
+        delete_label: "New schedule".into(),
+    }
+}
+
 #[test]
 fn dashboard_live_template_renders_monitoring_sections() {
     let html = routes::test_support::render_dashboard_live(sample_dashboard_view())
@@ -220,8 +247,21 @@ fn schedules_template_renders_form_actions_and_history() {
 
     assert!(html.contains("Search schedules"));
     assert!(html.contains("New schedule"));
+    assert!(html.contains("data-list-item"));
     assert!(html.contains("Pause schedule"));
     assert!(html.contains("Recent matching runs"));
+}
+
+#[test]
+fn schedule_detail_template_hides_destructive_controls_for_new_schedule() {
+    let html = routes::test_support::render_schedule_detail(sample_new_schedule_detail())
+        .expect("new schedule detail renders");
+
+    assert!(html.contains("Create schedule"));
+    assert!(html.contains("No teams are installed yet."));
+    assert!(html.contains("No matching runs found for this schedule yet."));
+    assert!(!html.contains("Delete schedule"));
+    assert!(!html.contains("Enable schedule"));
 }
 
 #[test]

--- a/crates/opengoose-web/templates/partials/schedule_detail.html
+++ b/crates/opengoose-web/templates/partials/schedule_detail.html
@@ -1,15 +1,5 @@
 <section class="detail-card">
-  <div class="detail-head">
-    <div>
-      <p class="eyebrow">Schedule editor</p>
-      <h2>{{ detail.title }}</h2>
-      <p>{{ detail.subtitle }}</p>
-    </div>
-    <div class="schedule-head-actions">
-      <span class="chip {% if detail.enabled %}tone-sage{% else %}tone-neutral{% endif %}">{% if detail.enabled %}Enabled{% else %}Paused{% endif %}</span>
-      <a class="secondary-button" href="/runs">View all runs</a>
-    </div>
-  </div>
+  {% include "partials/schedule_detail/header.html" %}
 
   {% let notice_option = &detail.notice %}
   {% include "components/notice.html" %}
@@ -17,106 +7,9 @@
   {% let meta_rows = &detail.meta %}
   {% include "components/meta_grid.html" %}
 
-  <form class="editor-form schedule-form" method="post" action="/schedules">
-    <input type="hidden" name="intent" value="save">
-    <input type="hidden" name="original_name" value="{{ detail.original_name }}">
-    <div class="schedule-form-grid">
-      <label class="control-field">
-        <span>Schedule name</span>
-        <input type="text" name="name" value="{{ detail.name }}" autocomplete="off" spellcheck="false" {% if detail.name_locked %}readonly{% endif %} required>
-      </label>
-      <label class="control-field">
-        <span>Cron expression</span>
-        <input type="text" name="cron_expression" value="{{ detail.cron_expression }}" autocomplete="off" spellcheck="false" placeholder="0 0 * * * *…" required>
-      </label>
-      <label class="control-field">
-        <span>Team</span>
-        <select name="team_name" {% if detail.team_options.len() == 0 %}disabled{% endif %}>
-        {% for option in detail.team_options %}
-          <option value="{{ option.value }}"{% if option.selected %} selected{% endif %}>{{ option.label }}</option>
-        {% endfor %}
-        </select>
-      </label>
-      <label class="control-field control-field-toggle">
-        <span>State</span>
-        <span class="toggle-chip">
-          <input type="checkbox" name="enabled" value="yes" {% if detail.enabled %}checked{% endif %}>
-          <strong>{% if detail.enabled %}Enabled{% else %}Paused{% endif %}</strong>
-        </span>
-      </label>
-    </div>
+  {% include "partials/schedule_detail/form.html" %}
 
-    <p class="surface-feedback">Cron syntax uses six fields: second, minute, hour, day, month, weekday.</p>
+  {% include "partials/schedule_detail/actions.html" %}
 
-    <label class="control-field">
-      <span>Input override</span>
-      <textarea class="schedule-textarea" name="input" rows="6" placeholder="Optional input sent to the team when this schedule fires…">{{ detail.input }}</textarea>
-    </label>
-
-    {% if detail.team_options.len() == 0 %}
-    <p class="surface-feedback">No teams are installed yet. Save a team definition on the Teams page before creating schedules.</p>
-    {% endif %}
-
-    <div class="schedule-action-row">
-      <button class="primary-button" type="submit" {% if detail.team_options.len() == 0 %}disabled{% endif %}>{{ detail.save_label }}</button>
-      <a class="secondary-button" href="/schedules?schedule=__new__">Reset form</a>
-    </div>
-  </form>
-
-  {% if detail.is_new %}
-  {% else %}
-  <div class="schedule-secondary-actions">
-    <form class="inline-form" method="post" action="/schedules">
-      <input type="hidden" name="intent" value="toggle">
-      <input type="hidden" name="original_name" value="{{ detail.original_name }}">
-      <button class="secondary-button" type="submit">{{ detail.toggle_label }}</button>
-    </form>
-
-    <form class="schedule-danger-zone" method="post" action="/schedules">
-      <input type="hidden" name="intent" value="delete">
-      <input type="hidden" name="original_name" value="{{ detail.original_name }}">
-      <label class="schedule-confirm">
-        <input type="checkbox" name="confirm_delete" value="yes">
-        <span>Confirm deletion of <strong>{{ detail.delete_label }}</strong></span>
-      </label>
-      <button class="secondary-button" type="submit">Delete schedule</button>
-    </form>
-  </div>
-  {% endif %}
-
-  <section class="schedule-history">
-    <div class="panel-head">
-      <div>
-        <p class="eyebrow">Execution history</p>
-        <h2>Recent matching runs</h2>
-      </div>
-    </div>
-
-    {% if detail.history.len() == 0 %}
-    <p class="empty-hint">{{ detail.history_hint }}</p>
-    {% else %}
-    <div class="table-wrap">
-      <table aria-label="Recent schedule runs">
-        <thead>
-          <tr>
-            <th>Run</th>
-            <th>Detail</th>
-            <th>Updated</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for item in detail.history %}
-          <tr data-table-row>
-            <td><a href="{{ item.page_url }}">{{ item.title }}</a></td>
-            <td>{{ item.detail }}</td>
-            <td>{{ item.updated_at }}</td>
-            <td><span class="chip tone-{{ item.status_tone }}">{{ item.status_label }}</span></td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    {% endif %}
-  </section>
+  {% include "partials/schedule_detail/history.html" %}
 </section>

--- a/crates/opengoose-web/templates/partials/schedule_detail/actions.html
+++ b/crates/opengoose-web/templates/partials/schedule_detail/actions.html
@@ -1,0 +1,19 @@
+{% if !detail.is_new %}
+<div class="schedule-secondary-actions">
+  <form class="inline-form" method="post" action="/schedules">
+    <input type="hidden" name="intent" value="toggle">
+    <input type="hidden" name="original_name" value="{{ detail.original_name }}">
+    <button class="secondary-button" type="submit">{{ detail.toggle_label }}</button>
+  </form>
+
+  <form class="schedule-danger-zone" method="post" action="/schedules">
+    <input type="hidden" name="intent" value="delete">
+    <input type="hidden" name="original_name" value="{{ detail.original_name }}">
+    <label class="schedule-confirm">
+      <input type="checkbox" name="confirm_delete" value="yes">
+      <span>Confirm deletion of <strong>{{ detail.delete_label }}</strong></span>
+    </label>
+    <button class="secondary-button" type="submit">Delete schedule</button>
+  </form>
+</div>
+{% endif %}

--- a/crates/opengoose-web/templates/partials/schedule_detail/form.html
+++ b/crates/opengoose-web/templates/partials/schedule_detail/form.html
@@ -1,0 +1,45 @@
+<form class="editor-form schedule-form" method="post" action="/schedules">
+  <input type="hidden" name="intent" value="save">
+  <input type="hidden" name="original_name" value="{{ detail.original_name }}">
+  <div class="schedule-form-grid">
+    <label class="control-field">
+      <span>Schedule name</span>
+      <input type="text" name="name" value="{{ detail.name }}" autocomplete="off" spellcheck="false" {% if detail.name_locked %}readonly{% endif %} required>
+    </label>
+    <label class="control-field">
+      <span>Cron expression</span>
+      <input type="text" name="cron_expression" value="{{ detail.cron_expression }}" autocomplete="off" spellcheck="false" placeholder="0 0 * * * *…" required>
+    </label>
+    <label class="control-field">
+      <span>Team</span>
+      <select name="team_name" {% if detail.team_options.len() == 0 %}disabled{% endif %}>
+      {% for option in detail.team_options %}
+        <option value="{{ option.value }}"{% if option.selected %} selected{% endif %}>{{ option.label }}</option>
+      {% endfor %}
+      </select>
+    </label>
+    <label class="control-field control-field-toggle">
+      <span>State</span>
+      <span class="toggle-chip">
+        <input type="checkbox" name="enabled" value="yes" {% if detail.enabled %}checked{% endif %}>
+        <strong>{% if detail.enabled %}Enabled{% else %}Paused{% endif %}</strong>
+      </span>
+    </label>
+  </div>
+
+  <p class="surface-feedback">Cron syntax uses six fields: second, minute, hour, day, month, weekday.</p>
+
+  <label class="control-field">
+    <span>Input override</span>
+    <textarea class="schedule-textarea" name="input" rows="6" placeholder="Optional input sent to the team when this schedule fires…">{{ detail.input }}</textarea>
+  </label>
+
+  {% if detail.team_options.len() == 0 %}
+  <p class="surface-feedback">No teams are installed yet. Save a team definition on the Teams page before creating schedules.</p>
+  {% endif %}
+
+  <div class="schedule-action-row">
+    <button class="primary-button" type="submit" {% if detail.team_options.len() == 0 %}disabled{% endif %}>{{ detail.save_label }}</button>
+    <a class="secondary-button" href="/schedules?schedule=__new__">Reset form</a>
+  </div>
+</form>

--- a/crates/opengoose-web/templates/partials/schedule_detail/header.html
+++ b/crates/opengoose-web/templates/partials/schedule_detail/header.html
@@ -1,0 +1,11 @@
+<div class="detail-head">
+  <div>
+    <p class="eyebrow">Schedule editor</p>
+    <h2>{{ detail.title }}</h2>
+    <p>{{ detail.subtitle }}</p>
+  </div>
+  <div class="schedule-head-actions">
+    <span class="chip {% if detail.enabled %}tone-sage{% else %}tone-neutral{% endif %}">{% if detail.enabled %}Enabled{% else %}Paused{% endif %}</span>
+    <a class="secondary-button" href="/runs">View all runs</a>
+  </div>
+</div>

--- a/crates/opengoose-web/templates/partials/schedule_detail/history.html
+++ b/crates/opengoose-web/templates/partials/schedule_detail/history.html
@@ -1,0 +1,35 @@
+<section class="schedule-history">
+  <div class="panel-head">
+    <div>
+      <p class="eyebrow">Execution history</p>
+      <h2>Recent matching runs</h2>
+    </div>
+  </div>
+
+  {% if detail.history.len() == 0 %}
+  <p class="empty-hint">{{ detail.history_hint }}</p>
+  {% else %}
+  <div class="table-wrap">
+    <table aria-label="Recent schedule runs">
+      <thead>
+        <tr>
+          <th>Run</th>
+          <th>Detail</th>
+          <th>Updated</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for item in detail.history %}
+        <tr data-table-row>
+          <td><a href="{{ item.page_url }}">{{ item.title }}</a></td>
+          <td>{{ item.detail }}</td>
+          <td>{{ item.updated_at }}</td>
+          <td><span class="chip tone-{{ item.status_tone }}">{{ item.status_label }}</span></td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+</section>

--- a/crates/opengoose-web/templates/partials/schedule_list_item.html
+++ b/crates/opengoose-web/templates/partials/schedule_list_item.html
@@ -1,0 +1,17 @@
+<a
+  href="{{ schedule.page_url }}"
+  class="rail-item{% if schedule.active %} is-active{% endif %}"
+  {% if schedule.active %}aria-current="page"{% endif %}
+  data-list-item
+  data-search="{{ schedule.title }} {{ schedule.subtitle }} {{ schedule.preview }} {{ schedule.source_label }}"
+>
+  <div>
+    <p class="rail-title">{{ schedule.title }}</p>
+    <p class="rail-subtitle">{{ schedule.subtitle }}</p>
+  </div>
+  <div class="rail-meta">
+    <span class="chip tone-{{ schedule.status_tone }}">{{ schedule.status_label }}</span>
+    <small>{{ schedule.source_label }}</small>
+  </div>
+  <p class="rail-preview">{{ schedule.preview }}</p>
+</a>

--- a/crates/opengoose-web/templates/schedules.html
+++ b/crates/opengoose-web/templates/schedules.html
@@ -13,23 +13,7 @@
 {% include "components/page_intro_action.html" %}
 {% include "components/list_detail_shell_start.html" %}
     {% for schedule in page.schedules %}
-    <a
-      href="{{ schedule.page_url }}"
-      class="rail-item{% if schedule.active %} is-active{% endif %}"
-      {% if schedule.active %}aria-current="page"{% endif %}
-      data-list-item
-      data-search="{{ schedule.title }} {{ schedule.subtitle }} {{ schedule.preview }} {{ schedule.source_label }}"
-    >
-      <div>
-        <p class="rail-title">{{ schedule.title }}</p>
-        <p class="rail-subtitle">{{ schedule.subtitle }}</p>
-      </div>
-      <div class="rail-meta">
-        <span class="chip tone-{{ schedule.status_tone }}">{{ schedule.status_label }}</span>
-        <small>{{ schedule.source_label }}</small>
-      </div>
-      <p class="rail-preview">{{ schedule.preview }}</p>
-    </a>
+    {% include "partials/schedule_list_item.html" %}
     {% endfor %}
 {% include "components/list_detail_shell_end.html" %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- split the schedule detail editor into focused Askama partials for the header, form, secondary actions, and history table
- extracted the schedule rail row from `schedules.html` into its own partial so the page template only owns list-shell structure
- added render coverage for the new schedule empty-state branch and preserved list item assertions

## Verification
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test

## Issue
- OPE-309
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
