### PR TITLE
refactor: Split schedule editor helpers [OPE-382]

### DIFF
--- a/crates/opengoose-web/src/data/schedules/editor/form.rs
+++ b/crates/opengoose-web/src/data/schedules/editor/form.rs
@@ -1,143 +1,22 @@
-use anyhow::{Context, Result};
 use opengoose_persistence::{OrchestrationRun, Schedule};
 use opengoose_teams::scheduler;
 use urlencoding::encode;
 
-use super::catalog::ScheduleCatalog;
-use super::selection::{NEW_SCHEDULE_KEY, Selection};
+use super::super::catalog::ScheduleCatalog;
+use super::options::build_team_options;
 use crate::data::utils::{preview, run_tone};
-use crate::data::views::{
-    MetaRow, Notice, ScheduleEditorView, ScheduleHistoryItem, ScheduleListItem, SchedulesPageView,
-    SelectOption,
-};
+use crate::data::views::{MetaRow, Notice, ScheduleEditorView, ScheduleHistoryItem};
 
-pub(super) struct ScheduleDraft {
-    pub(super) original_name: Option<String>,
-    pub(super) name: String,
-    pub(super) cron_expression: String,
-    pub(super) team_name: String,
-    pub(super) input: String,
-    pub(super) enabled: bool,
+pub(in crate::data::schedules) struct ScheduleDraft {
+    pub(in crate::data::schedules) original_name: Option<String>,
+    pub(in crate::data::schedules) name: String,
+    pub(in crate::data::schedules) cron_expression: String,
+    pub(in crate::data::schedules) team_name: String,
+    pub(in crate::data::schedules) input: String,
+    pub(in crate::data::schedules) enabled: bool,
 }
 
-pub(super) fn build_page(
-    catalog: &ScheduleCatalog,
-    selection: Selection,
-    detail_override: Option<ScheduleEditorView>,
-) -> Result<SchedulesPageView> {
-    let total = catalog.schedules.len();
-    let enabled = catalog
-        .schedules
-        .iter()
-        .filter(|schedule| schedule.enabled)
-        .count();
-    let active_name = match &selection {
-        Selection::Existing(name) => Some(name.as_str()),
-        Selection::New => None,
-    };
-
-    Ok(SchedulesPageView {
-        mode_label: if total == 0 {
-            "Ready for first schedule".into()
-        } else {
-            format!("{enabled} active of {total}")
-        },
-        mode_tone: if total == 0 {
-            "neutral"
-        } else if enabled > 0 {
-            "success"
-        } else {
-            "amber"
-        },
-        schedules: catalog
-            .schedules
-            .iter()
-            .map(|schedule| build_schedule_list_item(schedule, active_name))
-            .collect(),
-        selected: if let Some(detail) = detail_override {
-            detail
-        } else {
-            match selection {
-                Selection::Existing(name) => build_existing_detail(
-                    catalog
-                        .schedules
-                        .iter()
-                        .find(|schedule| schedule.name == name)
-                        .context("selected schedule missing")?,
-                    catalog,
-                    None,
-                ),
-                Selection::New => build_new_detail(catalog, None, None),
-            }
-        },
-        new_schedule_url: format!("/schedules?schedule={NEW_SCHEDULE_KEY}"),
-    })
-}
-
-pub(super) fn build_error_page(
-    catalog: &ScheduleCatalog,
-    draft: &ScheduleDraft,
-    message: impl Into<String>,
-) -> Result<SchedulesPageView> {
-    let selection = draft
-        .original_name
-        .as_ref()
-        .map(|name| Selection::Existing(name.clone()))
-        .unwrap_or(Selection::New);
-    let detail = build_draft_detail(
-        catalog,
-        draft,
-        Some(Notice {
-            text: message.into(),
-            tone: "danger",
-        }),
-    );
-    build_page(catalog, selection, Some(detail))
-}
-
-fn build_schedule_list_item(schedule: &Schedule, active_name: Option<&str>) -> ScheduleListItem {
-    let next_label = schedule
-        .next_run_at
-        .as_deref()
-        .map(|value| format!("Next {value}"))
-        .unwrap_or_else(|| {
-            if schedule.enabled {
-                "Next fire pending".into()
-            } else {
-                "Paused".into()
-            }
-        });
-    ScheduleListItem {
-        title: schedule.name.clone(),
-        subtitle: format!(
-            "{} · {}",
-            schedule.team_name,
-            if schedule.input.is_empty() {
-                "default input"
-            } else {
-                "custom input"
-            }
-        ),
-        preview: format!("{} · {}", schedule.cron_expression, next_label),
-        source_label: schedule
-            .last_run_at
-            .as_deref()
-            .map(|value| format!("Last {value}"))
-            .unwrap_or_else(|| "Never run".into()),
-        status_label: if schedule.enabled {
-            "Enabled".into()
-        } else {
-            "Paused".into()
-        },
-        status_tone: if schedule.enabled { "sage" } else { "neutral" },
-        page_url: format!("/schedules?schedule={}", encode(&schedule.name)),
-        active: active_name
-            .map(|name| name == schedule.name.as_str())
-            .unwrap_or(false),
-    }
-}
-
-fn build_existing_detail(
+pub(super) fn build_existing_detail(
     schedule: &Schedule,
     catalog: &ScheduleCatalog,
     notice: Option<Notice>,
@@ -206,7 +85,7 @@ fn build_existing_detail(
     }
 }
 
-fn build_new_detail(
+pub(super) fn build_new_detail(
     catalog: &ScheduleCatalog,
     draft: Option<&ScheduleDraft>,
     notice: Option<Notice>,
@@ -260,7 +139,7 @@ fn build_new_detail(
     }
 }
 
-fn build_draft_detail(
+pub(super) fn build_draft_detail(
     catalog: &ScheduleCatalog,
     draft: &ScheduleDraft,
     notice: Option<Notice>,
@@ -332,31 +211,6 @@ fn build_draft_detail(
     build_new_detail(catalog, Some(draft), notice)
 }
 
-fn build_team_options(
-    installed_teams: &[String],
-    selected_team: Option<&str>,
-) -> Vec<SelectOption> {
-    let mut names = installed_teams.to_vec();
-    if let Some(selected_team) = selected_team
-        && !selected_team.is_empty()
-        && !names.iter().any(|team| team == selected_team)
-    {
-        names.push(selected_team.to_string());
-        names.sort();
-    }
-
-    names
-        .into_iter()
-        .map(|team| SelectOption {
-            selected: selected_team
-                .map(|selected| selected == team.as_str())
-                .unwrap_or(false),
-            label: team.clone(),
-            value: team,
-        })
-        .collect()
-}
-
 fn build_history(schedule: &Schedule, runs: &[OrchestrationRun]) -> Vec<ScheduleHistoryItem> {
     let expected_input = effective_schedule_input(schedule);
     runs.iter()
@@ -381,36 +235,86 @@ fn effective_schedule_input(schedule: &Schedule) -> String {
     }
 }
 
-pub(super) fn normalize_input(input: String, max_bytes: usize) -> String {
-    if input.trim().is_empty() {
-        String::new()
-    } else {
-        truncate_to_byte_boundary(&input, max_bytes)
+#[cfg(test)]
+mod tests {
+    use opengoose_persistence::RunStatus;
+
+    use super::super::super::catalog::ScheduleCatalog;
+    use super::*;
+
+    #[test]
+    fn build_history_uses_effective_schedule_input_and_limits_matches() {
+        let schedule = sample_schedule();
+        let mut runs = (0..10)
+            .map(|index| sample_run(&format!("run-{index}"), "ops", "Scheduled run: nightly-ops"))
+            .collect::<Vec<_>>();
+        runs.push(sample_run(
+            "wrong-team",
+            "infra",
+            "Scheduled run: nightly-ops",
+        ));
+        runs.push(sample_run("wrong-input", "ops", "different input"));
+
+        let history = build_history(&schedule, &runs);
+
+        assert_eq!(history.len(), 8);
+        assert_eq!(history[0].title, "run-0");
+        assert_eq!(history[7].title, "run-7");
     }
-}
 
-pub(super) fn normalize_trimmed_field(value: &str, max_bytes: usize) -> String {
-    truncate_to_byte_boundary(value.trim(), max_bytes)
-}
+    #[test]
+    fn build_draft_detail_falls_back_to_new_detail_for_missing_original_schedule() {
+        let catalog = ScheduleCatalog {
+            schedules: vec![],
+            runs: vec![],
+            installed_teams: vec!["ops".into()],
+        };
+        let detail = build_draft_detail(
+            &catalog,
+            &ScheduleDraft {
+                original_name: Some("missing".into()),
+                name: "missing".into(),
+                cron_expression: "0 0 * * * *".into(),
+                team_name: "ops".into(),
+                input: String::new(),
+                enabled: true,
+            },
+            None,
+        );
 
-pub(super) fn normalize_optional_field(value: Option<&str>, max_bytes: usize) -> Option<String> {
-    value
-        .map(|item| normalize_trimmed_field(item, max_bytes))
-        .filter(|item| !item.is_empty())
-}
-
-pub(super) fn trimmed_len_exceeds(value: &str, max_bytes: usize) -> bool {
-    value.trim().len() > max_bytes
-}
-
-fn truncate_to_byte_boundary(value: &str, max_bytes: usize) -> String {
-    if value.len() <= max_bytes {
-        return value.to_owned();
+        assert!(detail.is_new);
+        assert_eq!(detail.title, "Create schedule");
+        assert_eq!(detail.team_name, "ops");
     }
 
-    let mut end = max_bytes;
-    while end > 0 && !value.is_char_boundary(end) {
-        end -= 1;
+    fn sample_schedule() -> Schedule {
+        Schedule {
+            id: 1,
+            name: "nightly-ops".into(),
+            cron_expression: "0 0 * * * *".into(),
+            team_name: "ops".into(),
+            input: String::new(),
+            enabled: true,
+            last_run_at: None,
+            next_run_at: Some("2026-03-12 00:00:00".into()),
+            created_at: "2026-03-11 00:00:00".into(),
+            updated_at: "2026-03-11 00:00:00".into(),
+        }
     }
-    value[..end].to_owned()
+
+    fn sample_run(id: &str, team_name: &str, input: &str) -> OrchestrationRun {
+        OrchestrationRun {
+            team_run_id: id.into(),
+            session_key: format!("session-{id}"),
+            team_name: team_name.into(),
+            workflow: "chain".into(),
+            input: input.into(),
+            status: RunStatus::Completed,
+            current_step: 1,
+            total_steps: 1,
+            result: None,
+            created_at: "2026-03-11 00:00:00".into(),
+            updated_at: "2026-03-11 00:00:00".into(),
+        }
+    }
 }

--- a/crates/opengoose-web/src/data/schedules/editor/mod.rs
+++ b/crates/opengoose-web/src/data/schedules/editor/mod.rs
@@ -1,0 +1,10 @@
+mod form;
+mod mutations;
+mod options;
+mod page;
+
+pub(super) use self::form::ScheduleDraft;
+pub(super) use self::mutations::{
+    normalize_input, normalize_optional_field, normalize_trimmed_field, trimmed_len_exceeds,
+};
+pub(super) use self::page::{build_error_page, build_page};

--- a/crates/opengoose-web/src/data/schedules/editor/mutations.rs
+++ b/crates/opengoose-web/src/data/schedules/editor/mutations.rs
@@ -1,0 +1,36 @@
+pub(in crate::data::schedules) fn normalize_input(input: String, max_bytes: usize) -> String {
+    if input.trim().is_empty() {
+        String::new()
+    } else {
+        truncate_to_byte_boundary(&input, max_bytes)
+    }
+}
+
+pub(in crate::data::schedules) fn normalize_trimmed_field(value: &str, max_bytes: usize) -> String {
+    truncate_to_byte_boundary(value.trim(), max_bytes)
+}
+
+pub(in crate::data::schedules) fn normalize_optional_field(
+    value: Option<&str>,
+    max_bytes: usize,
+) -> Option<String> {
+    value
+        .map(|item| normalize_trimmed_field(item, max_bytes))
+        .filter(|item| !item.is_empty())
+}
+
+pub(in crate::data::schedules) fn trimmed_len_exceeds(value: &str, max_bytes: usize) -> bool {
+    value.trim().len() > max_bytes
+}
+
+fn truncate_to_byte_boundary(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_owned();
+    }
+
+    let mut end = max_bytes;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_owned()
+}

--- a/crates/opengoose-web/src/data/schedules/editor/options.rs
+++ b/crates/opengoose-web/src/data/schedules/editor/options.rs
@@ -1,0 +1,51 @@
+use crate::data::views::SelectOption;
+
+pub(super) fn build_team_options(
+    installed_teams: &[String],
+    selected_team: Option<&str>,
+) -> Vec<SelectOption> {
+    let mut names = installed_teams.to_vec();
+    if let Some(selected_team) = selected_team
+        && !selected_team.is_empty()
+        && !names.iter().any(|team| team == selected_team)
+    {
+        names.push(selected_team.to_string());
+        names.sort();
+    }
+
+    names
+        .into_iter()
+        .map(|team| SelectOption {
+            selected: selected_team
+                .map(|selected| selected == team.as_str())
+                .unwrap_or(false),
+            label: team.clone(),
+            value: team,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_team_options;
+
+    #[test]
+    fn build_team_options_adds_missing_selection_in_sorted_order() {
+        let options = build_team_options(&["alpha".into(), "zeta".into()], Some("beta"));
+
+        assert_eq!(
+            options
+                .iter()
+                .map(|option| option.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "beta", "zeta"]
+        );
+        assert_eq!(
+            options
+                .iter()
+                .find(|option| option.value == "beta")
+                .map(|option| option.selected),
+            Some(true)
+        );
+    }
+}

--- a/crates/opengoose-web/src/data/schedules/editor/page.rs
+++ b/crates/opengoose-web/src/data/schedules/editor/page.rs
@@ -1,0 +1,127 @@
+use anyhow::{Context, Result};
+use urlencoding::encode;
+
+use super::super::catalog::ScheduleCatalog;
+use super::super::selection::{NEW_SCHEDULE_KEY, Selection};
+use super::form::{ScheduleDraft, build_draft_detail, build_existing_detail, build_new_detail};
+use crate::data::views::{Notice, ScheduleEditorView, ScheduleListItem, SchedulesPageView};
+
+pub(in crate::data::schedules) fn build_page(
+    catalog: &ScheduleCatalog,
+    selection: Selection,
+    detail_override: Option<ScheduleEditorView>,
+) -> Result<SchedulesPageView> {
+    let total = catalog.schedules.len();
+    let enabled = catalog
+        .schedules
+        .iter()
+        .filter(|schedule| schedule.enabled)
+        .count();
+    let active_name = match &selection {
+        Selection::Existing(name) => Some(name.as_str()),
+        Selection::New => None,
+    };
+
+    Ok(SchedulesPageView {
+        mode_label: if total == 0 {
+            "Ready for first schedule".into()
+        } else {
+            format!("{enabled} active of {total}")
+        },
+        mode_tone: if total == 0 {
+            "neutral"
+        } else if enabled > 0 {
+            "success"
+        } else {
+            "amber"
+        },
+        schedules: catalog
+            .schedules
+            .iter()
+            .map(|schedule| build_schedule_list_item(schedule, active_name))
+            .collect(),
+        selected: if let Some(detail) = detail_override {
+            detail
+        } else {
+            match selection {
+                Selection::Existing(name) => build_existing_detail(
+                    catalog
+                        .schedules
+                        .iter()
+                        .find(|schedule| schedule.name == name)
+                        .context("selected schedule missing")?,
+                    catalog,
+                    None,
+                ),
+                Selection::New => build_new_detail(catalog, None, None),
+            }
+        },
+        new_schedule_url: format!("/schedules?schedule={NEW_SCHEDULE_KEY}"),
+    })
+}
+
+pub(in crate::data::schedules) fn build_error_page(
+    catalog: &ScheduleCatalog,
+    draft: &ScheduleDraft,
+    message: impl Into<String>,
+) -> Result<SchedulesPageView> {
+    let selection = draft
+        .original_name
+        .as_ref()
+        .map(|name| Selection::Existing(name.clone()))
+        .unwrap_or(Selection::New);
+    let detail = build_draft_detail(
+        catalog,
+        draft,
+        Some(Notice {
+            text: message.into(),
+            tone: "danger",
+        }),
+    );
+    build_page(catalog, selection, Some(detail))
+}
+
+fn build_schedule_list_item(
+    schedule: &opengoose_persistence::Schedule,
+    active_name: Option<&str>,
+) -> ScheduleListItem {
+    let next_label = schedule
+        .next_run_at
+        .as_deref()
+        .map(|value| format!("Next {value}"))
+        .unwrap_or_else(|| {
+            if schedule.enabled {
+                "Next fire pending".into()
+            } else {
+                "Paused".into()
+            }
+        });
+    ScheduleListItem {
+        title: schedule.name.clone(),
+        subtitle: format!(
+            "{} · {}",
+            schedule.team_name,
+            if schedule.input.is_empty() {
+                "default input"
+            } else {
+                "custom input"
+            }
+        ),
+        preview: format!("{} · {}", schedule.cron_expression, next_label),
+        source_label: schedule
+            .last_run_at
+            .as_deref()
+            .map(|value| format!("Last {value}"))
+            .unwrap_or_else(|| "Never run".into()),
+        status_label: if schedule.enabled {
+            "Enabled".into()
+        } else {
+            "Paused".into()
+        },
+        status_tone: if schedule.enabled { "sage" } else { "neutral" },
+        page_url: format!("/schedules?schedule={}", encode(&schedule.name)),
+        active: active_name
+            .map(|name| name == schedule.name.as_str())
+            .unwrap_or(false),
+    }
+}


### PR DESCRIPTION
## Summary
- split the schedule editor data surface into focused `page`, `form`, `options`, and `mutations` helpers
- keep the public `data::schedules` API unchanged while isolating detail/history/select-option shaping behind the new module boundary
- add focused unit coverage for history filtering/limits and selected-team option assembly

## Verification
- cargo build
- cargo fmt --all
- cargo clippy --all-targets -- -D warnings
- cargo test

## Paperclip
- http://localhost:3131/OPE/issues/OPE-382
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
