### PR TITLE
Add trigger matching edge-case coverage

### DIFF
--- a/crates/opengoose-teams/src/triggers/evaluation.rs
+++ b/crates/opengoose-teams/src/triggers/evaluation.rs
@@ -226,8 +226,9 @@ pub fn matches_file_watch_event(condition_json: &str, path: &str) -> bool {
     };
 
     let pattern = match &cond.pattern {
-        Some(p) => p,
+        Some(p) if !p.is_empty() => p,
         None => return true,
+        Some(_) => return true,
     };
 
     let glob = match globset::Glob::new(pattern) {

--- a/crates/opengoose-teams/src/triggers/tests/matching.rs
+++ b/crates/opengoose-teams/src/triggers/tests/matching.rs
@@ -35,6 +35,18 @@ fn test_matches_message_payload_contains() {
 }
 
 #[test]
+fn test_matches_message_empty_payload_contains_matches_any_payload() {
+    let cond = r#"{"payload_contains":""}"#;
+    assert!(matches_message_event(cond, "any", None, ""));
+    assert!(matches_message_event(
+        cond,
+        "any",
+        Some("alerts"),
+        "all good"
+    ));
+}
+
+#[test]
 fn test_matches_message_combined() {
     let cond = r#"{"from_agent":"monitor","channel":"alerts","payload_contains":"critical"}"#;
     assert!(matches_message_event(
@@ -95,6 +107,13 @@ fn test_matches_on_message_content_contains_filter() {
     let cond = r#"{"content_contains":"alert"}"#;
     assert!(matches_on_message_event(cond, "any", "critical alert!"));
     assert!(!matches_on_message_event(cond, "any", "all good"));
+}
+
+#[test]
+fn test_matches_on_message_empty_content_filter_matches_any_content() {
+    let cond = r#"{"content_contains":""}"#;
+    assert!(matches_on_message_event(cond, "alice", ""));
+    assert!(matches_on_message_event(cond, "alice", "all good"));
 }
 
 #[test]
@@ -180,6 +199,14 @@ fn test_matches_file_watch_no_pattern_matches_all() {
 }
 
 #[test]
+fn test_matches_file_watch_empty_pattern_matches_all() {
+    let cond = r#"{"pattern":""}"#;
+    assert!(matches_file_watch_event(cond, "src/main.rs"));
+    assert!(matches_file_watch_event(cond, "/tmp/foo.log"));
+    assert!(matches_file_watch_event(cond, ""));
+}
+
+#[test]
 fn test_matches_file_watch_simple_glob() {
     let cond = r#"{"pattern":"src/**/*.rs"}"#;
     assert!(matches_file_watch_event(cond, "src/lib.rs"));
@@ -237,6 +264,14 @@ fn test_matches_webhook_path_no_path_matches_all() {
     assert!(matches_webhook_path("{}", "/github/pr"));
     assert!(matches_webhook_path("{}", "/any/path"));
     assert!(matches_webhook_path("{}", ""));
+}
+
+#[test]
+fn test_matches_webhook_path_empty_prefix_matches_all() {
+    let cond = r#"{"path":""}"#;
+    assert!(matches_webhook_path(cond, "/github/pr"));
+    assert!(matches_webhook_path(cond, "/any/path"));
+    assert!(matches_webhook_path(cond, ""));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add focused trigger matching tests for empty payload/content/path edge cases
- fix file-watch evaluation so an empty pattern matches all paths as documented
- verify the trigger test suite in opengoose-teams passes in the worktree

## Testing
- cargo test -p opengoose-teams triggers::tests -- --nocapture
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
