### PR TITLE
refactor: split Matrix gateway helpers [OPE-393]

### DIFF
--- a/crates/opengoose-matrix/src/gateway/api.rs
+++ b/crates/opengoose-matrix/src/gateway/api.rs
@@ -1,0 +1,110 @@
+use std::sync::atomic::Ordering;
+
+use crate::types::{MatrixError, SendEventResponse, SyncFilter, SyncResponse, WhoAmI};
+
+use super::{MatrixGateway, SYNC_TIMEOUT_MS, urlencoding};
+
+impl MatrixGateway {
+    pub(super) fn v3_url(&self, path: &str) -> String {
+        format!("{}/_matrix/client/v3{}", self.homeserver_url, path)
+    }
+
+    pub(super) fn next_txn_id(&self) -> String {
+        let n = self.txn_counter.fetch_add(1, Ordering::Relaxed);
+        format!("opengoose-{}-{}", std::process::id(), n)
+    }
+
+    pub(super) fn auth_header(&self) -> String {
+        format!("Bearer {}", self.access_token)
+    }
+
+    /// GET /account/whoami — returns the bot's Matrix user ID.
+    pub(super) async fn whoami(&self) -> anyhow::Result<String> {
+        let resp: WhoAmI = self
+            .client
+            .get(self.v3_url("/account/whoami"))
+            .header("Authorization", self.auth_header())
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(resp.user_id)
+    }
+
+    /// Register a minimal sync filter and return the filter ID.
+    pub(super) async fn register_filter(&self, user_id: &str) -> anyhow::Result<String> {
+        let encoded_user = urlencoding::encode(user_id).into_owned();
+        let filter = SyncFilter::messages_only();
+        let resp: serde_json::Value = self
+            .client
+            .post(self.v3_url(&format!("/user/{encoded_user}/filter")))
+            .header("Authorization", self.auth_header())
+            .json(&filter)
+            .send()
+            .await?
+            .json()
+            .await?;
+        resp.get("filter_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow::anyhow!("no filter_id in response"))
+    }
+
+    /// GET /sync — long-poll for new events.
+    pub(super) async fn sync(
+        &self,
+        since: Option<&str>,
+        filter_id: Option<&str>,
+    ) -> anyhow::Result<SyncResponse> {
+        let mut req = self
+            .client
+            .get(self.v3_url("/sync"))
+            .header("Authorization", self.auth_header())
+            .query(&[("timeout", SYNC_TIMEOUT_MS.to_string())]);
+
+        if let Some(s) = since {
+            req = req.query(&[("since", s)]);
+        }
+        if let Some(f) = filter_id {
+            req = req.query(&[("filter", f)]);
+        }
+
+        Ok(req.send().await?.json().await?)
+    }
+
+    /// PUT /rooms/{roomId}/send/{eventType}/{txnId} — send a message event.
+    pub(super) async fn send_event(
+        &self,
+        room_id: &str,
+        content: &serde_json::Value,
+    ) -> anyhow::Result<String> {
+        let encoded_room = urlencoding::encode(room_id).into_owned();
+        let txn_id = self.next_txn_id();
+        let url = self.v3_url(&format!(
+            "/rooms/{encoded_room}/send/m.room.message/{txn_id}"
+        ));
+
+        let resp = self
+            .client
+            .put(&url)
+            .header("Authorization", self.auth_header())
+            .json(content)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let err: MatrixError = resp.json().await.unwrap_or(MatrixError {
+                errcode: None,
+                error: Some("unknown error".into()),
+            });
+            anyhow::bail!(
+                "send_event failed: {} — {}",
+                err.errcode.unwrap_or_default(),
+                err.error.unwrap_or_default()
+            );
+        }
+
+        let ev: SendEventResponse = resp.json().await?;
+        Ok(ev.event_id)
+    }
+}

--- a/crates/opengoose-matrix/src/gateway/incoming.rs
+++ b/crates/opengoose-matrix/src/gateway/incoming.rs
@@ -1,0 +1,226 @@
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use opengoose_core::{StreamResponder, ThrottlePolicy};
+use opengoose_types::{AppEventKind, Platform, SessionKey};
+
+use crate::types::{RoomEvent, SyncResponse};
+
+use super::{MATRIX_MAX_LEN, MAX_RECONNECT_ATTEMPTS, MatrixGateway};
+
+struct IncomingTextEvent<'a> {
+    room_id: &'a str,
+    sender: &'a str,
+    body: &'a str,
+}
+
+impl MatrixGateway {
+    /// Build the SessionKey for a Matrix room.
+    ///
+    /// Namespace = server name extracted from the bot's user_id (e.g. `example.com`).
+    /// Channel ID = room_id (e.g. `!room:example.com`).
+    pub(super) fn session_key(server_name: &str, room_id: &str) -> SessionKey {
+        SessionKey::new(Platform::Custom("matrix".to_string()), server_name, room_id)
+    }
+
+    /// Extract the server name from a Matrix user_id (`@user:server.com` → `server.com`).
+    pub(super) fn server_name_from_user_id(user_id: &str) -> &str {
+        user_id
+            .split_once(':')
+            .map(|(_, server)| server)
+            .unwrap_or("matrix.org")
+    }
+
+    /// Handle the `!team` bot command and reply in the room.
+    async fn handle_team_command(&self, session_key: &SessionKey, room_id: &str, args: &str) {
+        let response = self.bridge.handle_pairing(session_key, args);
+        if let Err(e) = self.post_message(room_id, &response).await {
+            error!(%e, "failed to reply to !team command");
+        }
+    }
+
+    /// Run the /sync loop until cancelled.
+    pub(super) async fn run_sync_loop(
+        &self,
+        cancel: &CancellationToken,
+        bot_user_id: &str,
+        filter_id: Option<&str>,
+    ) -> anyhow::Result<()> {
+        let server_name = Self::server_name_from_user_id(bot_user_id);
+        let mut next_batch: Option<String> = None;
+        let mut reconnect_attempts: u32 = 0;
+
+        loop {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            let result = self.sync(next_batch.as_deref(), filter_id).await;
+
+            match result {
+                Ok(sync_resp) => {
+                    reconnect_attempts = 0;
+                    let batch = sync_resp.next_batch.clone();
+                    self.process_sync_response(sync_resp, bot_user_id, server_name)
+                        .await;
+                    next_batch = Some(batch);
+                }
+                Err(e) => {
+                    reconnect_attempts += 1;
+                    if reconnect_should_give_up(reconnect_attempts) {
+                        error!(%e, "matrix sync loop giving up after max reconnect attempts");
+                        return Err(e);
+                    }
+
+                    let delay = reconnect_delay(reconnect_attempts);
+                    let delay_secs = delay.as_secs();
+                    warn!(%e, attempt = reconnect_attempts, ?delay, "matrix /sync error, retrying...");
+                    self.metrics.record_reconnect("matrix", Some(e.to_string()));
+                    self.event_bus.emit(AppEventKind::ChannelReconnecting {
+                        platform: Platform::Custom("matrix".to_string()),
+                        attempt: reconnect_attempts,
+                        delay_secs,
+                    });
+                    tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        _ = tokio::time::sleep(delay) => {}
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn process_sync_response(
+        &self,
+        sync_resp: SyncResponse,
+        bot_user_id: &str,
+        server_name: &str,
+    ) {
+        if let Some(rooms) = sync_resp.rooms
+            && let Some(joined) = rooms.join
+        {
+            for (room_id, room) in joined {
+                let Some(timeline) = room.timeline else {
+                    continue;
+                };
+                let Some(events) = timeline.events else {
+                    continue;
+                };
+
+                for event in events {
+                    let Some(message) = parse_room_message(&room_id, &event, bot_user_id) else {
+                        continue;
+                    };
+                    self.process_incoming_message(server_name, message).await;
+                }
+            }
+        }
+    }
+
+    async fn process_incoming_message(&self, server_name: &str, message: IncomingTextEvent<'_>) {
+        let session_key = Self::session_key(server_name, message.room_id);
+        let display_name = Some(message.sender.to_string());
+
+        debug!(
+            room_id = %message.room_id,
+            sender = %message.sender,
+            body_len = message.body.len(),
+            "processing matrix room message"
+        );
+
+        if let Some(args) = message.body.strip_prefix("!team") {
+            self.handle_team_command(&session_key, message.room_id, args.trim())
+                .await;
+            return;
+        }
+
+        if !self.bridge.is_accepting_messages() {
+            info!(
+                room_id = %message.room_id,
+                "ignoring matrix message during shutdown drain"
+            );
+            return;
+        }
+
+        if let Err(e) = self
+            .bridge
+            .relay_and_drive_stream(
+                &session_key,
+                display_name,
+                message.body,
+                self as &dyn StreamResponder,
+                message.room_id,
+                ThrottlePolicy::matrix(),
+                MATRIX_MAX_LEN,
+            )
+            .await
+        {
+            error!(%e, "failed to relay matrix message");
+        }
+    }
+}
+
+fn parse_room_message<'a>(
+    room_id: &'a str,
+    event: &'a RoomEvent,
+    bot_user_id: &str,
+) -> Option<IncomingTextEvent<'a>> {
+    if !should_process_event(
+        &event.event_type,
+        &event.sender,
+        bot_user_id,
+        &event.content,
+    ) {
+        return None;
+    }
+
+    let body = extract_message_body(&event.content)?;
+    Some(IncomingTextEvent {
+        room_id,
+        sender: &event.sender,
+        body,
+    })
+}
+
+pub(super) fn should_process_event(
+    event_type: &str,
+    sender: &str,
+    bot_user_id: &str,
+    content: &serde_json::Value,
+) -> bool {
+    if event_type != "m.room.message" {
+        return false;
+    }
+    if sender == bot_user_id {
+        return false;
+    }
+    if content.get("msgtype").and_then(|value| value.as_str()) != Some("m.text") {
+        return false;
+    }
+    if content
+        .get("m.relates_to")
+        .and_then(|value| value.get("rel_type"))
+        .and_then(|value| value.as_str())
+        == Some("m.replace")
+    {
+        return false;
+    }
+    true
+}
+
+pub(super) fn extract_message_body(content: &serde_json::Value) -> Option<&str> {
+    let body = content.get("body")?.as_str()?.trim();
+    if body.is_empty() { None } else { Some(body) }
+}
+
+pub(super) fn reconnect_delay(attempt: u32) -> Duration {
+    Duration::from_secs(2u64.pow(attempt.min(5)))
+}
+
+pub(super) fn reconnect_should_give_up(attempt: u32) -> bool {
+    attempt >= MAX_RECONNECT_ATTEMPTS
+}

--- a/crates/opengoose-matrix/src/gateway/mod.rs
+++ b/crates/opengoose-matrix/src/gateway/mod.rs
@@ -5,25 +5,24 @@
 //! messages via the room event PUT endpoint. Uses atomic counters for
 //! monotonic transaction IDs and supports reconnection on error.
 
+mod api;
+mod incoming;
+mod outgoing;
+
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 use goose::gateway::handler::GatewayHandler;
 use goose::gateway::{Gateway, OutgoingMessage, PlatformUser};
 use tokio_util::sync::CancellationToken;
 
-use opengoose_core::message_utils::{split_message, truncate_for_display};
-use opengoose_core::{DraftHandle, GatewayBridge, StreamResponder};
-use opengoose_types::{AppEventKind, ChannelMetricsStore, EventBus, Platform, SessionKey};
-
-use crate::types::{
-    MatrixError, SendEventResponse, SyncFilter, SyncResponse, WhoAmI, edit_content, text_content,
-};
+use opengoose_core::GatewayBridge;
+use opengoose_types::{AppEventKind, ChannelMetricsStore, EventBus, Platform};
 
 /// Maximum message length for Matrix rooms.
 /// The spec doesn't mandate a limit, but 32 KiB is a safe practical ceiling
@@ -114,288 +113,6 @@ impl MatrixGateway {
             txn_counter: AtomicU64::new(0),
         })
     }
-
-    // -----------------------------------------------------------------------
-    // Internal helpers
-    // -----------------------------------------------------------------------
-
-    fn v3_url(&self, path: &str) -> String {
-        format!("{}/_matrix/client/v3{}", self.homeserver_url, path)
-    }
-
-    fn next_txn_id(&self) -> String {
-        let n = self.txn_counter.fetch_add(1, Ordering::Relaxed);
-        format!("opengoose-{}-{}", std::process::id(), n)
-    }
-
-    fn auth_header(&self) -> String {
-        format!("Bearer {}", self.access_token)
-    }
-
-    /// GET /account/whoami — returns the bot's Matrix user ID.
-    async fn whoami(&self) -> anyhow::Result<String> {
-        let resp: WhoAmI = self
-            .client
-            .get(self.v3_url("/account/whoami"))
-            .header("Authorization", self.auth_header())
-            .send()
-            .await?
-            .json()
-            .await?;
-        Ok(resp.user_id)
-    }
-
-    /// Register a minimal sync filter and return the filter ID.
-    async fn register_filter(&self, user_id: &str) -> anyhow::Result<String> {
-        let encoded_user = urlencoding::encode(user_id).into_owned();
-        let filter = SyncFilter::messages_only();
-        let resp: serde_json::Value = self
-            .client
-            .post(self.v3_url(&format!("/user/{encoded_user}/filter")))
-            .header("Authorization", self.auth_header())
-            .json(&filter)
-            .send()
-            .await?
-            .json()
-            .await?;
-        resp.get("filter_id")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .ok_or_else(|| anyhow::anyhow!("no filter_id in response"))
-    }
-
-    /// GET /sync — long-poll for new events.
-    async fn sync(
-        &self,
-        since: Option<&str>,
-        filter_id: Option<&str>,
-    ) -> anyhow::Result<SyncResponse> {
-        let mut req = self
-            .client
-            .get(self.v3_url("/sync"))
-            .header("Authorization", self.auth_header())
-            .query(&[("timeout", SYNC_TIMEOUT_MS.to_string())]);
-
-        if let Some(s) = since {
-            req = req.query(&[("since", s)]);
-        }
-        if let Some(f) = filter_id {
-            req = req.query(&[("filter", f)]);
-        }
-
-        Ok(req.send().await?.json().await?)
-    }
-
-    /// PUT /rooms/{roomId}/send/{eventType}/{txnId} — send a message event.
-    async fn send_event(
-        &self,
-        room_id: &str,
-        content: &serde_json::Value,
-    ) -> anyhow::Result<String> {
-        let encoded_room = urlencoding::encode(room_id).into_owned();
-        let txn_id = self.next_txn_id();
-        let url = self.v3_url(&format!(
-            "/rooms/{encoded_room}/send/m.room.message/{txn_id}"
-        ));
-
-        let resp = self
-            .client
-            .put(&url)
-            .header("Authorization", self.auth_header())
-            .json(content)
-            .send()
-            .await?;
-
-        if !resp.status().is_success() {
-            let err: MatrixError = resp.json().await.unwrap_or(MatrixError {
-                errcode: None,
-                error: Some("unknown error".into()),
-            });
-            anyhow::bail!(
-                "send_event failed: {} — {}",
-                err.errcode.unwrap_or_default(),
-                err.error.unwrap_or_default()
-            );
-        }
-
-        let ev: SendEventResponse = resp.json().await?;
-        Ok(ev.event_id)
-    }
-
-    /// Build the SessionKey for a Matrix room.
-    ///
-    /// Namespace = server name extracted from the bot's user_id (e.g. `example.com`).
-    /// Channel ID = room_id (e.g. `!room:example.com`).
-    fn session_key(server_name: &str, room_id: &str) -> SessionKey {
-        SessionKey::new(Platform::Custom("matrix".to_string()), server_name, room_id)
-    }
-
-    /// Extract the server name from a Matrix user_id (`@user:server.com` → `server.com`).
-    fn server_name_from_user_id(user_id: &str) -> &str {
-        user_id
-            .split_once(':')
-            .map(|(_, server)| server)
-            .unwrap_or("matrix.org")
-    }
-
-    /// Send a plain-text message to a room, splitting if needed.
-    async fn post_message(&self, room_id: &str, text: &str) -> anyhow::Result<()> {
-        debug!(room_id = %room_id, text_len = text.len(), "posting matrix message");
-        for chunk in split_message(text, MATRIX_MAX_LEN) {
-            let content = text_content(chunk);
-            if let Err(e) = self.send_event(room_id, &content).await {
-                warn!(%e, %room_id, "failed to send matrix message chunk");
-            }
-        }
-        Ok(())
-    }
-
-    /// Handle the `!team` bot command and reply in the room.
-    async fn handle_team_command(&self, session_key: &SessionKey, room_id: &str, args: &str) {
-        let response = self.bridge.handle_pairing(session_key, args);
-        if let Err(e) = self.post_message(room_id, &response).await {
-            error!(%e, "failed to reply to !team command");
-        }
-    }
-
-    /// Run the /sync loop until cancelled.
-    async fn run_sync_loop(
-        &self,
-        cancel: &CancellationToken,
-        bot_user_id: &str,
-        filter_id: Option<&str>,
-    ) -> anyhow::Result<()> {
-        let server_name = Self::server_name_from_user_id(bot_user_id);
-        let mut next_batch: Option<String> = None;
-        let mut reconnect_attempts: u32 = 0;
-
-        loop {
-            if cancel.is_cancelled() {
-                break;
-            }
-
-            let result = self.sync(next_batch.as_deref(), filter_id).await;
-
-            match result {
-                Ok(sync_resp) => {
-                    reconnect_attempts = 0;
-                    let batch = sync_resp.next_batch.clone();
-
-                    if let Some(rooms) = sync_resp.rooms
-                        && let Some(joined) = rooms.join
-                    {
-                        for (room_id, room) in joined {
-                            let Some(timeline) = room.timeline else {
-                                continue;
-                            };
-                            let Some(events) = timeline.events else {
-                                continue;
-                            };
-
-                            for event in events {
-                                // Only handle m.room.message
-                                if event.event_type != "m.room.message" {
-                                    continue;
-                                }
-                                // Ignore our own messages
-                                if event.sender == bot_user_id {
-                                    continue;
-                                }
-                                // Only plain text messages
-                                if event.content.get("msgtype").and_then(|v| v.as_str())
-                                    != Some("m.text")
-                                {
-                                    continue;
-                                }
-                                // Ignore edits (m.relates_to with m.replace)
-                                if event
-                                    .content
-                                    .get("m.relates_to")
-                                    .and_then(|v| v.get("rel_type"))
-                                    .and_then(|v| v.as_str())
-                                    == Some("m.replace")
-                                {
-                                    continue;
-                                }
-
-                                let Some(body) = event.content.get("body").and_then(|v| v.as_str())
-                                else {
-                                    continue;
-                                };
-
-                                let body = body.trim();
-                                if body.is_empty() {
-                                    continue;
-                                }
-
-                                let session_key = Self::session_key(server_name, &room_id);
-                                let display_name = Some(event.sender.clone());
-
-                                debug!(
-                                    room_id = %room_id,
-                                    sender = %event.sender,
-                                    body_len = body.len(),
-                                    "processing matrix room message"
-                                );
-
-                                // Check for !team command
-                                if let Some(args) = body.strip_prefix("!team") {
-                                    let args = args.trim();
-                                    self.handle_team_command(&session_key, &room_id, args).await;
-                                    continue;
-                                }
-
-                                if !self.bridge.is_accepting_messages() {
-                                    info!(room_id = %room_id, "ignoring matrix message during shutdown drain");
-                                    continue;
-                                }
-
-                                if let Err(e) = self
-                                    .bridge
-                                    .relay_and_drive_stream(
-                                        &session_key,
-                                        display_name,
-                                        body,
-                                        self as &dyn StreamResponder,
-                                        &room_id,
-                                        opengoose_core::ThrottlePolicy::matrix(),
-                                        MATRIX_MAX_LEN,
-                                    )
-                                    .await
-                                {
-                                    error!(%e, "failed to relay matrix message");
-                                }
-                            }
-                        }
-                    }
-
-                    next_batch = Some(batch);
-                }
-                Err(e) => {
-                    reconnect_attempts += 1;
-                    if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
-                        error!(%e, "matrix sync loop giving up after max reconnect attempts");
-                        return Err(e);
-                    }
-                    let delay = Duration::from_secs(2u64.pow(reconnect_attempts.min(5)));
-                    let delay_secs = delay.as_secs();
-                    warn!(%e, attempt = reconnect_attempts, ?delay, "matrix /sync error, retrying...");
-                    self.metrics.record_reconnect("matrix", Some(e.to_string()));
-                    self.event_bus.emit(AppEventKind::ChannelReconnecting {
-                        platform: Platform::Custom("matrix".to_string()),
-                        attempt: reconnect_attempts,
-                        delay_secs,
-                    });
-                    tokio::select! {
-                        _ = cancel.cancelled() => break,
-                        _ = tokio::time::sleep(delay) => {}
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -461,14 +178,7 @@ impl Gateway for MatrixGateway {
         message: OutgoingMessage,
     ) -> anyhow::Result<()> {
         if let OutgoingMessage::Text { body } = message {
-            let channel_id = self
-                .bridge
-                .route_outgoing_text(&user.user_id, &body, "matrix")
-                .await;
-
-            if let Err(e) = self.post_message(&channel_id, &body).await {
-                error!(%e, "failed to send matrix message");
-            }
+            self.send_outgoing_text(user, &body).await?;
         }
         Ok(())
     }
@@ -480,46 +190,6 @@ impl Gateway for MatrixGateway {
     fn info(&self) -> HashMap<String, String> {
         HashMap::from([("type".into(), "matrix".into())])
     }
-}
-
-// ---------------------------------------------------------------------------
-// StreamResponder trait
-// ---------------------------------------------------------------------------
-
-#[async_trait]
-impl StreamResponder for MatrixGateway {
-    fn supports_streaming(&self) -> bool {
-        true
-    }
-
-    fn max_message_len(&self) -> usize {
-        MATRIX_MAX_LEN
-    }
-
-    async fn create_draft(&self, room_id: &str) -> anyhow::Result<DraftHandle> {
-        debug!(room_id = %room_id, "creating matrix draft");
-        let content = text_content("Thinking...");
-        let event_id = self.send_event(room_id, &content).await?;
-        debug!(room_id = %room_id, event_id = %event_id, "matrix draft created");
-        Ok(DraftHandle {
-            message_id: event_id,
-            channel_id: room_id.to_string(),
-        })
-    }
-
-    async fn update_draft(&self, handle: &DraftHandle, content: &str) -> anyhow::Result<()> {
-        debug!(room_id = %handle.channel_id, event_id = %handle.message_id, content_len = content.len(), "updating matrix draft");
-        let display = truncate_for_display(content, MATRIX_MAX_LEN);
-        let ev_content = edit_content(&handle.message_id, display);
-        self.send_event(&handle.channel_id, &ev_content).await?;
-        Ok(())
-    }
-
-    async fn send_new_message(&self, room_id: &str, content: &str) -> anyhow::Result<()> {
-        self.post_message(room_id, content).await
-    }
-
-    // finalize_draft uses the default implementation from StreamResponder
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/opengoose-matrix/src/gateway/outgoing.rs
+++ b/crates/opengoose-matrix/src/gateway/outgoing.rs
@@ -1,0 +1,86 @@
+use async_trait::async_trait;
+use tracing::{debug, error, warn};
+
+use goose::gateway::PlatformUser;
+
+use opengoose_core::message_utils::{split_message, truncate_for_display};
+use opengoose_core::{DraftHandle, StreamResponder};
+
+use crate::types::{edit_content, text_content};
+
+use super::{MATRIX_MAX_LEN, MatrixGateway};
+
+impl MatrixGateway {
+    /// Send a plain-text message to a room, splitting if needed.
+    pub(super) async fn post_message(&self, room_id: &str, text: &str) -> anyhow::Result<()> {
+        debug!(room_id = %room_id, text_len = text.len(), "posting matrix message");
+        for chunk in split_message(text, MATRIX_MAX_LEN) {
+            let content = text_content(chunk);
+            if let Err(e) = self.send_event(room_id, &content).await {
+                warn!(%e, %room_id, "failed to send matrix message chunk");
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn send_outgoing_text(
+        &self,
+        user: &PlatformUser,
+        body: &str,
+    ) -> anyhow::Result<()> {
+        let channel_id = self
+            .bridge
+            .route_outgoing_text(&user.user_id, body, "matrix")
+            .await;
+
+        if let Err(e) = self.post_message(&channel_id, body).await {
+            error!(%e, "failed to send matrix message");
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// StreamResponder trait
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl StreamResponder for MatrixGateway {
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn max_message_len(&self) -> usize {
+        MATRIX_MAX_LEN
+    }
+
+    async fn create_draft(&self, room_id: &str) -> anyhow::Result<DraftHandle> {
+        debug!(room_id = %room_id, "creating matrix draft");
+        let content = text_content("Thinking...");
+        let event_id = self.send_event(room_id, &content).await?;
+        debug!(room_id = %room_id, event_id = %event_id, "matrix draft created");
+        Ok(DraftHandle {
+            message_id: event_id,
+            channel_id: room_id.to_string(),
+        })
+    }
+
+    async fn update_draft(&self, handle: &DraftHandle, content: &str) -> anyhow::Result<()> {
+        debug!(
+            room_id = %handle.channel_id,
+            event_id = %handle.message_id,
+            content_len = content.len(),
+            "updating matrix draft"
+        );
+        let display = truncate_for_display(content, MATRIX_MAX_LEN);
+        let ev_content = edit_content(&handle.message_id, display);
+        self.send_event(&handle.channel_id, &ev_content).await?;
+        Ok(())
+    }
+
+    async fn send_new_message(&self, room_id: &str, content: &str) -> anyhow::Result<()> {
+        self.post_message(room_id, content).await
+    }
+
+    // finalize_draft uses the default implementation from StreamResponder
+}

--- a/crates/opengoose-matrix/src/gateway/tests.rs
+++ b/crates/opengoose-matrix/src/gateway/tests.rs
@@ -4,6 +4,9 @@ use opengoose_types::Platform;
 
 use super::{
     MATRIX_MAX_LEN, MAX_RECONNECT_ATTEMPTS, MatrixGateway, REQUEST_TIMEOUT, SYNC_TIMEOUT_MS,
+    incoming::{
+        extract_message_body, reconnect_delay, reconnect_should_give_up, should_process_event,
+    },
     urlencoding,
 };
 
@@ -90,36 +93,8 @@ fn test_txn_id_format() {
 }
 
 // -----------------------------------------------------------------------
-// Message filtering logic (extracted from run_sync_loop)
+// Message filtering logic
 // -----------------------------------------------------------------------
-
-/// Mirror of the filtering conditions in run_sync_loop, expressed as a
-/// pure function so they can be unit-tested without network I/O.
-fn should_process_event(
-    event_type: &str,
-    sender: &str,
-    bot_user_id: &str,
-    content: &serde_json::Value,
-) -> bool {
-    if event_type != "m.room.message" {
-        return false;
-    }
-    if sender == bot_user_id {
-        return false;
-    }
-    if content.get("msgtype").and_then(|v| v.as_str()) != Some("m.text") {
-        return false;
-    }
-    if content
-        .get("m.relates_to")
-        .and_then(|v| v.get("rel_type"))
-        .and_then(|v| v.as_str())
-        == Some("m.replace")
-    {
-        return false;
-    }
-    true
-}
 
 #[test]
 fn test_event_filter_accepts_plain_text() {
@@ -221,15 +196,16 @@ fn test_event_filter_accepts_reply_with_different_rel_type() {
 
 #[test]
 fn test_reconnect_delay_exponential_backoff() {
-    // The sync loop uses: Duration::from_secs(2u64.pow(attempt.min(5)))
     // Verify the capped exponential sequence: 2, 4, 8, 16, 32, 32, 32, ...
-    let delays: Vec<u64> = (1u32..=8).map(|attempt| 2u64.pow(attempt.min(5))).collect();
+    let delays: Vec<u64> = (1u32..=8)
+        .map(|attempt| reconnect_delay(attempt).as_secs())
+        .collect();
     assert_eq!(delays, vec![2, 4, 8, 16, 32, 32, 32, 32]);
 }
 
 #[test]
 fn test_reconnect_delay_first_attempt_is_two_seconds() {
-    let delay = 2u64.pow(1);
+    let delay = reconnect_delay(1).as_secs();
     assert_eq!(delay, 2);
 }
 
@@ -483,63 +459,47 @@ fn test_team_command_not_matched_by_partial_prefix() {
 }
 
 // -----------------------------------------------------------------------
-// Body extraction logic — mirrors run_sync_loop body-skipping conditions
+// Body extraction logic
 // -----------------------------------------------------------------------
-
-/// Mirror of the body extraction + trim + empty check in run_sync_loop.
-fn extract_body(content: &serde_json::Value) -> Option<String> {
-    let raw = content.get("body")?.as_str()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-}
 
 #[test]
 fn test_body_absent_is_skipped() {
     // Content with no "body" key — should not be processed
     let content = serde_json::json!({"msgtype": "m.text"});
-    assert!(extract_body(&content).is_none());
+    assert!(extract_message_body(&content).is_none());
 }
 
 #[test]
 fn test_body_empty_string_is_skipped() {
     let content = serde_json::json!({"msgtype": "m.text", "body": ""});
-    assert!(extract_body(&content).is_none());
+    assert!(extract_message_body(&content).is_none());
 }
 
 #[test]
 fn test_body_whitespace_only_is_skipped() {
     // Whitespace-only body trims to empty — should be ignored
     let content = serde_json::json!({"msgtype": "m.text", "body": "   \t\n  "});
-    assert!(extract_body(&content).is_none());
+    assert!(extract_message_body(&content).is_none());
 }
 
 #[test]
 fn test_body_non_string_is_skipped() {
     // body set to null or a number — as_str() returns None
     let null_body = serde_json::json!({"msgtype": "m.text", "body": null});
-    assert!(extract_body(&null_body).is_none());
+    assert!(extract_message_body(&null_body).is_none());
     let num_body = serde_json::json!({"msgtype": "m.text", "body": 42});
-    assert!(extract_body(&num_body).is_none());
+    assert!(extract_message_body(&num_body).is_none());
 }
 
 #[test]
 fn test_body_valid_text_is_processed() {
     let content = serde_json::json!({"msgtype": "m.text", "body": "  hello  "});
-    assert_eq!(extract_body(&content).as_deref(), Some("hello"));
+    assert_eq!(extract_message_body(&content), Some("hello"));
 }
 
 // -----------------------------------------------------------------------
 // Reconnection logic — attempt counter vs MAX_RECONNECT_ATTEMPTS
 // -----------------------------------------------------------------------
-
-/// Mirror of the reconnection guard in run_sync_loop.
-fn reconnect_should_give_up(attempt: u32) -> bool {
-    attempt >= MAX_RECONNECT_ATTEMPTS
-}
 
 #[test]
 fn test_reconnect_below_max_continues() {
@@ -653,9 +613,9 @@ fn test_sync_batch_token_advances_with_each_response() {
 #[test]
 fn test_reconnect_delay_cap_at_attempt_5_and_beyond() {
     // At attempt 5 and 6 both produce the same 32s delay (capped at .min(5))
-    let delay_at_5 = 2u64.pow(5);
-    let delay_at_6 = 2u64.pow(5);
-    let delay_at_10 = 2u64.pow(5);
+    let delay_at_5 = reconnect_delay(5).as_secs();
+    let delay_at_6 = reconnect_delay(6).as_secs();
+    let delay_at_10 = reconnect_delay(10).as_secs();
     assert_eq!(delay_at_5, 32);
     assert_eq!(delay_at_6, 32);
     assert_eq!(delay_at_10, 32);
@@ -664,10 +624,10 @@ fn test_reconnect_delay_cap_at_attempt_5_and_beyond() {
 #[test]
 fn test_reconnect_delay_before_cap() {
     // Attempts 1–4 each double the previous delay
-    let delay_1 = 2u64.pow(1);
-    let delay_2 = 2u64.pow(2);
-    let delay_3 = 2u64.pow(3);
-    let delay_4 = 2u64.pow(4);
+    let delay_1 = reconnect_delay(1).as_secs();
+    let delay_2 = reconnect_delay(2).as_secs();
+    let delay_3 = reconnect_delay(3).as_secs();
+    let delay_4 = reconnect_delay(4).as_secs();
     assert_eq!(delay_1, 2);
     assert_eq!(delay_2, 4);
     assert_eq!(delay_3, 8);


### PR DESCRIPTION
## Summary
- split the Matrix gateway runtime into focused `api`, `incoming`, and `outgoing` helper modules
- keep `MatrixGateway` trait orchestration in `gateway/mod.rs` while preserving sync, reconnect, reply/edit, and send semantics
- point gateway tests at the extracted sync helper functions so the split stays covered

## Verification
- cargo +nightly fmt --all
- cargo clippy -p opengoose-matrix --all-targets -- -D warnings
- cargo test -p opengoose-matrix

## Paperclip
- Issue: OPE-393
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
