### PR TITLE
test: expand auth middleware test coverage [OPE-508]

### DIFF
--- a/crates/opengoose-web/src/middleware/auth.rs
+++ b/crates/opengoose-web/src/middleware/auth.rs
@@ -355,9 +355,8 @@ mod tests {
         let store = Arc::new(ApiKeyStore::new(db));
         let layer = AuthLayer::new(store);
         // Verify the layer can wrap a service (type-level check)
-        let _service: AuthService<tower::util::ServiceFn<fn(Request<Body>) -> _>> =
-            layer.layer(tower::service_fn(|_req: Request<Body>| async {
-                Ok::<_, std::convert::Infallible>(StatusCode::OK.into_response())
-            }));
+        let _service = layer.layer(tower::service_fn(|_req: Request<Body>| async {
+            Ok::<_, std::convert::Infallible>(StatusCode::OK.into_response())
+        }));
     }
 }


### PR DESCRIPTION
## Summary

- Expand test coverage for `crates/opengoose-web/src/middleware/auth.rs` from 8 to 14 tests
- Add routes for all `PUBLIC_PATHS` entries (`/api/health/ready`, `/api/health/live`, `/api/metrics`) to test fixture
- Update `public_endpoints_skip_auth` to validate all 6 public paths instead of just 3

### New tests added
- `rejects_empty_bearer_token` — empty string after "Bearer " prefix
- `rejects_bearer_prefix_only` — "Bearer" without trailing space
- `public_paths_exact_match_only` — subpaths of public endpoints still require auth
- `multiple_keys_independently_valid` — multiple API keys work independently, revoking one doesn't affect others
- `unauthorized_response_has_correct_status` — unit test for the `unauthorized()` helper
- `auth_layer_produces_auth_service` — verifies `AuthLayer` wraps inner services correctly

### Validation
- 14/14 tests passing
- `cargo fmt` clean
- `cargo clippy` zero warnings

## Test plan
- [x] All 14 auth middleware tests pass
- [x] No formatting issues
- [x] No clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
