### PR TITLE
ci: add concurrency control and broaden change detection

### DIFF
--- a/.github/workflows/ci-quality-gate.yml
+++ b/.github/workflows/ci-quality-gate.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-quality-gate-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -36,11 +41,11 @@ jobs:
 
           CHANGED=$(git diff --name-only "$BASE" HEAD -- \
             'crates/' \
-            'scripts/web-smoke.sh' \
-            'scripts/web-smoke-agent-browser.sh' \
+            '.github/workflows/*.yml' \
+            '.github/workflows/*.yaml' \
+            'scripts/web-smoke*.sh' \
             'Cargo.toml' \
-            'Cargo.lock' \
-            '.github/workflows/ci-quality-gate.yml')
+            'Cargo.lock')
 
           if [[ -n "$CHANGED" ]]; then
             echo "rust=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger for manual CI runs
- Add concurrency group to cancel superseded CI runs on the same ref
- Broaden workflow file change detection to catch all `.yml`/`.yaml` changes
- Simplify web-smoke script glob pattern

## Test plan

- [x] CI workflow syntax valid
- [x] Concurrency group scoped per-ref to avoid cross-branch cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
