### PR TITLE
refactor(slack): split gateway socket and dispatch modules [OPE-405]

### DIFF
--- a/crates/opengoose-slack/src/gateway/dispatch.rs
+++ b/crates/opengoose-slack/src/gateway/dispatch.rs
@@ -1,0 +1,138 @@
+//! Slack envelope dispatch and `/team` command handling.
+
+use tracing::{debug, error, info};
+
+use opengoose_core::StreamResponder;
+use opengoose_types::{Platform, SessionKey};
+
+use crate::types::{SlashCommand, SocketEnvelope};
+
+use super::envelope::classify_slack_envelope;
+use super::types::SlackEnvelopeAction;
+use super::{SLACK_MAX_LEN, SlackGateway};
+
+impl SlackGateway {
+    async fn handle_team_command(&self, cmd: &SlashCommand) {
+        let Some(session_key) = team_command_session_key(cmd) else {
+            return;
+        };
+
+        let response = self
+            .bridge
+            .handle_pairing(&session_key, team_command_args(cmd));
+
+        if let Some(response_url) = cmd.response_url.as_deref() {
+            self.respond_ephemeral(response_url, &response).await;
+        }
+    }
+
+    /// Process a single Socket Mode envelope.
+    pub(super) async fn handle_envelope(&self, envelope: &SocketEnvelope, bot_user_id: &str) {
+        match classify_slack_envelope(envelope, bot_user_id) {
+            SlackEnvelopeAction::Ignore => {
+                debug!(envelope_type = %envelope.envelope_type, "ignoring slack envelope");
+            }
+            SlackEnvelopeAction::Relay {
+                session_key,
+                channel,
+                text,
+                display_name,
+            } => {
+                if !self.bridge.is_accepting_messages() {
+                    info!(channel = %channel, "ignoring slack message during shutdown drain");
+                    return;
+                }
+                debug!(
+                    channel = %channel,
+                    user = %display_name,
+                    text_len = text.len(),
+                    "relaying slack message to engine"
+                );
+                if let Err(error) = self
+                    .bridge
+                    .relay_and_drive_stream(
+                        &session_key,
+                        Some(display_name),
+                        &text,
+                        self as &dyn StreamResponder,
+                        &channel,
+                        opengoose_core::ThrottlePolicy::slack(),
+                        SLACK_MAX_LEN,
+                    )
+                    .await
+                {
+                    // Error event is emitted by bridge; just log here.
+                    error!(%error, "failed to relay slack message");
+                }
+            }
+            SlackEnvelopeAction::TeamCommand(ref cmd) => {
+                debug!(command = ?cmd.command, "handling slack team command");
+                self.handle_team_command(cmd).await;
+            }
+        }
+    }
+}
+
+fn team_command_session_key(cmd: &SlashCommand) -> Option<SessionKey> {
+    let channel_id = cmd.channel_id.as_deref()?;
+    let team_id = cmd.team_id.as_deref().unwrap_or("unknown");
+    Some(SessionKey::new(Platform::Slack, team_id, channel_id))
+}
+
+fn team_command_args(cmd: &SlashCommand) -> &str {
+    cmd.text.as_deref().unwrap_or("").trim()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slash_command() -> SlashCommand {
+        SlashCommand {
+            command: Some("/team".to_string()),
+            text: Some(" ops ".to_string()),
+            channel_id: Some("C123".to_string()),
+            team_id: Some("T123".to_string()),
+            user_name: Some("alice".to_string()),
+            response_url: Some("https://hooks.slack.com/commands/123".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_team_command_session_key_preserves_slack_team_and_channel() {
+        let session_key = team_command_session_key(&slash_command()).expect("session key");
+        assert_eq!(session_key.platform, Platform::Slack);
+        assert_eq!(session_key.namespace.as_deref(), Some("T123"));
+        assert_eq!(session_key.channel_id, "C123");
+    }
+
+    #[test]
+    fn test_team_command_session_key_defaults_team_to_unknown() {
+        let mut cmd = slash_command();
+        cmd.team_id = None;
+
+        let session_key = team_command_session_key(&cmd).expect("session key");
+        assert_eq!(session_key.namespace.as_deref(), Some("unknown"));
+    }
+
+    #[test]
+    fn test_team_command_session_key_requires_channel_id() {
+        let mut cmd = slash_command();
+        cmd.channel_id = None;
+
+        assert!(team_command_session_key(&cmd).is_none());
+    }
+
+    #[test]
+    fn test_team_command_args_trim_whitespace() {
+        assert_eq!(team_command_args(&slash_command()), "ops");
+    }
+
+    #[test]
+    fn test_team_command_args_default_to_empty_string() {
+        let mut cmd = slash_command();
+        cmd.text = None;
+
+        assert_eq!(team_command_args(&cmd), "");
+    }
+}

--- a/crates/opengoose-slack/src/gateway/mod.rs
+++ b/crates/opengoose-slack/src/gateway/mod.rs
@@ -1,34 +1,29 @@
 //! Slack Socket Mode gateway implementation.
 
+mod dispatch;
 mod envelope;
 mod messages;
+mod socket;
 mod types;
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures_util::{SinkExt, StreamExt};
-use tokio_tungstenite::tungstenite::Message as WsMessage;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info};
 
 use goose::gateway::handler::GatewayHandler;
 use goose::gateway::{Gateway, OutgoingMessage, PlatformUser};
 use tokio_util::sync::CancellationToken;
 
 use opengoose_core::{DraftHandle, GatewayBridge, StreamResponder};
-use opengoose_types::{AppEventKind, ChannelMetricsStore, EventBus, Platform, SessionKey};
-
-use crate::types::*;
-
-use self::envelope::classify_slack_envelope;
-use self::types::SlackEnvelopeAction;
+use opengoose_types::{AppEventKind, ChannelMetricsStore, EventBus, Platform};
 
 /// Safety split at 4000 chars for readability (Slack allows ~40k).
-const SLACK_MAX_LEN: usize = 4000;
+pub(crate) const SLACK_MAX_LEN: usize = 4000;
 
 /// Maximum number of consecutive reconnect attempts before giving up.
-const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+pub(crate) const MAX_RECONNECT_ATTEMPTS: u32 = 10;
 
 /// Slack channel gateway using Socket Mode (WebSocket) + Web API.
 ///
@@ -73,229 +68,6 @@ impl SlackGateway {
             event_bus,
             metrics,
         }
-    }
-
-    /// Open a Socket Mode WebSocket connection.
-    async fn connect_websocket(&self) -> anyhow::Result<String> {
-        let resp: ConnectionsOpenResponse = self
-            .client
-            .post("https://slack.com/api/apps.connections.open")
-            .bearer_auth(&self.app_token)
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        if !resp.ok {
-            anyhow::bail!(
-                "apps.connections.open failed: {}",
-                resp.error.unwrap_or_default()
-            );
-        }
-
-        resp.url
-            .ok_or_else(|| anyhow::anyhow!("no WebSocket URL in response"))
-    }
-
-    /// Handle the /team slash command.
-    async fn handle_team_command(&self, cmd: &SlashCommand) {
-        let Some(channel_id) = cmd.channel_id.as_deref() else {
-            return;
-        };
-        let team_id = cmd.team_id.as_deref().unwrap_or("unknown");
-        let session_key = SessionKey::new(Platform::Slack, team_id, channel_id);
-
-        let args = cmd.text.as_deref().unwrap_or("").trim();
-        let response = self.bridge.handle_pairing(&session_key, args);
-
-        if let Some(ref url) = cmd.response_url {
-            self.respond_ephemeral(url, &response).await;
-        }
-    }
-
-    /// Process a single Socket Mode envelope.
-    async fn handle_envelope(&self, envelope: &SocketEnvelope, bot_user_id: &str) {
-        match classify_slack_envelope(envelope, bot_user_id) {
-            SlackEnvelopeAction::Ignore => {
-                debug!(envelope_type = %envelope.envelope_type, "ignoring slack envelope");
-            }
-            SlackEnvelopeAction::Relay {
-                session_key,
-                channel,
-                text,
-                display_name,
-            } => {
-                if !self.bridge.is_accepting_messages() {
-                    info!(channel = %channel, "ignoring slack message during shutdown drain");
-                    return;
-                }
-                debug!(
-                    channel = %channel,
-                    user = %display_name,
-                    text_len = text.len(),
-                    "relaying slack message to engine"
-                );
-                if let Err(e) = self
-                    .bridge
-                    .relay_and_drive_stream(
-                        &session_key,
-                        Some(display_name),
-                        &text,
-                        self as &dyn StreamResponder,
-                        &channel,
-                        opengoose_core::ThrottlePolicy::slack(),
-                        SLACK_MAX_LEN,
-                    )
-                    .await
-                {
-                    // Error event is emitted by bridge; just log here
-                    error!(%e, "failed to relay slack message");
-                }
-            }
-            SlackEnvelopeAction::TeamCommand(ref cmd) => {
-                debug!(command = ?cmd.command, "handling slack team command");
-                self.handle_team_command(cmd).await;
-            }
-        }
-    }
-
-    /// Get the bot's user ID for filtering self-messages.
-    async fn get_bot_user_id(&self) -> anyhow::Result<String> {
-        let resp: AuthTestResponse = self
-            .client
-            .post("https://slack.com/api/auth.test")
-            .bearer_auth(&self.bot_token)
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        if !resp.ok {
-            anyhow::bail!("auth.test failed: {}", resp.error.unwrap_or_default());
-        }
-
-        resp.user_id
-            .ok_or_else(|| anyhow::anyhow!("auth.test returned no user_id"))
-    }
-
-    /// Run the WebSocket event loop with reconnection support.
-    async fn run_socket_mode(
-        &self,
-        cancel: &CancellationToken,
-        bot_user_id: &str,
-    ) -> anyhow::Result<()> {
-        let mut reconnect_attempts: u32 = 0;
-
-        loop {
-            if cancel.is_cancelled() {
-                break;
-            }
-
-            // Get a new WebSocket URL
-            let ws_url = match self.connect_websocket().await {
-                Ok(url) => {
-                    reconnect_attempts = 0;
-                    url
-                }
-                Err(e) => {
-                    reconnect_attempts += 1;
-                    let Some(delay) = websocket_reconnect_delay(reconnect_attempts) else {
-                        return Err(e);
-                    };
-                    let delay_secs = delay.as_secs();
-                    warn!(%e, ?delay, "failed to get WebSocket URL, retrying...");
-                    self.metrics.record_reconnect("slack", Some(e.to_string()));
-                    self.event_bus.emit(AppEventKind::ChannelReconnecting {
-                        platform: Platform::Slack,
-                        attempt: reconnect_attempts,
-                        delay_secs,
-                    });
-                    tokio::time::sleep(delay).await;
-                    continue;
-                }
-            };
-
-            info!("connecting to slack socket mode");
-
-            let (ws_stream, _) = match tokio_tungstenite::connect_async(&ws_url).await {
-                Ok(conn) => conn,
-                Err(e) => {
-                    reconnect_attempts += 1;
-                    let Some(delay) = websocket_reconnect_delay(reconnect_attempts) else {
-                        return Err(e.into());
-                    };
-                    let delay_secs = delay.as_secs();
-                    warn!(%e, ?delay, "WebSocket connect failed, retrying...");
-                    self.metrics.record_reconnect("slack", Some(e.to_string()));
-                    self.event_bus.emit(AppEventKind::ChannelReconnecting {
-                        platform: Platform::Slack,
-                        attempt: reconnect_attempts,
-                        delay_secs,
-                    });
-                    tokio::time::sleep(delay).await;
-                    continue;
-                }
-            };
-
-            let (mut ws_write, mut ws_read) = ws_stream.split();
-
-            info!("slack socket mode connected");
-            self.metrics.set_connected("slack");
-
-            // Process messages until disconnect
-            loop {
-                tokio::select! {
-                    _ = cancel.cancelled() => {
-                        let _ = ws_write.close().await;
-                        return Ok(());
-                    }
-                    msg = ws_read.next() => {
-                        match msg {
-                            Some(Ok(WsMessage::Text(text))) => {
-                                let Ok(envelope) = serde_json::from_str::<SocketEnvelope>(&text) else {
-                                    continue;
-                                };
-
-                                // ACK immediately (must be within 5 seconds)
-                                let ack = EnvelopeAck {
-                                    envelope_id: envelope.envelope_id.clone(),
-                                    payload: None,
-                                };
-                                if let Ok(ack_json) = serde_json::to_string(&ack)
-                                    && ws_write
-                                        .send(WsMessage::Text(ack_json.into()))
-                                        .await
-                                        .is_err()
-                                {
-                                    warn!("failed to send ACK, reconnecting...");
-                                    break;
-                                }
-
-                                // Handle the envelope
-                                self.handle_envelope(&envelope, bot_user_id).await;
-                            }
-                            Some(Ok(WsMessage::Ping(data))) => {
-                                let _ = ws_write.send(WsMessage::Pong(data)).await;
-                            }
-                            Some(Ok(WsMessage::Close(_))) | None => {
-                                info!("slack WebSocket closed, reconnecting...");
-                                break;
-                            }
-                            Some(Err(e)) => {
-                                warn!(%e, "slack WebSocket error, reconnecting...");
-                                break;
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-
-            // Small delay before reconnect
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        }
-
-        Ok(())
     }
 }
 
@@ -356,24 +128,7 @@ impl Gateway for SlackGateway {
     }
 
     async fn validate_config(&self) -> anyhow::Result<()> {
-        // Verify bot token
-        let resp: AuthTestResponse = self
-            .client
-            .post("https://slack.com/api/auth.test")
-            .bearer_auth(&self.bot_token)
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        if !resp.ok {
-            anyhow::bail!(
-                "Slack bot token validation failed: {}",
-                resp.error.unwrap_or_default()
-            );
-        }
-
-        Ok(())
+        self.get_bot_user_id().await.map(|_| ())
     }
 
     fn info(&self) -> HashMap<String, String> {
@@ -404,169 +159,4 @@ impl StreamResponder for SlackGateway {
     }
 
     // finalize_draft uses the default implementation from StreamResponder
-}
-
-fn websocket_reconnect_delay(attempts: u32) -> Option<std::time::Duration> {
-    if attempts >= MAX_RECONNECT_ATTEMPTS {
-        None
-    } else {
-        Some(std::time::Duration::from_secs(2u64.pow(attempts.min(5))))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_slack_max_len_constant() {
-        assert_eq!(SLACK_MAX_LEN, 4000);
-    }
-
-    #[test]
-    fn test_max_reconnect_attempts_constant() {
-        assert_eq!(MAX_RECONNECT_ATTEMPTS, 10);
-    }
-
-    #[test]
-    fn test_websocket_reconnect_delay_exhausted() {
-        assert!(websocket_reconnect_delay(MAX_RECONNECT_ATTEMPTS).is_none());
-        assert!(websocket_reconnect_delay(MAX_RECONNECT_ATTEMPTS - 1).is_some());
-    }
-
-    #[test]
-    fn test_websocket_reconnect_delay_growth() {
-        assert_eq!(
-            websocket_reconnect_delay(1).unwrap(),
-            std::time::Duration::from_secs(2)
-        );
-        assert_eq!(
-            websocket_reconnect_delay(5).unwrap(),
-            std::time::Duration::from_secs(32)
-        );
-    }
-
-    #[test]
-    fn test_websocket_reconnect_delay_full_sequence() {
-        // Verify the exponential capped sequence: 2, 4, 8, 16, 32, 32, 32, 32, 32
-        let delays: Vec<u64> = (1..MAX_RECONNECT_ATTEMPTS)
-            .map(|attempt| websocket_reconnect_delay(attempt).unwrap().as_secs())
-            .collect();
-        assert_eq!(delays, vec![2, 4, 8, 16, 32, 32, 32, 32, 32]);
-    }
-
-    #[test]
-    fn test_websocket_reconnect_delay_attempt_zero_is_one_second() {
-        assert_eq!(
-            websocket_reconnect_delay(0).unwrap(),
-            std::time::Duration::from_secs(1)
-        );
-    }
-
-    #[test]
-    fn test_metrics_store_records_reconnect_and_connect() {
-        use opengoose_types::ChannelMetricsStore;
-
-        let store = ChannelMetricsStore::new();
-
-        store.record_reconnect("slack", Some("connection refused".into()));
-        store.record_reconnect("slack", Some("timeout".into()));
-
-        let snap = store.snapshot();
-        assert_eq!(snap["slack"].reconnect_count, 2);
-        assert_eq!(snap["slack"].last_error.as_deref(), Some("timeout"));
-        assert!(snap["slack"].uptime_secs.is_none());
-
-        // Successful connect clears error and sets uptime
-        store.set_connected("slack");
-        let snap = store.snapshot();
-        assert_eq!(snap["slack"].reconnect_count, 2); // count preserved
-        assert!(snap["slack"].last_error.is_none()); // error cleared
-        assert!(snap["slack"].uptime_secs.is_some()); // uptime set
-    }
-
-    #[test]
-    fn test_event_bus_emits_channel_reconnecting() {
-        use opengoose_types::{AppEventKind, EventBus, Platform};
-
-        let bus = EventBus::new(16);
-        let mut rx = bus.subscribe();
-
-        bus.emit(AppEventKind::ChannelReconnecting {
-            platform: Platform::Slack,
-            attempt: 1,
-            delay_secs: 2,
-        });
-
-        let event = rx.try_recv().expect("event should be buffered");
-        assert!(matches!(
-            event.kind,
-            AppEventKind::ChannelReconnecting {
-                platform: Platform::Slack,
-                attempt: 1,
-                delay_secs: 2,
-            }
-        ));
-    }
-
-    #[test]
-    fn test_metrics_and_event_bus_coordination() {
-        use opengoose_types::{AppEventKind, ChannelMetricsStore, EventBus, Platform};
-
-        let store = ChannelMetricsStore::new();
-        let bus = EventBus::new(32);
-        let mut rx = bus.subscribe();
-
-        for attempt in 1..=3u32 {
-            let delay_secs = 2u64.pow(attempt.min(5));
-            store.record_reconnect("slack", Some(format!("attempt {attempt} failed")));
-            bus.emit(AppEventKind::ChannelReconnecting {
-                platform: Platform::Slack,
-                attempt,
-                delay_secs,
-            });
-        }
-
-        // Metrics reflects 3 attempts with the last error
-        let snap = store.snapshot();
-        assert_eq!(snap["slack"].reconnect_count, 3);
-        assert_eq!(
-            snap["slack"].last_error.as_deref(),
-            Some("attempt 3 failed")
-        );
-
-        // Event bus has 3 ChannelReconnecting events in order
-        for expected_attempt in 1..=3u32 {
-            let event = rx.try_recv().expect("event should be buffered");
-            match event.kind {
-                AppEventKind::ChannelReconnecting { attempt, .. } => {
-                    assert_eq!(attempt, expected_attempt);
-                }
-                _ => panic!("expected ChannelReconnecting event"),
-            }
-        }
-
-        // After connect: error cleared, uptime set, count remains cumulative
-        store.set_connected("slack");
-        let snap = store.snapshot();
-        assert!(snap["slack"].last_error.is_none());
-        assert!(snap["slack"].uptime_secs.is_some());
-        assert_eq!(snap["slack"].reconnect_count, 3);
-    }
-
-    #[test]
-    fn test_websocket_reconnect_delay_at_max_minus_one() {
-        let delay = websocket_reconnect_delay(MAX_RECONNECT_ATTEMPTS - 1);
-        assert!(delay.is_some());
-    }
-
-    #[test]
-    fn test_websocket_reconnect_delay_above_max_all_none() {
-        for attempt in MAX_RECONNECT_ATTEMPTS..=MAX_RECONNECT_ATTEMPTS + 5 {
-            assert!(
-                websocket_reconnect_delay(attempt).is_none(),
-                "expected None for attempt {attempt}"
-            );
-        }
-    }
 }

--- a/crates/opengoose-slack/src/gateway/socket.rs
+++ b/crates/opengoose-slack/src/gateway/socket.rs
@@ -1,0 +1,331 @@
+//! Slack Socket Mode connection and reconnect handling.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::tungstenite::Message as WsMessage;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use opengoose_types::{AppEventKind, Platform};
+
+use crate::types::{AuthTestResponse, ConnectionsOpenResponse, EnvelopeAck, SocketEnvelope};
+
+use super::{MAX_RECONNECT_ATTEMPTS, SlackGateway};
+
+impl SlackGateway {
+    /// Open a Socket Mode WebSocket connection.
+    async fn connect_websocket(&self) -> anyhow::Result<String> {
+        let resp: ConnectionsOpenResponse = self
+            .client
+            .post("https://slack.com/api/apps.connections.open")
+            .bearer_auth(&self.app_token)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if !resp.ok {
+            anyhow::bail!(
+                "apps.connections.open failed: {}",
+                resp.error.unwrap_or_default()
+            );
+        }
+
+        resp.url
+            .ok_or_else(|| anyhow::anyhow!("no WebSocket URL in response"))
+    }
+
+    /// Get the bot's user ID for filtering self-messages.
+    pub(super) async fn get_bot_user_id(&self) -> anyhow::Result<String> {
+        let resp: AuthTestResponse = self
+            .client
+            .post("https://slack.com/api/auth.test")
+            .bearer_auth(&self.bot_token)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if !resp.ok {
+            anyhow::bail!("auth.test failed: {}", resp.error.unwrap_or_default());
+        }
+
+        resp.user_id
+            .ok_or_else(|| anyhow::anyhow!("auth.test returned no user_id"))
+    }
+
+    fn emit_reconnect(&self, attempts: u32, error: String) -> Option<Duration> {
+        let delay = websocket_reconnect_delay(attempts)?;
+        self.metrics.record_reconnect("slack", Some(error));
+        self.event_bus.emit(AppEventKind::ChannelReconnecting {
+            platform: Platform::Slack,
+            attempt: attempts,
+            delay_secs: delay.as_secs(),
+        });
+        Some(delay)
+    }
+
+    /// Run the WebSocket event loop with reconnection support.
+    pub(super) async fn run_socket_mode(
+        &self,
+        cancel: &CancellationToken,
+        bot_user_id: &str,
+    ) -> anyhow::Result<()> {
+        let mut reconnect_attempts: u32 = 0;
+
+        loop {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            let ws_url = match self.connect_websocket().await {
+                Ok(url) => {
+                    reconnect_attempts = 0;
+                    url
+                }
+                Err(error) => {
+                    reconnect_attempts += 1;
+                    let Some(delay) = self.emit_reconnect(reconnect_attempts, error.to_string())
+                    else {
+                        return Err(error);
+                    };
+                    warn!(%error, ?delay, "failed to get WebSocket URL, retrying...");
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+            };
+
+            info!("connecting to slack socket mode");
+
+            let (ws_stream, _) = match tokio_tungstenite::connect_async(&ws_url).await {
+                Ok(connection) => connection,
+                Err(error) => {
+                    reconnect_attempts += 1;
+                    let Some(delay) = self.emit_reconnect(reconnect_attempts, error.to_string())
+                    else {
+                        return Err(error.into());
+                    };
+                    warn!(%error, ?delay, "WebSocket connect failed, retrying...");
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+            };
+
+            let (mut ws_write, mut ws_read) = ws_stream.split();
+
+            info!("slack socket mode connected");
+            self.metrics.set_connected("slack");
+
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        let _ = ws_write.close().await;
+                        return Ok(());
+                    }
+                    message = ws_read.next() => {
+                        match message {
+                            Some(Ok(WsMessage::Text(text))) => {
+                                let Ok(envelope) = serde_json::from_str::<SocketEnvelope>(&text) else {
+                                    continue;
+                                };
+
+                                let ack = EnvelopeAck {
+                                    envelope_id: envelope.envelope_id.clone(),
+                                    payload: None,
+                                };
+                                if let Ok(ack_json) = serde_json::to_string(&ack)
+                                    && ws_write
+                                        .send(WsMessage::Text(ack_json.into()))
+                                        .await
+                                        .is_err()
+                                {
+                                    warn!("failed to send ACK, reconnecting...");
+                                    break;
+                                }
+
+                                self.handle_envelope(&envelope, bot_user_id).await;
+                            }
+                            Some(Ok(WsMessage::Ping(data))) => {
+                                let _ = ws_write.send(WsMessage::Pong(data)).await;
+                            }
+                            Some(Ok(WsMessage::Close(_))) | None => {
+                                info!("slack WebSocket closed, reconnecting...");
+                                break;
+                            }
+                            Some(Err(error)) => {
+                                warn!(%error, "slack WebSocket error, reconnecting...");
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+
+        Ok(())
+    }
+}
+
+fn websocket_reconnect_delay(attempts: u32) -> Option<Duration> {
+    if attempts >= MAX_RECONNECT_ATTEMPTS {
+        None
+    } else {
+        Some(Duration::from_secs(2u64.pow(attempts.min(5))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slack_max_len_constant() {
+        assert_eq!(super::super::SLACK_MAX_LEN, 4000);
+    }
+
+    #[test]
+    fn test_max_reconnect_attempts_constant() {
+        assert_eq!(MAX_RECONNECT_ATTEMPTS, 10);
+    }
+
+    #[test]
+    fn test_websocket_reconnect_delay_exhausted() {
+        assert!(websocket_reconnect_delay(MAX_RECONNECT_ATTEMPTS).is_none());
+        assert!(websocket_reconnect_delay(MAX_RECONNECT_ATTEMPTS - 1).is_some());
+    }
+
+    #[test]
+    fn test_websocket_reconnect_delay_growth() {
+        assert_eq!(
+            websocket_reconnect_delay(1).unwrap(),
+            Duration::from_secs(2)
+        );
+        assert_eq!(
+            websocket_reconnect_delay(5).unwrap(),
+            Duration::from_secs(32)
+        );
+    }
+
+    #[test]
+    fn test_websocket_reconnect_delay_full_sequence() {
+        let delays: Vec<u64> = (1..MAX_RECONNECT_ATTEMPTS)
+            .map(|attempt| websocket_reconnect_delay(attempt).unwrap().as_secs())
+            .collect();
+        assert_eq!(delays, vec![2, 4, 8, 16, 32, 32, 32, 32, 32]);
+    }
+
+    #[test]
+    fn test_websocket_reconnect_delay_attempt_zero_is_one_second() {
+        assert_eq!(
+            websocket_reconnect_delay(0).unwrap(),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn test_metrics_store_records_reconnect_and_connect() {
+        use opengoose_types::ChannelMetricsStore;
+
+        let store = ChannelMetricsStore::new();
+
+        store.record_reconnect("slack", Some("connection refused".into()));
+        store.record_reconnect("slack", Some("timeout".into()));
+
+        let snap = store.snapshot();
+        assert_eq!(snap["slack"].reconnect_count, 2);
+        assert_eq!(snap["slack"].last_error.as_deref(), Some("timeout"));
+        assert!(snap["slack"].uptime_secs.is_none());
+
+        store.set_connected("slack");
+        let snap = store.snapshot();
+        assert_eq!(snap["slack"].reconnect_count, 2);
+        assert!(snap["slack"].last_error.is_none());
+        assert!(snap["slack"].uptime_secs.is_some());
+    }
+
+    #[test]
+    fn test_event_bus_emits_channel_reconnecting() {
+        use opengoose_types::{AppEventKind, EventBus, Platform};
+
+        let bus = EventBus::new(16);
+        let mut rx = bus.subscribe();
+
+        bus.emit(AppEventKind::ChannelReconnecting {
+            platform: Platform::Slack,
+            attempt: 1,
+            delay_secs: 2,
+        });
+
+        let event = rx.try_recv().expect("event should be buffered");
+        assert!(matches!(
+            event.kind,
+            AppEventKind::ChannelReconnecting {
+                platform: Platform::Slack,
+                attempt: 1,
+                delay_secs: 2,
+            }
+        ));
+    }
+
+    #[test]
+    fn test_metrics_and_event_bus_coordination() {
+        use opengoose_types::{AppEventKind, ChannelMetricsStore, EventBus, Platform};
+
+        let store = ChannelMetricsStore::new();
+        let bus = EventBus::new(32);
+        let mut rx = bus.subscribe();
+
+        for attempt in 1..=3u32 {
+            let delay_secs = 2u64.pow(attempt.min(5));
+            store.record_reconnect("slack", Some(format!("attempt {attempt} failed")));
+            bus.emit(AppEventKind::ChannelReconnecting {
+                platform: Platform::Slack,
+                attempt,
+                delay_secs,
+            });
+        }
+
+        let snap = store.snapshot();
+        assert_eq!(snap["slack"].reconnect_count, 3);
+        assert_eq!(
+            snap["slack"].last_error.as_deref(),
+            Some("attempt 3 failed")
+        );
+
+        for expected_attempt in 1..=3u32 {
+            let event = rx.try_recv().expect("event should be buffered");
+            match event.kind {
+                AppEventKind::ChannelReconnecting { attempt, .. } => {
+                    assert_eq!(attempt, expected_attempt);
+                }
+                _ => panic!("expected ChannelReconnecting event"),
+            }
+        }
+
+        store.set_connected("slack");
+        let snap = store.snapshot();
+        assert!(snap["slack"].last_error.is_none());
+        assert!(snap["slack"].uptime_secs.is_some());
+        assert_eq!(snap["slack"].reconnect_count, 3);
+    }
+
+    #[test]
+    fn test_websocket_reconnect_delay_at_max_minus_one() {
+        let delay = websocket_reconnect_delay(MAX_RECONNECT_ATTEMPTS - 1);
+        assert!(delay.is_some());
+    }
+
+    #[test]
+    fn test_websocket_reconnect_delay_above_max_all_none() {
+        for attempt in MAX_RECONNECT_ATTEMPTS..=MAX_RECONNECT_ATTEMPTS + 5 {
+            assert!(
+                websocket_reconnect_delay(attempt).is_none(),
+                "expected None for attempt {attempt}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- split the Slack gateway Socket Mode lifecycle into a dedicated `socket.rs` module
- move envelope dispatch and `/team` command orchestration into `dispatch.rs`
- keep `mod.rs` focused on the gateway struct, constructors, and trait impls while adding five command helper tests

## Testing
- cargo test -p opengoose-slack gateway
- cargo test -p opengoose-slack
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
