### PR TITLE
fix(tui): use sort_by_key+Reverse for descending score sort

### DIFF
--- a/crates/opengoose-tui/src/command.rs
+++ b/crates/opengoose-tui/src/command.rs
@@ -264,12 +264,13 @@ mod tests {
         let mut app = test_app();
         execute(&mut app, CommandId::ListSessions);
         assert_eq!(app.events.len(), 1);
-        assert!(app
-            .events
-            .back()
-            .unwrap()
-            .summary
-            .contains("No sessions available yet"));
+        assert!(
+            app.events
+                .back()
+                .unwrap()
+                .summary
+                .contains("No sessions available yet")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `scored.sort_by(|a, b| b.score.cmp(&a.score))` triggers Clippy's `clippy::unnecessary-sort-by` lint under `-D warnings`, aborting the nightly CI job entirely.
- Replace with the idiomatic `scored.sort_by_key(|cmd| std::cmp::Reverse(cmd.score))`.

## Root Cause

Clippy (nightly) requires `sort_by_key` + `Reverse` for reverse-order sorts. The old form is valid Rust but not accepted under strict lint settings.

## Testing

- Existing tests in `command.rs` cover `filter_commands` behaviour and pass unchanged.
- Nightly Clippy should now pass for `opengoose-tui`.

Closes #164
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
