### PR TITLE
fix(ci): correct glossary-maintainer paths to match actual repo structure

### DIFF
--- a/.github/workflows/glossary-maintainer.md
+++ b/.github/workflows/glossary-maintainer.md
@@ -45,7 +45,7 @@ tools:
 ---
 # Glossary Maintainer
 
-You are an AI documentation agent that maintains the project glossary at `docs/src/content/docs/reference/glossary.md`.
+You are an AI documentation agent that maintains the project glossary at `docs/glossary.md`.
 
 ## Your Mission
 
@@ -117,10 +117,10 @@ Based on the scope (daily or weekly):
 
 ### 4. Review Current Glossary
 
-Read the current glossary:
+Read the current glossary (create it if it does not exist yet):
 
 ```bash
-cat docs/src/content/docs/reference/glossary.md
+cat docs/glossary.md 2>/dev/null || echo "Glossary does not exist yet - will create it"
 ```
 
 **Check for:**
@@ -131,10 +131,10 @@ cat docs/src/content/docs/reference/glossary.md
 
 ### 5. Follow Documentation Guidelines
 
-**IMPORTANT**: Read the documentation instructions before making changes:
+**IMPORTANT**: Read the documentation instructions if they exist:
 
 ```bash
-cat .github/instructions/documentation.instructions.md
+cat .github/instructions/documentation.instructions.md 2>/dev/null || echo "No documentation instructions file found - use good technical writing practices"
 ```
 
 The glossary is a **Reference** document (information-oriented) and must:


### PR DESCRIPTION
## Root Cause

Glossary Maintainer has failed on **4/4 scheduled runs** (#48). The agent starts, makes 1 LLM call, then exits silently without calling any safe-output tool (not even \`noop\`).

Investigation of the workflow prompt shows two hard \`cat\` calls to non-existent files:

| Expected path (in prompt) | Actual state |
|---|---|
| \`docs/src/content/docs/reference/glossary.md\` | ❌ Does not exist |
| \`.github/instructions/documentation.instructions.md\` | ❌ Does not exist |

When the agent tries to read these files in Steps 4 and 5, they fail. The agent has no fallback path and exits without calling \`noop\`, which the framework treats as a workflow failure.

## Fix

1. **Correct the glossary path** → \`docs/glossary.md\` (matching actual repo structure)
2. **Add \`2>/dev/null\` fallbacks** to both \`cat\` commands with informative fallback messages
3. **Recompile** workflow with \`gh aw compile\`

## Expected Outcome

The agent will now proceed past Steps 4 and 5 even if the glossary doesn't exist yet. On the first run it will create \`docs/glossary.md\`. Subsequent runs will update it incrementally.

Closes #48
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
