### PR TITLE
test: Expand team command coverage [OPE-399]

### DIFF
--- a/crates/opengoose-cli/src/cmd/team.rs
+++ b/crates/opengoose-cli/src/cmd/team.rs
@@ -429,7 +429,7 @@ async fn cmd_resume(run_id: &str) -> Result<()> {
 mod tests {
     use super::*;
     use std::io::Write;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     async fn test_execute(action: TeamAction, output: CliOutput) -> Result<()> {
         let tmp = tempfile::tempdir().unwrap();
@@ -443,6 +443,44 @@ mod tests {
 
     fn json_output() -> CliOutput {
         CliOutput::new(crate::cmd::output::OutputMode::Json)
+    }
+
+    async fn execute_in_store_dir(action: TeamAction, dir: &Path, output: CliOutput) -> Result<()> {
+        execute_with_store(action, TeamStore::with_dir(dir.to_path_buf()), output).await
+    }
+
+    fn write_team_file(contents: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{contents}").unwrap();
+        file
+    }
+
+    fn chain_team_yaml(name: &str) -> String {
+        format!(
+            r#"version: "1.0.0"
+title: "{name}"
+description: "Custom team"
+workflow: chain
+agents:
+  - profile: developer
+    role: "Implement the change"
+"#
+        )
+    }
+
+    fn router_team_yaml(name: &str) -> String {
+        format!(
+            r#"version: "1.0.0"
+title: "{name}"
+description: "Router team"
+workflow: router
+agents:
+  - profile: triager
+    role: "Route work to the right specialist"
+router:
+  strategy: content-based
+"#
+        )
     }
 
     #[tokio::test]
@@ -561,6 +599,240 @@ mod tests {
         assert!(
             msg.contains("yaml") || msg.contains("parse") || msg.contains("invalid"),
             "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_persists_valid_team_definition() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(&chain_team_yaml("custom-team"));
+
+        execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap();
+
+        let team = TeamStore::with_dir(store_dir.path().to_path_buf())
+            .get("custom-team")
+            .unwrap();
+        assert_eq!(team.title, "custom-team");
+        assert_eq!(team.description.as_deref(), Some("Custom team"));
+        assert_eq!(team.agents.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn add_rejects_duplicate_team_without_force() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(&chain_team_yaml("duplicate-team"));
+        let action = TeamAction::Add {
+            path: team_file.path().to_path_buf(),
+            force: false,
+        };
+
+        execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap();
+
+        let err = execute_in_store_dir(action, store_dir.path(), text_output())
+            .await
+            .unwrap_err();
+
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(
+            msg.contains("already exists"),
+            "unexpected duplicate-team error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_rejects_empty_title_validation_error() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(
+            r#"version: "1.0.0"
+title: "   "
+workflow: chain
+agents:
+  - profile: developer
+"#,
+        );
+
+        let err = execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(msg.contains("title is required"), "unexpected error: {msg}");
+    }
+
+    #[tokio::test]
+    async fn add_rejects_empty_agents_validation_error() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(
+            r#"version: "1.0.0"
+title: "empty-agents"
+workflow: chain
+agents: []
+"#,
+        );
+
+        let err = execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(
+            msg.contains("at least one agent is required"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_rejects_empty_agent_profile_validation_error() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(
+            r#"version: "1.0.0"
+title: "bad-profile"
+workflow: chain
+agents:
+  - profile: "   "
+"#,
+        );
+
+        let err = execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(
+            msg.contains("agent profile name cannot be empty"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_router_team_requires_router_config() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(
+            r#"version: "1.0.0"
+title: "router-without-config"
+workflow: router
+agents:
+  - profile: triager
+    role: "Pick the right teammate"
+"#,
+        );
+
+        let err = execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(
+            msg.contains("router workflow requires"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn add_router_team_with_config_succeeds() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(&router_team_yaml("router-team"));
+
+        execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap();
+
+        let team = TeamStore::with_dir(store_dir.path().to_path_buf())
+            .get("router-team")
+            .unwrap();
+        assert_eq!(team.workflow, opengoose_teams::OrchestrationPattern::Router);
+        assert_eq!(
+            team.router.unwrap().strategy,
+            opengoose_teams::RouterStrategy::ContentBased
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_existing_team_deletes_definition() {
+        let store_dir = tempfile::tempdir().unwrap();
+        let team_file = write_team_file(&chain_team_yaml("remove-me"));
+
+        execute_in_store_dir(
+            TeamAction::Add {
+                path: team_file.path().to_path_buf(),
+                force: false,
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap();
+
+        execute_in_store_dir(
+            TeamAction::Remove {
+                name: "remove-me".into(),
+            },
+            store_dir.path(),
+            text_output(),
+        )
+        .await
+        .unwrap();
+
+        let err = TeamStore::with_dir(store_dir.path().to_path_buf())
+            .get("remove-me")
+            .unwrap_err();
+        let msg = err.to_string().to_ascii_lowercase();
+        assert!(
+            msg.contains("not found") || msg.contains("does not exist"),
+            "unexpected post-remove error: {msg}"
         );
     }
 

--- a/crates/opengoose-cli/src/main.rs
+++ b/crates/opengoose-cli/src/main.rs
@@ -348,6 +348,49 @@ mod tests {
     }
 
     #[test]
+    fn parse_team_show_subcommand() {
+        let cli = Cli::parse_from(["opengoose", "team", "show", "code-review"]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Show { name },
+            }) => {
+                assert_eq!(name, "code-review");
+            }
+            _ => panic!("expected Team show command"),
+        }
+    }
+
+    #[test]
+    fn parse_team_remove_subcommand() {
+        let cli = Cli::parse_from(["opengoose", "team", "remove", "code-review"]);
+
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Remove { name },
+            }) => {
+                assert_eq!(name, "code-review");
+            }
+            _ => panic!("expected Team remove command"),
+        }
+    }
+
+    #[test]
+    fn parse_json_flag_after_team_subcommand_for_show() {
+        let cli = Cli::parse_from(["opengoose", "team", "--json", "show", "code-review"]);
+
+        assert!(cli.json);
+        match cli.command {
+            Some(Command::Team {
+                action: cmd::team::TeamAction::Show { name },
+            }) => {
+                assert_eq!(name, "code-review");
+            }
+            _ => panic!("expected Team show command"),
+        }
+    }
+
+    #[test]
     fn parse_team_add_force_subcommand() {
         let cli = Cli::parse_from([
             "opengoose",

--- a/crates/opengoose-cli/tests/cli_smoke.rs
+++ b/crates/opengoose-cli/tests/cli_smoke.rs
@@ -189,6 +189,82 @@ agents:
 }
 
 #[test]
+fn team_show_json_reports_router_configuration() {
+    let (_temp, home, goose_root) = test_env();
+    let team_path = home.join("router-team.yaml");
+    fs::write(
+        &team_path,
+        r#"version: "1.0.0"
+title: "router-team"
+description: "Route prompts to the best agent"
+workflow: router
+agents:
+  - profile: triager
+    role: "Select the specialist"
+router:
+  strategy: content-based
+"#,
+    )
+    .unwrap();
+
+    let add = run_cli(
+        &home,
+        &goose_root,
+        &["team", "add", team_path.to_str().unwrap()],
+    );
+    assert!(add.status.success());
+
+    let show = run_cli(
+        &home,
+        &goose_root,
+        &["--json", "team", "show", "router-team"],
+    );
+    assert!(show.status.success());
+
+    let payload = stdout_json(&show);
+    assert_eq!(payload["ok"], Value::Bool(true));
+    assert_eq!(payload["team"]["title"], Value::from("router-team"));
+    assert_eq!(payload["team"]["workflow"], Value::from("router"));
+    assert_eq!(
+        payload["team"]["router"]["strategy"],
+        Value::from("content-based")
+    );
+}
+
+#[test]
+fn team_show_missing_team_reports_structured_error() {
+    let (_temp, home, goose_root) = test_env();
+
+    let output = run_cli(
+        &home,
+        &goose_root,
+        &["--json", "team", "show", "missing-team"],
+    );
+    assert_runtime_error_message(&output, "not_found", "team `missing-team` not found");
+}
+
+#[test]
+fn team_remove_json_reports_removed_flag_for_existing_team() {
+    let (_temp, home, goose_root) = test_env();
+
+    let init = run_cli(&home, &goose_root, &["team", "init"]);
+    assert!(init.status.success());
+
+    let remove = run_cli(
+        &home,
+        &goose_root,
+        &["--json", "team", "remove", "code-review"],
+    );
+    assert!(remove.status.success());
+
+    let payload = stdout_json(&remove);
+    assert_eq!(payload["ok"], Value::Bool(true));
+    assert_eq!(payload["command"], Value::from("team.remove"));
+    assert_eq!(payload["team"], Value::from("code-review"));
+    assert_eq!(payload["removed"], Value::Bool(true));
+}
+
+#[test]
 fn run_command_rejects_json_output() {
     let (_temp, home, goose_root) = test_env();
 


### PR DESCRIPTION
## Summary
- add semantic team command tests for valid team creation, duplicate detection, validation failures, router workflow handling, and successful removal
- cover missing clap parser cases for team show, team remove, and JSON flag placement after the team subcommand
- extend CLI smoke coverage for JSON team show/remove output and structured missing-team errors

## Validation
- cargo fmt --all
- cargo clippy --all-targets
- cargo test
- cargo build

Paperclip issue: OPE-399