### PR TITLE
refactor: split telegram gateway runtime helpers [OPE-414]

### DIFF
--- a/crates/opengoose-telegram/src/gateway/delivery.rs
+++ b/crates/opengoose-telegram/src/gateway/delivery.rs
@@ -1,0 +1,35 @@
+use goose::gateway::{Gateway, OutgoingMessage, PlatformUser};
+
+use opengoose_types::SessionKey;
+
+use super::TelegramGateway;
+
+impl TelegramGateway {
+    pub(crate) async fn deliver_outgoing_message(
+        &self,
+        user: &PlatformUser,
+        message: OutgoingMessage,
+    ) -> anyhow::Result<()> {
+        let raw_user = self.raw_recipient(user, &message).await;
+        self.inner.send_message(&raw_user, message).await
+    }
+
+    async fn raw_recipient(&self, user: &PlatformUser, message: &OutgoingMessage) -> PlatformUser {
+        PlatformUser {
+            platform: user.platform.clone(),
+            user_id: self.raw_channel_id(&user.user_id, message).await,
+            display_name: user.display_name.clone(),
+        }
+    }
+
+    async fn raw_channel_id(&self, user_id: &str, message: &OutgoingMessage) -> String {
+        match message {
+            OutgoingMessage::Text { body } => {
+                self.bridge
+                    .route_outgoing_text(user_id, body, "telegram")
+                    .await
+            }
+            _ => SessionKey::from_stable_id(user_id).channel_id,
+        }
+    }
+}

--- a/crates/opengoose-telegram/src/gateway/mod.rs
+++ b/crates/opengoose-telegram/src/gateway/mod.rs
@@ -9,17 +9,19 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tracing::{debug, error, info, warn};
 
 use goose::gateway::handler::GatewayHandler;
 use goose::gateway::telegram::TelegramGateway as GooseTelegramGateway;
 use goose::gateway::{Gateway, GatewayConfig, OutgoingMessage, PlatformUser};
 use tokio_util::sync::CancellationToken;
 
-use opengoose_core::{GatewayBridge, StreamResponder};
-use opengoose_types::{AppEventKind, EventBus, Platform, SessionKey};
+use opengoose_core::GatewayBridge;
+use opengoose_types::{EventBus, Platform, SessionKey};
 
 mod commands;
+mod delivery;
+mod polling;
+mod relay;
 mod streaming;
 mod types;
 pub(crate) use types::*;
@@ -110,48 +112,6 @@ impl TelegramGateway {
         Self::build(bot_token.into(), bridge, event_bus, api_base_url.into())
     }
 
-    /// Long-poll for updates from Telegram.
-    /// This must be implemented here (not delegated) because we intercept
-    /// messages for /team commands and bridge routing before goose sees them.
-    async fn get_updates(&self, offset: Option<i64>) -> anyhow::Result<Vec<Update>> {
-        let mut params = serde_json::json!({ "timeout": 30 });
-        if let Some(off) = offset {
-            params["offset"] = serde_json::json!(off);
-        }
-
-        let resp: TelegramResponse<Vec<Update>> = self
-            .client
-            .post(self.api_url("getUpdates"))
-            .json(&params)
-            .send()
-            .await?
-            .json()
-            .await?;
-
-        if !resp.ok {
-            anyhow::bail!(
-                "getUpdates failed: {}",
-                resp.description.unwrap_or_default()
-            );
-        }
-
-        Ok(resp.result.unwrap_or_default())
-    }
-
-    /// Get the bot's username for mention stripping.
-    async fn get_bot_username(&self) -> Option<String> {
-        let resp: TelegramResponse<BotInfo> = self
-            .client
-            .post(self.api_url("getMe"))
-            .send()
-            .await
-            .ok()?
-            .json()
-            .await
-            .ok()?;
-        resp.result.and_then(|b| b.username)
-    }
-
     /// Build a SessionKey from a Telegram chat.
     fn session_key(chat: &Chat) -> SessionKey {
         let chat_id = chat.id.to_string();
@@ -174,142 +134,7 @@ impl Gateway for TelegramGateway {
         cancel: CancellationToken,
     ) -> anyhow::Result<()> {
         self.bridge.on_start(handler).await;
-
-        let bot_username = self.get_bot_username().await.unwrap_or_default();
-        info!(bot_username = %bot_username, "telegram gateway starting");
-
-        let mut offset: Option<i64> = None;
-        let mut ready_emitted = false;
-        let mut reconnect_attempts: u32 = 0;
-
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => {
-                    info!("telegram gateway shutting down");
-                    self.event_bus.emit(AppEventKind::ChannelDisconnected {
-                        platform: Platform::Telegram,
-                        reason: "shutdown".into(),
-                    });
-                    break;
-                }
-                result = self.get_updates(offset) => {
-                    match result {
-                        Ok(updates) => {
-                            reconnect_attempts = 0;
-                            // Emit ready only after first successful poll
-                            if !ready_emitted {
-                                info!("telegram gateway connected");
-                                self.event_bus.emit(AppEventKind::ChannelReady {
-                                    platform: Platform::Telegram,
-                                });
-                                ready_emitted = true;
-                            }
-                            for update in updates {
-                                offset = Some(update.update_id + 1);
-
-                                let Some(msg) = update.message else {
-                                    continue;
-                                };
-
-                                // Check for /team command
-                                if let Some(args) = Self::is_bot_command(&msg) {
-                                    let session_key = Self::session_key(&msg.chat);
-                                    if let Err(e) = self.handle_team_command(&session_key, args, msg.chat.id).await {
-                                        error!(%e, "failed to handle /team command");
-                                    }
-                                    continue;
-                                }
-
-                                let Some(text) = msg.text.as_deref() else {
-                                    continue;
-                                };
-
-                                // Strip @botname mention in groups
-                                let text = if msg.chat.chat_type != "private" && !bot_username.is_empty() {
-                                    Self::strip_mention(text, &bot_username)
-                                } else {
-                                    text
-                                };
-
-                                let text = text.trim();
-                                if text.is_empty() {
-                                    continue;
-                                }
-
-                                let session_key = Self::session_key(&msg.chat);
-                                let display_name = msg.from.as_ref().map(|u| {
-                                    match &u.last_name {
-                                        Some(last) => format!("{} {}", u.first_name, last),
-                                        None => u.first_name.clone(),
-                                    }
-                                });
-
-                                if !self.bridge.is_accepting_messages() {
-                                    info!(chat_id = msg.chat.id, "ignoring telegram message during shutdown drain");
-                                    continue;
-                                }
-
-                                debug!(
-                                    chat_id = msg.chat.id,
-                                    chat_type = %msg.chat.chat_type,
-                                    text_len = text.len(),
-                                    "relaying telegram message to engine"
-                                );
-
-                                // Send typing indicator via goose's gateway
-                                let user = Self::platform_user(msg.chat.id);
-                                let _ = self.inner.send_message(&user, OutgoingMessage::Typing).await;
-
-                                let chat_id_str = msg.chat.id.to_string();
-                                if let Err(e) = self.bridge.relay_and_drive_stream(
-                                    &session_key,
-                                    display_name,
-                                    text,
-                                    self as &dyn StreamResponder,
-                                    &chat_id_str,
-                                    opengoose_core::ThrottlePolicy::telegram(),
-                                    TELEGRAM_MAX_LEN,
-                                ).await {
-                                    // Error event is emitted by bridge; just log here
-                                    error!(%e, "failed to relay telegram message");
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            reconnect_attempts += 1;
-                            if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
-                                let reason = format!("getUpdates failed after {MAX_RECONNECT_ATTEMPTS} attempts: {e}");
-                                error!(%e, "telegram gateway giving up after max reconnect attempts");
-                                self.event_bus.emit(AppEventKind::ChannelDisconnected {
-                                    platform: Platform::Telegram,
-                                    reason: reason.clone(),
-                                });
-                                self.event_bus.emit(AppEventKind::Error {
-                                    context: "telegram".into(),
-                                    message: reason,
-                                });
-                                break;
-                            }
-                            let delay = Duration::from_secs(2u64.pow(reconnect_attempts.min(5)));
-                            warn!(%e, attempt = reconnect_attempts, ?delay, "telegram getUpdates error, retrying...");
-                            tokio::select! {
-                                _ = cancel.cancelled() => {
-                                    info!("telegram gateway shutting down during reconnect");
-                                    self.event_bus.emit(AppEventKind::ChannelDisconnected {
-                                        platform: Platform::Telegram,
-                                        reason: "shutdown".into(),
-                                    });
-                                    break;
-                                }
-                                _ = tokio::time::sleep(delay) => {}
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(())
+        self.run_polling_loop(cancel).await
     }
 
     async fn send_message(
@@ -317,23 +142,7 @@ impl Gateway for TelegramGateway {
         user: &PlatformUser,
         message: OutgoingMessage,
     ) -> anyhow::Result<()> {
-        // Extract the raw chat_id once (e.g. "telegram:direct:12345" -> "12345")
-        // because goose's TelegramGateway expects a raw Telegram chat ID.
-        let raw_channel_id = if let OutgoingMessage::Text { ref body } = message {
-            // Bridge handles persistence, pairing detection, events, and channel routing.
-            self.bridge
-                .route_outgoing_text(&user.user_id, body, "telegram")
-                .await
-        } else {
-            SessionKey::from_stable_id(&user.user_id).channel_id
-        };
-
-        let raw_user = PlatformUser {
-            platform: user.platform.clone(),
-            user_id: raw_channel_id,
-            display_name: user.display_name.clone(),
-        };
-        self.inner.send_message(&raw_user, message).await
+        self.deliver_outgoing_message(user, message).await
     }
 
     async fn validate_config(&self) -> anyhow::Result<()> {

--- a/crates/opengoose-telegram/src/gateway/polling.rs
+++ b/crates/opengoose-telegram/src/gateway/polling.rs
@@ -1,0 +1,126 @@
+use std::time::Duration;
+
+use tracing::{error, info, warn};
+
+use opengoose_types::{AppEventKind, Platform};
+use tokio_util::sync::CancellationToken;
+
+use super::{BotInfo, TelegramGateway, TelegramResponse, Update};
+
+impl TelegramGateway {
+    pub(crate) async fn run_polling_loop(&self, cancel: CancellationToken) -> anyhow::Result<()> {
+        let bot_username = self.get_bot_username().await.unwrap_or_default();
+        info!(bot_username = %bot_username, "telegram gateway starting");
+
+        let mut offset: Option<i64> = None;
+        let mut ready_emitted = false;
+        let mut reconnect_attempts: u32 = 0;
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => {
+                    info!("telegram gateway shutting down");
+                    self.emit_disconnect("shutdown");
+                    break;
+                }
+                result = self.get_updates(offset) => {
+                    match result {
+                        Ok(updates) => {
+                            reconnect_attempts = 0;
+                            if !ready_emitted {
+                                info!("telegram gateway connected");
+                                self.event_bus.emit(AppEventKind::ChannelReady {
+                                    platform: Platform::Telegram,
+                                });
+                                ready_emitted = true;
+                            }
+
+                            for update in updates {
+                                offset = Some(update.update_id + 1);
+                                self.handle_update(update, &bot_username).await;
+                            }
+                        }
+                        Err(e) => {
+                            reconnect_attempts += 1;
+                            if reconnect_attempts >= super::MAX_RECONNECT_ATTEMPTS {
+                                let reason = format!(
+                                    "getUpdates failed after {} attempts: {e}",
+                                    super::MAX_RECONNECT_ATTEMPTS
+                                );
+                                error!(%e, "telegram gateway giving up after max reconnect attempts");
+                                self.emit_disconnect(reason.clone());
+                                self.event_bus.emit(AppEventKind::Error {
+                                    context: "telegram".into(),
+                                    message: reason,
+                                });
+                                break;
+                            }
+
+                            let delay = Self::reconnect_delay(reconnect_attempts);
+                            warn!(%e, attempt = reconnect_attempts, ?delay, "telegram getUpdates error, retrying...");
+                            tokio::select! {
+                                _ = cancel.cancelled() => {
+                                    info!("telegram gateway shutting down during reconnect");
+                                    self.emit_disconnect("shutdown");
+                                    break;
+                                }
+                                _ = tokio::time::sleep(delay) => {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn get_updates(&self, offset: Option<i64>) -> anyhow::Result<Vec<Update>> {
+        let mut params = serde_json::json!({ "timeout": 30 });
+        if let Some(off) = offset {
+            params["offset"] = serde_json::json!(off);
+        }
+
+        let resp: TelegramResponse<Vec<Update>> = self
+            .client
+            .post(self.api_url("getUpdates"))
+            .json(&params)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        if !resp.ok {
+            anyhow::bail!(
+                "getUpdates failed: {}",
+                resp.description.unwrap_or_default()
+            );
+        }
+
+        Ok(resp.result.unwrap_or_default())
+    }
+
+    async fn get_bot_username(&self) -> Option<String> {
+        let resp: TelegramResponse<BotInfo> = self
+            .client
+            .post(self.api_url("getMe"))
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
+        resp.result.and_then(|bot| bot.username)
+    }
+
+    fn emit_disconnect(&self, reason: impl Into<String>) {
+        self.event_bus.emit(AppEventKind::ChannelDisconnected {
+            platform: Platform::Telegram,
+            reason: reason.into(),
+        });
+    }
+
+    pub(crate) fn reconnect_delay(reconnect_attempts: u32) -> Duration {
+        Duration::from_secs(2u64.pow(reconnect_attempts.min(5)))
+    }
+}

--- a/crates/opengoose-telegram/src/gateway/relay.rs
+++ b/crates/opengoose-telegram/src/gateway/relay.rs
@@ -1,0 +1,144 @@
+use tracing::{debug, error, info};
+
+use goose::gateway::{Gateway, OutgoingMessage};
+
+use opengoose_core::{StreamResponder, ThrottlePolicy};
+
+use super::{TELEGRAM_MAX_LEN, TelegramGateway, TelegramMessage, Update, User};
+
+impl TelegramGateway {
+    pub(crate) async fn handle_update(&self, update: Update, bot_username: &str) {
+        let Some(message) = update.message else {
+            return;
+        };
+
+        self.handle_incoming_message(message, bot_username).await;
+    }
+
+    async fn handle_incoming_message(&self, message: TelegramMessage, bot_username: &str) {
+        if let Some(args) = Self::is_bot_command(&message) {
+            let session_key = Self::session_key(&message.chat);
+            if let Err(e) = self
+                .handle_team_command(&session_key, args, message.chat.id)
+                .await
+            {
+                error!(%e, "failed to handle /team command");
+            }
+            return;
+        }
+
+        let Some(text) = Self::normalized_message_text(&message, bot_username) else {
+            return;
+        };
+
+        let session_key = Self::session_key(&message.chat);
+        let display_name = Self::display_name(message.from.as_ref());
+
+        if !self.bridge.is_accepting_messages() {
+            info!(
+                chat_id = message.chat.id,
+                "ignoring telegram message during shutdown drain"
+            );
+            return;
+        }
+
+        debug!(
+            chat_id = message.chat.id,
+            chat_type = %message.chat.chat_type,
+            text_len = text.len(),
+            "relaying telegram message to engine"
+        );
+
+        let typing_user = Self::platform_user(message.chat.id);
+        let _ = self
+            .inner
+            .send_message(&typing_user, OutgoingMessage::Typing)
+            .await;
+
+        let chat_id = message.chat.id.to_string();
+        if let Err(e) = self
+            .bridge
+            .relay_and_drive_stream(
+                &session_key,
+                display_name,
+                text,
+                self as &dyn StreamResponder,
+                &chat_id,
+                ThrottlePolicy::telegram(),
+                TELEGRAM_MAX_LEN,
+            )
+            .await
+        {
+            error!(%e, "failed to relay telegram message");
+        }
+    }
+
+    fn normalized_message_text<'a>(
+        message: &'a TelegramMessage,
+        bot_username: &str,
+    ) -> Option<&'a str> {
+        let text = message.text.as_deref()?;
+        let text = if message.chat.chat_type != "private" && !bot_username.is_empty() {
+            Self::strip_mention(text, bot_username)
+        } else {
+            text
+        };
+
+        let text = text.trim();
+        (!text.is_empty()).then_some(text)
+    }
+
+    pub(crate) fn display_name(user: Option<&User>) -> Option<String> {
+        user.map(|user| match &user.last_name {
+            Some(last_name) => format!("{} {}", user.first_name, last_name),
+            None => user.first_name.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gateway::types::{Chat, TelegramMessage};
+
+    use super::*;
+
+    fn message(chat_type: &str, text: Option<&str>) -> TelegramMessage {
+        TelegramMessage {
+            message_id: 1,
+            chat: Chat {
+                id: 1,
+                chat_type: chat_type.to_string(),
+            },
+            from: None,
+            text: text.map(str::to_string),
+            entities: None,
+        }
+    }
+
+    #[test]
+    fn normalized_message_text_strips_group_mentions_and_whitespace() {
+        let message = message("group", Some("@my_bot   hello  "));
+        assert_eq!(
+            TelegramGateway::normalized_message_text(&message, "my_bot"),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn normalized_message_text_preserves_private_message_mentions() {
+        let message = message("private", Some("@my_bot hello"));
+        assert_eq!(
+            TelegramGateway::normalized_message_text(&message, "my_bot"),
+            Some("@my_bot hello")
+        );
+    }
+
+    #[test]
+    fn normalized_message_text_skips_empty_results() {
+        let message = message("group", Some("@my_bot   "));
+        assert_eq!(
+            TelegramGateway::normalized_message_text(&message, "my_bot"),
+            None
+        );
+    }
+}

--- a/crates/opengoose-telegram/src/gateway/tests.rs
+++ b/crates/opengoose-telegram/src/gateway/tests.rs
@@ -114,9 +114,8 @@ fn test_request_timeout_constant() {
 
 #[test]
 fn test_reconnect_delay_exponential_backoff() {
-    // Production code: Duration::from_secs(2u64.pow(reconnect_attempts.min(5)))
     let delays: Vec<u64> = (1u32..=10)
-        .map(|attempt| 2u64.pow(attempt.min(5)))
+        .map(|attempt| TelegramGateway::reconnect_delay(attempt).as_secs())
         .collect();
     assert_eq!(delays[0], 2); // attempt 1 → 2s
     assert_eq!(delays[1], 4); // attempt 2 → 4s
@@ -131,26 +130,32 @@ fn test_reconnect_delay_exponential_backoff() {
 
 #[test]
 fn test_display_name_with_last_name() {
-    // When last_name is present: "first last"
-    let first_name = "Alice";
-    let last_name = Some("Smith".to_string());
-    let display_name = match &last_name {
-        Some(last) => format!("{} {}", first_name, last),
-        None => first_name.to_string(),
+    let user = User {
+        id: 1,
+        first_name: "Alice".to_string(),
+        last_name: Some("Smith".to_string()),
+        username: None,
     };
-    assert_eq!(display_name, "Alice Smith");
+
+    assert_eq!(
+        TelegramGateway::display_name(Some(&user)).as_deref(),
+        Some("Alice Smith")
+    );
 }
 
 #[test]
 fn test_display_name_first_name_only() {
-    // When last_name is absent: just first_name
-    let first_name = "Bob";
-    let last_name: Option<String> = None;
-    let display_name = match &last_name {
-        Some(last) => format!("{} {}", first_name, last),
-        None => first_name.to_string(),
+    let user = User {
+        id: 1,
+        first_name: "Bob".to_string(),
+        last_name: None,
+        username: None,
     };
-    assert_eq!(display_name, "Bob");
+
+    assert_eq!(
+        TelegramGateway::display_name(Some(&user)).as_deref(),
+        Some("Bob")
+    );
 }
 
 // --- Telegram Bot API URL format ---


### PR DESCRIPTION
## Summary
- split the Telegram gateway runtime so `mod.rs` delegates polling/reconnect lifecycle, incoming relay handling, and outgoing delivery routing to focused helpers
- keep `/team` command handling, mention stripping, typing indicators, bridge streaming, and raw chat-id delivery behavior unchanged
- add relay helper coverage and point existing reconnect/display-name tests at the extracted helper methods

## Verification
- `cargo fmt --all`
- `cargo clippy -p opengoose-telegram --all-targets -- -D warnings`
- `cargo test -p opengoose-telegram`
- `cargo test`

## Paperclip
- Issue: `OPE-414`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
