### PR TITLE
refactor: split workflows page data surface [OPE-354]

### DIFF
--- a/crates/opengoose-web/src/data/workflows/catalog.rs
+++ b/crates/opengoose-web/src/data/workflows/catalog.rs
@@ -50,3 +50,124 @@ pub(super) fn build_workflow_catalog(
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use opengoose_persistence::RunStatus;
+    use opengoose_teams::{OrchestrationPattern, TeamAgent, TeamDefinition};
+
+    use super::*;
+
+    fn team_entry(name: &str) -> TeamCatalogEntry {
+        TeamCatalogEntry {
+            name: name.into(),
+            team: TeamDefinition {
+                version: "1.0.0".into(),
+                title: name.into(),
+                description: None,
+                workflow: OrchestrationPattern::Chain,
+                agents: vec![TeamAgent {
+                    profile: format!("{name}-agent"),
+                    role: None,
+                }],
+                router: None,
+                fan_out: None,
+                goal: None,
+            },
+            source_label: "Bundled default".into(),
+            is_live: false,
+        }
+    }
+
+    fn schedule(name: &str, team_name: &str) -> Schedule {
+        Schedule {
+            id: 1,
+            name: name.into(),
+            cron_expression: "0 0 * * *".into(),
+            team_name: team_name.into(),
+            input: String::new(),
+            enabled: true,
+            last_run_at: None,
+            next_run_at: None,
+            created_at: "2026-03-12 00:00:00".into(),
+            updated_at: "2026-03-12 00:00:00".into(),
+        }
+    }
+
+    fn trigger(name: &str, team_name: &str) -> Trigger {
+        Trigger {
+            id: 1,
+            name: name.into(),
+            trigger_type: "webhook_received".into(),
+            condition_json: "{}".into(),
+            team_name: team_name.into(),
+            input: String::new(),
+            enabled: true,
+            last_fired_at: None,
+            fire_count: 0,
+            created_at: "2026-03-12 00:00:00".into(),
+            updated_at: "2026-03-12 00:00:00".into(),
+        }
+    }
+
+    fn run(team_run_id: &str, team_name: &str) -> OrchestrationRun {
+        OrchestrationRun {
+            team_run_id: team_run_id.into(),
+            session_key: format!("session-{team_run_id}"),
+            team_name: team_name.into(),
+            workflow: "chain".into(),
+            input: String::new(),
+            status: RunStatus::Running,
+            current_step: 1,
+            total_steps: 2,
+            result: None,
+            created_at: "2026-03-12 00:00:00".into(),
+            updated_at: "2026-03-12 00:00:00".into(),
+        }
+    }
+
+    #[test]
+    fn build_workflow_catalog_groups_records_and_caps_recent_runs() {
+        let catalog = build_workflow_catalog(
+            &[team_entry("alpha"), team_entry("beta")],
+            &[
+                schedule("nightly-alpha", "alpha"),
+                schedule("nightly-beta", "beta"),
+            ],
+            &[
+                trigger("alpha-webhook", "alpha"),
+                trigger("beta-webhook", "beta"),
+            ],
+            &[
+                run("alpha-1", "alpha"),
+                run("alpha-2", "alpha"),
+                run("alpha-3", "alpha"),
+                run("alpha-4", "alpha"),
+                run("alpha-5", "alpha"),
+                run("alpha-6", "alpha"),
+                run("alpha-7", "alpha"),
+                run("beta-1", "beta"),
+            ],
+        );
+
+        let alpha = catalog
+            .iter()
+            .find(|entry| entry.name == "alpha")
+            .expect("alpha workflow should exist");
+        let beta = catalog
+            .iter()
+            .find(|entry| entry.name == "beta")
+            .expect("beta workflow should exist");
+
+        assert_eq!(alpha.schedules.len(), 1);
+        assert_eq!(alpha.triggers.len(), 1);
+        assert_eq!(alpha.recent_runs.len(), 6);
+        assert_eq!(alpha.recent_runs[0].team_run_id, "alpha-1");
+        assert_eq!(alpha.recent_runs[5].team_run_id, "alpha-6");
+
+        assert_eq!(beta.schedules.len(), 1);
+        assert_eq!(beta.triggers.len(), 1);
+        assert_eq!(beta.recent_runs.len(), 1);
+        assert_eq!(beta.recent_runs[0].team_run_id, "beta-1");
+    }
+}

--- a/crates/opengoose-web/src/data/workflows/view_model.rs
+++ b/crates/opengoose-web/src/data/workflows/view_model.rs
@@ -271,4 +271,15 @@ mod tests {
                 .any(|item| item.title == "beta" && item.active)
         );
     }
+
+    #[test]
+    fn build_workflows_page_falls_back_to_first_workflow_when_selection_is_unknown() {
+        let catalog = vec![workflow_entry("alpha"), workflow_entry("beta")];
+        let page = build_workflows_page(&catalog, true, Some("missing".into())).unwrap();
+
+        assert_eq!(page.mode_label, "Bundled defaults");
+        assert_eq!(page.selected.title, "alpha");
+        assert!(page.workflows[0].active);
+        assert!(!page.workflows[1].active);
+    }
 }


### PR DESCRIPTION
## Summary
- split `crates/opengoose-web/src/data/workflows.rs` into focused `catalog`, `loader`, `summary`, and `view_model` helpers
- preserve bundled-preview fallback, deep-link workflow selection, and list/detail assembly for schedules, triggers, and recent runs
- add seam-level regression coverage for catalog grouping/run capping and selection fallback

## Verification
- cargo fmt --all
- cargo clippy --all-targets
- cargo test

## Paperclip
- [OPE-354](http://localhost:3131/OPE/issues/OPE-354)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
