### PR TITLE
Add security hardening: redact sensitive data and limit input size

### DIFF
--- a/crates/opengoose-persistence/src/event_store/types.rs
+++ b/crates/opengoose-persistence/src/event_store/types.rs
@@ -83,6 +83,17 @@ pub(super) struct NewStoredEvent {
     payload: String,
 }
 
+impl std::fmt::Debug for NewStoredEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NewStoredEvent")
+            .field("event_kind", &self.event_kind)
+            .field("source_gateway", &self.source_gateway)
+            .field("session_key", &"<redacted>")
+            .field("payload", &"<redacted>")
+            .finish()
+    }
+}
+
 impl NewStoredEvent {
     pub(super) fn from_kind(kind: &AppEventKind) -> PersistenceResult<Self> {
         let payload = serde_json::to_string(kind)

--- a/crates/opengoose-persistence/src/models.rs
+++ b/crates/opengoose-persistence/src/models.rs
@@ -200,6 +200,17 @@ pub struct NewEventHistory<'a> {
     pub payload: &'a str,
 }
 
+impl std::fmt::Debug for NewEventHistory<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NewEventHistory")
+            .field("event_kind", &self.event_kind)
+            .field("source_gateway", &self.source_gateway)
+            .field("session_key", &"<redacted>")
+            .field("payload", &"<redacted>")
+            .finish()
+    }
+}
+
 // ── Agent Messages ──
 
 #[derive(Queryable, Selectable)]

--- a/crates/opengoose-web/src/handlers/triggers/validation.rs
+++ b/crates/opengoose-web/src/handlers/triggers/validation.rs
@@ -42,12 +42,17 @@ pub(super) fn validate_update_request(
     })
 }
 
+/// Maximum number of characters accepted as test-run input from the request body.
+/// Prevents unbounded memory allocation from a maliciously large request body.
+const MAX_TEST_INPUT_CHARS: usize = 65_536;
+
 pub(super) fn resolve_test_input(
     trigger: &Trigger,
     body: Option<TestTriggerRequest>,
     name: &str,
 ) -> String {
     body.and_then(|payload| payload.input)
+        .map(|value| value.chars().take(MAX_TEST_INPUT_CHARS).collect::<String>())
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| {

--- a/crates/opengoose-web/src/handlers/webhooks/tests.rs
+++ b/crates/opengoose-web/src/handlers/webhooks/tests.rs
@@ -15,6 +15,8 @@ use crate::state::AppState;
 
 /// Test-only HMAC secret — never used outside of unit tests.
 const TEST_HMAC_SECRET: &str = "test-only-hmac-secret";
+/// Test-only HMAC secret for custom-header tests — never used outside of unit tests.
+const TEST_SIG_SECRET: &str = "test-only-sig-secret";
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -202,7 +204,7 @@ async fn test_valid_hmac_signature_with_custom_headers_returns_200() {
         .create(
             "signed-hook",
             "webhook_received",
-            r#"{"path":"/signed","hmac_secret":"sig-secret","signature_header":"X-Hub-Signature-256","timestamp_header":"X-Hub-Timestamp"}"#,
+            &format!(r#"{{"path":"/signed","hmac_secret":"{TEST_SIG_SECRET}","signature_header":"X-Hub-Signature-256","timestamp_header":"X-Hub-Timestamp"}}"#),
             "my-team",
             "",
         )
@@ -211,7 +213,7 @@ async fn test_valid_hmac_signature_with_custom_headers_returns_200() {
     let app = router(state);
     let timestamp = Utc::now().timestamp().to_string();
     let body = r#"{"event":"push"}"#;
-    let signature = signed_signature("sig-secret", &timestamp, body.as_bytes());
+    let signature = signed_signature(TEST_SIG_SECRET, &timestamp, body.as_bytes());
 
     let req = Request::builder()
         .method("POST")
@@ -319,7 +321,7 @@ async fn test_missing_custom_hmac_headers_returns_401() {
         .create(
             "signed-hook",
             "webhook_received",
-            r#"{"path":"/signed","hmac_secret":"sig-secret","signature_header":"X-Hub-Signature-256","timestamp_header":"X-Hub-Timestamp"}"#,
+            &format!(r#"{{"path":"/signed","hmac_secret":"{TEST_SIG_SECRET}","signature_header":"X-Hub-Signature-256","timestamp_header":"X-Hub-Timestamp"}}"#),
             "my-team",
             "",
         )
@@ -329,7 +331,7 @@ async fn test_missing_custom_hmac_headers_returns_401() {
 
     let timestamp = Utc::now().timestamp().to_string();
     let body = r#"{"event":"push"}"#;
-    let signature = signed_signature("sig-secret", &timestamp, body.as_bytes());
+    let signature = signed_signature(TEST_SIG_SECRET, &timestamp, body.as_bytes());
 
     let req = Request::builder()
         .method("POST")


### PR DESCRIPTION
## Summary
This PR implements security improvements across the persistence and webhook handling layers by redacting sensitive information in debug output and enforcing input size limits to prevent denial-of-service attacks.

## Key Changes

- **Redact sensitive data in Debug implementations**: Added custom `Debug` trait implementations for `NewStoredEvent` and `NewEventHistory` structs that redact `session_key` and `payload` fields to prevent accidental exposure of sensitive information in logs and error messages.

- **Enforce input size limits**: Added `MAX_TEST_INPUT_CHARS` constant (65,536 characters) in trigger validation to prevent unbounded memory allocation from maliciously large request bodies during test trigger execution.

- **Improve test constants**: Extracted hardcoded HMAC secret string into a reusable `TEST_SIG_SECRET` constant in webhook tests for better maintainability and consistency.

## Implementation Details

- The custom `Debug` implementations replace sensitive field values with `"<redacted>"` placeholders while preserving visibility of non-sensitive metadata like `event_kind` and `source_gateway`.
- Input truncation is applied before trimming and filtering to ensure the size limit is enforced at the earliest point.
- Test constants are now centralized, making it easier to update test credentials and reducing the risk of inconsistencies.

https://claude.ai/code/session_01N3En2hE1Dh7wC6QryEkhak
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
