### PR TITLE
fix(ci): stagger schedules and fix missing doc paths for ci-coach/cli-checker

### DIFF
--- a/.github/workflows/ci-coach.lock.yml
+++ b/.github/workflows/ci-coach.lock.yml
@@ -30,7 +30,7 @@
 #     - shared/ci-data-analysis.md
 #     - shared/reporting.md
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"0acf7472cba3f08588872950184d4a280964c8955a48d022a4ca7257022efbd5","compiler_version":"v0.53.4"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"85c5c8466532be2bb39ed525e49da39e767738e9e525cfba1a5889c7b13203e4","compiler_version":"v0.53.4"}
 
 name: "CI Optimization Coach"
 "on":

--- a/.github/workflows/ci-coach.md
+++ b/.github/workflows/ci-coach.md
@@ -2,7 +2,7 @@
 description: Daily CI optimization coach that analyzes workflow runs for efficiency improvements and cost reduction opportunities
 on:
   schedule:
-    - cron: "0 13 * * 1-5"  # 1 PM UTC on weekdays
+    - cron: "0 13 * * 1-5"  # 1:00 PM UTC on weekdays
   workflow_dispatch:
 permissions:
   contents: read

--- a/.github/workflows/cli-consistency-checker.lock.yml
+++ b/.github/workflows/cli-consistency-checker.lock.yml
@@ -25,12 +25,12 @@
 #
 # Source: github/gh-aw/.github/workflows/cli-consistency-checker.md@b28e62023cd0a102f6d701e4272f9acedb04f3e1
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"58c7162b8924f0afb0de6bf3c4c12102261e15b1a09b6e02f8dac110ce749256","compiler_version":"v0.53.4"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"9c2e2a435ebd9dddbcffff015247c329c3489ad39bae52c207f0e44c9a7109b3","compiler_version":"v0.53.4"}
 
 name: "CLI Consistency Checker"
 "on":
   schedule:
-  - cron: "0 13 * * 1-5"
+  - cron: "15 13 * * 1-5"
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/cli-consistency-checker.md
+++ b/.github/workflows/cli-consistency-checker.md
@@ -2,7 +2,7 @@
 description: Inspects the opengoose-cli to identify inconsistencies, typos, bugs, or documentation gaps by running commands and analyzing output
 on:
   schedule:
-    - cron: "0 13 * * 1-5"  # Daily at 1 PM UTC, weekdays only (Mon-Fri)
+    - cron: "15 13 * * 1-5"  # 1:15 PM UTC on weekdays (staggered from ci-coach at 1:00 PM)
   workflow_dispatch:
 permissions:
   contents: read
@@ -131,8 +131,8 @@ After running all commands, look for these types of problems:
 - Do command descriptions match their actual behavior?
 
 ### Documentation Cross-Reference
-- Fetch documentation from `${{ github.workspace }}/docs/src/content/docs/setup/cli.md`
-- Compare CLI help output with documented commands
+- Check if a CLI docs file exists: `ls docs/cli.md docs/web-dashboard.md README.md 2>/dev/null`
+- If documentation exists, compare CLI help output with documented commands
 - Check if all documented commands exist and vice versa
 - Verify examples in documentation match CLI behavior
 


### PR DESCRIPTION
## Problem

Both workflows were failing with `startup_failure` on **every scheduled run** (issue #155):

| Workflow | Failures |
|---|---|
| CI Optimization Coach | 3/3 scheduled runs |
| CLI Consistency Checker | 3/4 scheduled runs |

Both were scheduled at **identical times** (`0 13 * * 1-5`), creating platform-level startup contention. Manual `workflow_dispatch` worked (or worked initially), which is consistent with schedule-time runner allocation pressure.

Additionally, `cli-consistency-checker` referenced `docs/src/content/docs/setup/cli.md` which does not exist in this repo, matching the same silent-exit pattern seen in issue #48.

## Changes

### Schedule stagger
- `ci-coach`: unchanged at `0 13 * * 1-5` (1:00 PM UTC)
- `cli-consistency-checker`: shifted to `15 13 * * 1-5` (1:15 PM UTC)

### Path fix (cli-consistency-checker)
- Removed hard reference to non-existent `docs/src/content/docs/setup/cli.md`
- Replaced with resilient `ls` check against actual existing doc files

### Recompile
Both `.lock.yml` files recompiled with `gh aw compile`.

## Expected Outcome

- No more `startup_failure` from schedule collision
- CLI Consistency Checker agent proceeds past the documentation cross-reference step

Closes #155
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
