### PR TITLE
test: expand plugin runtime coverage [OPE-509]

### DIFF
--- a/crates/opengoose-teams/src/plugin/tests/runtime.rs
+++ b/crates/opengoose-teams/src/plugin/tests/runtime.rs
@@ -31,10 +31,51 @@ description = "Recent commits"
 
     let skill = skill_store.get("git-tools/git-log").unwrap();
     assert_eq!(skill.version, "1.0.0");
+    assert_eq!(skill.description.as_deref(), Some("Recent commits"));
     assert_eq!(skill.extensions.len(), 1);
     assert_eq!(skill.extensions[0].name, "git-log");
     assert_eq!(skill.extensions[0].cmd.as_deref(), Some("git"));
     assert_eq!(skill.extensions[0].args, vec!["log", "--oneline"]);
+}
+
+#[test]
+fn test_plugin_runtime_init_preserves_extension_metadata() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join("skills");
+    let skill_store = opengoose_profiles::SkillStore::with_dir(skill_dir);
+
+    let plugin_dir = tmp.path().join("env-plugin");
+    write_manifest(
+        &plugin_dir,
+        r#"
+name = "env-plugin"
+version = "1.2.3"
+capabilities = ["skill"]
+
+[[skills]]
+name = "custom-tool"
+cmd = "my-tool"
+timeout = 45
+envs = { API_KEY = "test", MODE = "production" }
+"#,
+    );
+
+    let manifest = load_manifest(&plugin_dir.join("plugin.toml")).unwrap();
+    let loaded = LoadedPlugin::new(manifest, plugin_dir);
+
+    PluginRuntime::init_plugin(&loaded, &skill_store).unwrap();
+
+    let skill = skill_store.get("env-plugin/custom-tool").unwrap();
+    assert_eq!(skill.extensions.len(), 1);
+    assert_eq!(skill.extensions[0].timeout, Some(45));
+    assert_eq!(
+        skill.extensions[0].envs.get("API_KEY"),
+        Some(&"test".to_string())
+    );
+    assert_eq!(
+        skill.extensions[0].envs.get("MODE"),
+        Some(&"production".to_string())
+    );
 }
 
 #[test]
@@ -99,6 +140,38 @@ capabilities = ["channel_adapter"]
 }
 
 #[test]
+fn test_plugin_runtime_init_returns_plugin_error_when_skill_store_save_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join("skills");
+    std::fs::write(&skill_dir, "not a directory").unwrap();
+    let skill_store = opengoose_profiles::SkillStore::with_dir(skill_dir);
+
+    let plugin_dir = tmp.path().join("broken-save");
+    write_manifest(
+        &plugin_dir,
+        r#"
+name = "broken-save"
+version = "1.0.0"
+capabilities = ["skill"]
+
+[[skills]]
+name = "tool"
+cmd = "echo"
+"#,
+    );
+
+    let manifest = load_manifest(&plugin_dir.join("plugin.toml")).unwrap();
+    let loaded = LoadedPlugin::new(manifest, plugin_dir);
+
+    let err = PluginRuntime::init_plugin(&loaded, &skill_store).unwrap_err();
+    assert!(matches!(err, crate::error::TeamError::PluginInit(_)));
+    assert!(
+        err.to_string()
+            .contains("failed to register skill 'broken-save/tool'")
+    );
+}
+
+#[test]
 fn test_plugin_runtime_shutdown_removes_skills() {
     let tmp = tempfile::tempdir().unwrap();
     let skill_dir = tmp.path().join("skills");
@@ -155,6 +228,40 @@ cmd = "echo"
 
     let removed = PluginRuntime::shutdown_plugin(&loaded, &skill_store).unwrap();
     assert!(removed.is_empty());
+}
+
+#[test]
+fn test_plugin_runtime_shutdown_returns_plugin_error_when_skill_store_remove_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let skill_dir = tmp.path().join("skills");
+    let skill_store = opengoose_profiles::SkillStore::with_dir(skill_dir);
+
+    let plugin_dir = tmp.path().join("broken-remove");
+    write_manifest(
+        &plugin_dir,
+        r#"
+name = "broken-remove"
+version = "1.0.0"
+capabilities = ["skill"]
+
+[[skills]]
+name = "tool"
+cmd = "echo"
+"#,
+    );
+
+    let manifest = load_manifest(&plugin_dir.join("plugin.toml")).unwrap();
+    let loaded = LoadedPlugin::new(manifest, plugin_dir);
+    std::fs::create_dir_all(skill_store.dir()).unwrap();
+    let broken_skill_path = skill_store.skill_path("broken-remove/tool");
+    std::fs::create_dir_all(std::path::Path::new(&broken_skill_path)).unwrap();
+
+    let err = PluginRuntime::shutdown_plugin(&loaded, &skill_store).unwrap_err();
+    assert!(matches!(err, crate::error::TeamError::PluginInit(_)));
+    assert!(
+        err.to_string()
+            .contains("failed to remove skill 'broken-remove/tool'")
+    );
 }
 
 #[test]

--- a/crates/opengoose-teams/src/plugin/tests/status.rs
+++ b/crates/opengoose-teams/src/plugin/tests/status.rs
@@ -46,6 +46,10 @@ cmd = "ls"
     assert!(snapshot.runtime_initialized);
     assert_eq!(snapshot.registered_skills, vec!["file-tools/ls"]);
     assert!(snapshot.missing_skills.is_empty());
+    assert_eq!(
+        snapshot.runtime_note.as_deref(),
+        Some("registered 1 declared skill(s)")
+    );
 }
 
 #[test]
@@ -83,6 +87,50 @@ cmd = "grep"
     assert!(!snapshot.runtime_initialized);
     assert!(snapshot.registered_skills.is_empty());
     assert_eq!(snapshot.missing_skills, vec!["missing-tools/grep"]);
+    assert_eq!(
+        snapshot.runtime_note.as_deref(),
+        Some("missing 1 of 1 declared skill(s)")
+    );
+}
+
+#[test]
+fn skill_plugin_reports_unavailable_skill_store() {
+    let db = test_db();
+    let store = PluginStore::new(db);
+    let temp = tempfile::tempdir().expect("temp dir");
+    let plugin_dir = temp.path().join("offline-tools");
+    write_manifest(
+        &plugin_dir,
+        r#"
+name = "offline-tools"
+version = "1.0.0"
+capabilities = ["skill"]
+
+[[skills]]
+name = "find"
+cmd = "find"
+"#,
+    );
+
+    let plugin = store
+        .install(
+            "offline-tools",
+            "1.0.0",
+            &plugin_dir.to_string_lossy(),
+            None,
+            None,
+            "skill",
+        )
+        .expect("plugin should install");
+
+    let snapshot = plugin_status_snapshot(&plugin, None);
+    assert!(!snapshot.runtime_initialized);
+    assert!(snapshot.registered_skills.is_empty());
+    assert_eq!(snapshot.missing_skills, vec!["offline-tools/find"]);
+    assert_eq!(
+        snapshot.runtime_note.as_deref(),
+        Some("skill store unavailable; runtime registration could not be verified")
+    );
 }
 
 #[test]
@@ -118,6 +166,81 @@ capabilities = ["channel_adapter"]
         snapshot.runtime_note.as_deref(),
         Some("channel adapter runtime loading is not implemented yet")
     );
+}
+
+#[test]
+fn plugin_without_runtime_capability_reports_explicit_note() {
+    let db = test_db();
+    let store = PluginStore::new(db);
+    let temp = tempfile::tempdir().expect("temp dir");
+    let skill_store = opengoose_profiles::SkillStore::with_dir(temp.path().join("skills"));
+    let plugin_dir = temp.path().join("docs-plugin");
+    write_manifest(
+        &plugin_dir,
+        r#"
+name = "docs-plugin"
+version = "1.0.0"
+"#,
+    );
+
+    let plugin = store
+        .install(
+            "docs-plugin",
+            "1.0.0",
+            &plugin_dir.to_string_lossy(),
+            None,
+            None,
+            "",
+        )
+        .expect("plugin should install");
+
+    let snapshot = plugin_status_snapshot(&plugin, Some(&skill_store));
+    assert!(!snapshot.runtime_initialized);
+    assert!(snapshot.registered_skills.is_empty());
+    assert!(snapshot.missing_skills.is_empty());
+    assert_eq!(
+        snapshot.runtime_note.as_deref(),
+        Some("plugin does not declare a runtime capability")
+    );
+}
+
+#[test]
+fn manifest_capabilities_override_persisted_capabilities_in_snapshot() {
+    let db = test_db();
+    let store = PluginStore::new(db);
+    let temp = tempfile::tempdir().expect("temp dir");
+    let skill_store = opengoose_profiles::SkillStore::with_dir(temp.path().join("skills"));
+    let plugin_dir = temp.path().join("dual-runtime");
+    write_manifest(
+        &plugin_dir,
+        r#"
+name = "dual-runtime"
+version = "1.0.0"
+capabilities = ["skill", "channel_adapter"]
+
+[[skills]]
+name = "echo"
+cmd = "echo"
+"#,
+    );
+
+    let manifest = load_manifest(&plugin_dir.join("plugin.toml")).expect("manifest");
+    let loaded = LoadedPlugin::from_manifest(manifest, plugin_dir.clone());
+    PluginRuntime::init_plugin(&loaded, &skill_store).expect("runtime init should succeed");
+    let plugin = store
+        .install(
+            "dual-runtime",
+            "1.0.0",
+            &plugin_dir.to_string_lossy(),
+            None,
+            None,
+            "skill",
+        )
+        .expect("plugin should install");
+
+    let snapshot = plugin_status_snapshot(&plugin, Some(&skill_store));
+    assert_eq!(snapshot.capabilities, vec!["skill", "channel_adapter"]);
+    assert!(snapshot.runtime_initialized);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add plugin runtime tests for extension metadata preservation and lifecycle error paths
- expand plugin status snapshot coverage for runtime notes and capability resolution
- keep the change scoped to existing plugin test modules

## Testing
- cargo fmt --all --check
- cargo test -p opengoose-teams plugin::tests -- --nocapture
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
