### PR TITLE
test: split live snapshot and event tests [OPE-506]

### DIFF
--- a/crates/opengoose-web/src/live/tests/event_changes.rs
+++ b/crates/opengoose-web/src/live/tests/event_changes.rs
@@ -1,65 +1,8 @@
-use std::sync::Arc;
+use opengoose_types::{AppEventKind, EventBus};
 
-use opengoose_persistence::Database;
-use opengoose_types::{AppEvent, AppEventKind, EventBus};
-
-use super::changes::emit_live_snapshot_changes;
-use super::snapshot::{LiveSnapshot, capture_live_snapshot};
-
-fn make_db() -> Arc<Database> {
-    Arc::new(Database::open_in_memory().expect("in-memory db"))
-}
-
-// -- capture_live_snapshot --------------------------------------------------
-
-#[test]
-fn capture_live_snapshot_empty_db_returns_defaults() {
-    let db = make_db();
-    let snap = capture_live_snapshot(db).expect("snapshot should succeed");
-    assert!(snap.sessions.is_empty());
-    assert!(snap.runs.is_empty());
-    assert_eq!(snap.queue.pending, 0);
-    assert_eq!(snap.queue.processing, 0);
-    assert_eq!(snap.queue.completed, 0);
-    assert_eq!(snap.queue.failed, 0);
-    assert_eq!(snap.queue.dead, 0);
-    assert!(snap.queue.last_message_id.is_none());
-    assert!(snap.queue.last_team_run_id.is_none());
-}
-
-#[test]
-fn capture_live_snapshot_with_session_populates_sessions() {
-    use opengoose_persistence::SessionStore;
-    use opengoose_types::{Platform, SessionKey};
-
-    let db = make_db();
-    let session_store = SessionStore::new(db.clone());
-    let key = SessionKey::new(Platform::Discord, "guild-1", "channel-1");
-    session_store
-        .append_user_message(&key, "hello", Some("user"))
-        .expect("append should succeed");
-
-    let snap = capture_live_snapshot(db).expect("snapshot should succeed");
-    assert_eq!(snap.sessions.len(), 1);
-    assert!(snap.sessions.contains_key(&key.to_stable_id()));
-}
-
-#[test]
-fn capture_live_snapshot_is_ok_result() {
-    let db = make_db();
-    let result = capture_live_snapshot(db);
-    assert!(result.is_ok());
-}
-
-// -- emit_live_snapshot_changes ---------------------------------------------
-
-fn drain_events(rx: &mut tokio::sync::broadcast::Receiver<AppEvent>) -> Vec<AppEventKind> {
-    let mut events = Vec::new();
-    while let Ok(ev) = rx.try_recv() {
-        events.push(ev.kind);
-    }
-    events
-}
+use super::super::changes::emit_live_snapshot_changes;
+use super::super::snapshot::LiveSnapshot;
+use super::drain_events;
 
 #[test]
 fn identical_snapshots_emit_no_events() {
@@ -91,13 +34,13 @@ fn new_session_emits_session_updated_and_dashboard_updated() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::SessionUpdated { .. })),
+            .any(|event| matches!(event, AppEventKind::SessionUpdated { .. })),
         "expected SessionUpdated",
     );
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::DashboardUpdated)),
+            .any(|event| matches!(event, AppEventKind::DashboardUpdated)),
         "expected DashboardUpdated",
     );
 }
@@ -125,13 +68,13 @@ fn updated_session_timestamp_emits_session_updated() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::SessionUpdated { .. })),
+            .any(|event| matches!(event, AppEventKind::SessionUpdated { .. })),
         "expected SessionUpdated on timestamp change",
     );
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::DashboardUpdated)),
+            .any(|event| matches!(event, AppEventKind::DashboardUpdated)),
         "expected DashboardUpdated",
     );
 }
@@ -154,7 +97,7 @@ fn session_removed_emits_dashboard_updated() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::DashboardUpdated)),
+            .any(|event| matches!(event, AppEventKind::DashboardUpdated)),
         "expected DashboardUpdated when session count changes",
     );
 }
@@ -175,15 +118,16 @@ fn new_run_emits_run_updated_and_dashboard_updated() {
 
     let events = drain_events(&mut rx);
     assert!(
-        events.iter().any(
-            |e| matches!(e, AppEventKind::RunUpdated { team_run_id, .. } if team_run_id == "run-abc")
-        ),
+        events.iter().any(|event| matches!(
+            event,
+            AppEventKind::RunUpdated { team_run_id, .. } if team_run_id == "run-abc"
+        )),
         "expected RunUpdated for run-abc",
     );
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::DashboardUpdated)),
+            .any(|event| matches!(event, AppEventKind::DashboardUpdated)),
         "expected DashboardUpdated",
     );
 }
@@ -209,9 +153,10 @@ fn run_status_change_emits_run_updated() {
 
     let events = drain_events(&mut rx);
     assert!(
-        events
-            .iter()
-            .any(|e| matches!(e, AppEventKind::RunUpdated { status, .. } if status == "completed")),
+        events.iter().any(|event| matches!(
+            event,
+            AppEventKind::RunUpdated { status, .. } if status == "completed"
+        )),
         "expected RunUpdated with completed status",
     );
 }
@@ -234,7 +179,7 @@ fn run_removed_emits_dashboard_updated() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::DashboardUpdated)),
+            .any(|event| matches!(event, AppEventKind::DashboardUpdated)),
         "expected DashboardUpdated when run count changes",
     );
 }
@@ -255,13 +200,13 @@ fn queue_stats_change_emits_queue_updated_and_dashboard_updated() {
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::QueueUpdated { .. })),
+            .any(|event| matches!(event, AppEventKind::QueueUpdated { .. })),
         "expected QueueUpdated",
     );
     assert!(
         events
             .iter()
-            .any(|e| matches!(e, AppEventKind::DashboardUpdated)),
+            .any(|event| matches!(event, AppEventKind::DashboardUpdated)),
         "expected DashboardUpdated",
     );
 }
@@ -281,7 +226,7 @@ fn queue_unchanged_emits_no_queue_event() {
     assert!(
         !events
             .iter()
-            .any(|e| matches!(e, AppEventKind::QueueUpdated { .. })),
+            .any(|event| matches!(event, AppEventKind::QueueUpdated { .. })),
         "expected no QueueUpdated when queue is unchanged",
     );
 }
@@ -301,7 +246,7 @@ fn queue_updated_carries_last_team_run_id() {
     let events = drain_events(&mut rx);
     let queue_event = events
         .iter()
-        .find(|e| matches!(e, AppEventKind::QueueUpdated { .. }));
+        .find(|event| matches!(event, AppEventKind::QueueUpdated { .. }));
     assert!(queue_event.is_some());
     if let Some(AppEventKind::QueueUpdated { team_run_id }) = queue_event {
         assert_eq!(team_run_id.as_deref(), Some("team-run-42"));
@@ -337,7 +282,7 @@ fn multiple_session_changes_emit_multiple_session_updated_events() {
     let events = drain_events(&mut rx);
     let session_events: Vec<_> = events
         .iter()
-        .filter(|e| matches!(e, AppEventKind::SessionUpdated { .. }))
+        .filter(|event| matches!(event, AppEventKind::SessionUpdated { .. }))
         .collect();
     assert_eq!(
         session_events.len(),
@@ -348,7 +293,7 @@ fn multiple_session_changes_emit_multiple_session_updated_events() {
 
     let dashboard_events: Vec<_> = events
         .iter()
-        .filter(|e| matches!(e, AppEventKind::DashboardUpdated))
+        .filter(|event| matches!(event, AppEventKind::DashboardUpdated))
         .collect();
     assert_eq!(
         dashboard_events.len(),
@@ -372,7 +317,7 @@ fn unchanged_session_emits_no_session_updated() {
     assert!(
         !events
             .iter()
-            .any(|e| matches!(e, AppEventKind::SessionUpdated { .. })),
+            .any(|event| matches!(event, AppEventKind::SessionUpdated { .. })),
         "expected no SessionUpdated for unchanged sessions",
     );
 }

--- a/crates/opengoose-web/src/live/tests/mod.rs
+++ b/crates/opengoose-web/src/live/tests/mod.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use opengoose_persistence::Database;
+use opengoose_types::{AppEvent, AppEventKind};
+
+fn make_db() -> Arc<Database> {
+    Arc::new(Database::open_in_memory().expect("in-memory db"))
+}
+
+fn drain_events(rx: &mut tokio::sync::broadcast::Receiver<AppEvent>) -> Vec<AppEventKind> {
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event.kind);
+    }
+    events
+}
+
+mod event_changes;
+mod snapshot_capture;

--- a/crates/opengoose-web/src/live/tests/snapshot_capture.rs
+++ b/crates/opengoose-web/src/live/tests/snapshot_capture.rs
@@ -1,0 +1,41 @@
+use opengoose_persistence::SessionStore;
+use opengoose_types::{Platform, SessionKey};
+
+use super::super::snapshot::capture_live_snapshot;
+use super::make_db;
+
+#[test]
+fn capture_live_snapshot_empty_db_returns_defaults() {
+    let db = make_db();
+    let snap = capture_live_snapshot(db).expect("snapshot should succeed");
+    assert!(snap.sessions.is_empty());
+    assert!(snap.runs.is_empty());
+    assert_eq!(snap.queue.pending, 0);
+    assert_eq!(snap.queue.processing, 0);
+    assert_eq!(snap.queue.completed, 0);
+    assert_eq!(snap.queue.failed, 0);
+    assert_eq!(snap.queue.dead, 0);
+    assert!(snap.queue.last_message_id.is_none());
+    assert!(snap.queue.last_team_run_id.is_none());
+}
+
+#[test]
+fn capture_live_snapshot_with_session_populates_sessions() {
+    let db = make_db();
+    let session_store = SessionStore::new(db.clone());
+    let key = SessionKey::new(Platform::Discord, "guild-1", "channel-1");
+    session_store
+        .append_user_message(&key, "hello", Some("user"))
+        .expect("append should succeed");
+
+    let snap = capture_live_snapshot(db).expect("snapshot should succeed");
+    assert_eq!(snap.sessions.len(), 1);
+    assert!(snap.sessions.contains_key(&key.to_stable_id()));
+}
+
+#[test]
+fn capture_live_snapshot_is_ok_result() {
+    let db = make_db();
+    let result = capture_live_snapshot(db);
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
## Summary
- replace the single crates/opengoose-web/src/live/tests.rs file with a thin crates/opengoose-web/src/live/tests/mod.rs root
- move snapshot capture coverage into crates/opengoose-web/src/live/tests/snapshot_capture.rs
- keep event-diff coverage in crates/opengoose-web/src/live/tests/event_changes.rs so live update assertions stay focused

## Verification
- cargo test -p opengoose-web live::tests
