### PR TITLE
test: expand recipe bridge conversion and extension coverage

### DIFF
--- a/crates/opengoose-teams/src/recipe_bridge/tests/conversion.rs
+++ b/crates/opengoose-teams/src/recipe_bridge/tests/conversion.rs
@@ -1,0 +1,291 @@
+//! Tests for conversion helper functions and edge cases.
+
+use std::collections::HashMap;
+
+use goose::recipe::{RecipeParameterInputType, RecipeParameterRequirement};
+use opengoose_profiles::{ExtensionRef, ParameterRef, ProfileSettings};
+
+use super::super::conversion::{profile_to_recipe, recipe_to_profile, settings_to_retry_config};
+use super::{empty_profile, empty_recipe};
+
+// ── settings_to_retry_config ──────────────────────────────────────────
+
+#[test]
+fn retry_config_none_when_max_retries_unset() {
+    let settings = ProfileSettings {
+        goose_provider: None,
+        goose_model: None,
+        provider_fallbacks: vec![],
+        temperature: None,
+        max_turns: None,
+        message_retention_days: None,
+        event_retention_days: None,
+        max_retries: None,
+        retry_checks: vec!["cargo test".into()],
+        on_failure: Some("cargo clean".into()),
+    };
+    assert!(settings_to_retry_config(&settings).is_none());
+}
+
+#[test]
+fn retry_config_with_empty_checks() {
+    let settings = ProfileSettings {
+        goose_provider: None,
+        goose_model: None,
+        provider_fallbacks: vec![],
+        temperature: None,
+        max_turns: None,
+        message_retention_days: None,
+        event_retention_days: None,
+        max_retries: Some(5),
+        retry_checks: vec![],
+        on_failure: None,
+    };
+    let config = settings_to_retry_config(&settings).unwrap();
+    assert_eq!(config.max_retries, 5);
+    assert!(config.checks.is_empty());
+    assert!(config.on_failure.is_none());
+    assert!(config.timeout_seconds.is_none());
+}
+
+// ── parse_input_type / format_input_type round-trips ──────────────────
+
+#[test]
+fn input_type_round_trips() {
+    let types = ["string", "number", "boolean", "date", "file", "select"];
+    for type_str in types {
+        let mut profile = empty_profile("param-test");
+        profile.parameters = Some(vec![ParameterRef {
+            key: "k".into(),
+            input_type: type_str.into(),
+            requirement: "optional".into(),
+            description: "test".into(),
+            default: None,
+        }]);
+        let recipe = profile_to_recipe(&profile);
+        let back = recipe_to_profile(&recipe);
+        assert_eq!(
+            back.parameters.as_ref().unwrap()[0].input_type,
+            type_str,
+            "round-trip failed for input_type={type_str}"
+        );
+    }
+}
+
+#[test]
+fn unknown_input_type_defaults_to_string() {
+    let mut profile = empty_profile("unknown-type");
+    profile.parameters = Some(vec![ParameterRef {
+        key: "k".into(),
+        input_type: "unknown_custom_type".into(),
+        requirement: "optional".into(),
+        description: "test".into(),
+        default: None,
+    }]);
+    let recipe = profile_to_recipe(&profile);
+    let param = &recipe.parameters.as_ref().unwrap()[0];
+    assert!(matches!(param.input_type, RecipeParameterInputType::String));
+}
+
+// ── parse_requirement / format_requirement round-trips ────────────────
+
+#[test]
+fn requirement_round_trips() {
+    let reqs = ["required", "optional", "user_prompt"];
+    for req_str in reqs {
+        let mut profile = empty_profile("req-test");
+        profile.parameters = Some(vec![ParameterRef {
+            key: "k".into(),
+            input_type: "string".into(),
+            requirement: req_str.into(),
+            description: "test".into(),
+            default: None,
+        }]);
+        let recipe = profile_to_recipe(&profile);
+        let back = recipe_to_profile(&recipe);
+        assert_eq!(
+            back.parameters.as_ref().unwrap()[0].requirement,
+            req_str,
+            "round-trip failed for requirement={req_str}"
+        );
+    }
+}
+
+#[test]
+fn unknown_requirement_defaults_to_optional() {
+    let mut profile = empty_profile("unknown-req");
+    profile.parameters = Some(vec![ParameterRef {
+        key: "k".into(),
+        input_type: "string".into(),
+        requirement: "something_else".into(),
+        description: "test".into(),
+        default: None,
+    }]);
+    let recipe = profile_to_recipe(&profile);
+    let param = &recipe.parameters.as_ref().unwrap()[0];
+    assert!(matches!(
+        param.requirement,
+        RecipeParameterRequirement::Optional
+    ));
+}
+
+// ── profile_to_recipe edge cases ──────────────────────────────────────
+
+#[test]
+fn profile_with_no_description_becomes_empty_string() {
+    let profile = empty_profile("no-desc");
+    let recipe = profile_to_recipe(&profile);
+    assert_eq!(recipe.description, "");
+}
+
+#[test]
+fn profile_with_empty_extensions_produces_none() {
+    let mut profile = empty_profile("no-ext");
+    profile.extensions = vec![];
+    let recipe = profile_to_recipe(&profile);
+    assert!(recipe.extensions.is_none());
+}
+
+#[test]
+fn profile_with_extensions_produces_some() {
+    let mut profile = empty_profile("with-ext");
+    profile.extensions = vec![ExtensionRef {
+        name: "dev".into(),
+        ext_type: "builtin".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: None,
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: None,
+        dependencies: None,
+    }];
+    let recipe = profile_to_recipe(&profile);
+    assert_eq!(recipe.extensions.as_ref().unwrap().len(), 1);
+}
+
+#[test]
+fn profile_with_no_settings_produces_no_retry() {
+    let profile = empty_profile("no-settings");
+    let recipe = profile_to_recipe(&profile);
+    assert!(recipe.settings.is_none());
+    assert!(recipe.retry.is_none());
+}
+
+#[test]
+fn temperature_cast_f64_to_f32() {
+    let mut profile = empty_profile("temp-cast");
+    profile.settings = Some(ProfileSettings {
+        goose_provider: None,
+        goose_model: None,
+        provider_fallbacks: vec![],
+        temperature: Some(0.7),
+        max_turns: Some(20),
+        message_retention_days: None,
+        event_retention_days: None,
+        max_retries: None,
+        retry_checks: vec![],
+        on_failure: None,
+    });
+    let recipe = profile_to_recipe(&profile);
+    let settings = recipe.settings.unwrap();
+    let temp = settings.temperature.unwrap();
+    assert!((temp - 0.7f32).abs() < f32::EPSILON);
+    assert_eq!(settings.max_turns, Some(20));
+}
+
+// ── recipe_to_profile edge cases ──────────────────────────────────────
+
+#[test]
+fn recipe_empty_description_becomes_none_in_profile() {
+    let recipe = empty_recipe("empty-desc");
+    let profile = recipe_to_profile(&recipe);
+    assert!(profile.description.is_none());
+}
+
+#[test]
+fn recipe_nonempty_description_becomes_some() {
+    let mut recipe = empty_recipe("has-desc");
+    recipe.description = "A useful agent".into();
+    let profile = recipe_to_profile(&recipe);
+    assert_eq!(profile.description.as_deref(), Some("A useful agent"));
+}
+
+#[test]
+fn recipe_with_no_extensions_produces_empty_vec() {
+    let recipe = empty_recipe("no-ext");
+    let profile = recipe_to_profile(&recipe);
+    assert!(profile.extensions.is_empty());
+}
+
+#[test]
+fn recipe_response_with_json_schema_preserved() {
+    let mut recipe = empty_recipe("response");
+    recipe.response = Some(goose::recipe::Response {
+        json_schema: Some(serde_json::json!({"type": "object", "properties": {}})),
+    });
+    let profile = recipe_to_profile(&recipe);
+    assert!(profile.response.is_some());
+    assert_eq!(
+        profile.response.unwrap()["type"],
+        serde_json::json!("object")
+    );
+}
+
+#[test]
+fn recipe_response_with_no_schema_produces_none() {
+    let mut recipe = empty_recipe("no-schema");
+    recipe.response = Some(goose::recipe::Response { json_schema: None });
+    let profile = recipe_to_profile(&recipe);
+    assert!(profile.response.is_none());
+}
+
+#[test]
+fn parameter_default_value_preserved() {
+    let mut profile = empty_profile("param-default");
+    profile.parameters = Some(vec![ParameterRef {
+        key: "timeout".into(),
+        input_type: "number".into(),
+        requirement: "optional".into(),
+        description: "Timeout in seconds".into(),
+        default: Some("30".into()),
+    }]);
+    let recipe = profile_to_recipe(&profile);
+    let back = recipe_to_profile(&recipe);
+    let param = &back.parameters.unwrap()[0];
+    assert_eq!(param.default, Some("30".into()));
+}
+
+#[test]
+fn multiple_parameters_preserved_in_order() {
+    let mut profile = empty_profile("multi-params");
+    profile.parameters = Some(vec![
+        ParameterRef {
+            key: "alpha".into(),
+            input_type: "string".into(),
+            requirement: "required".into(),
+            description: "first".into(),
+            default: None,
+        },
+        ParameterRef {
+            key: "beta".into(),
+            input_type: "number".into(),
+            requirement: "optional".into(),
+            description: "second".into(),
+            default: Some("42".into()),
+        },
+        ParameterRef {
+            key: "gamma".into(),
+            input_type: "boolean".into(),
+            requirement: "user_prompt".into(),
+            description: "third".into(),
+            default: None,
+        },
+    ]);
+    let recipe = profile_to_recipe(&profile);
+    let back = recipe_to_profile(&recipe);
+    let params = back.parameters.unwrap();
+    let keys: Vec<_> = params.iter().map(|p| p.key.as_str()).collect();
+    assert_eq!(keys, vec!["alpha", "beta", "gamma"]);
+}

--- a/crates/opengoose-teams/src/recipe_bridge/tests/extensions.rs
+++ b/crates/opengoose-teams/src/recipe_bridge/tests/extensions.rs
@@ -1,0 +1,362 @@
+//! Tests for extension type conversion (ext_ref_to_config / config_to_ext_ref).
+
+use std::collections::HashMap;
+
+use goose::agents::extension::{Envs, ExtensionConfig};
+
+use opengoose_profiles::ExtensionRef;
+
+use super::super::extensions::{config_to_ext_ref, ext_ref_to_config};
+
+fn builtin_ext(name: &str) -> ExtensionRef {
+    ExtensionRef {
+        name: name.into(),
+        ext_type: "builtin".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: Some(300),
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: None,
+        dependencies: None,
+    }
+}
+
+// ── ext_ref_to_config ─────────────────────────────────────────────────
+
+#[test]
+fn builtin_ext_converts() {
+    let ext = builtin_ext("developer");
+    let config = ext_ref_to_config(&ext).unwrap();
+    match config {
+        ExtensionConfig::Builtin {
+            name,
+            timeout,
+            bundled,
+            ..
+        } => {
+            assert_eq!(name, "developer");
+            assert_eq!(timeout, Some(300));
+            assert_eq!(bundled, Some(true));
+        }
+        _ => panic!("expected Builtin config"),
+    }
+}
+
+#[test]
+fn stdio_ext_converts() {
+    let ext = ExtensionRef {
+        name: "my-tool".into(),
+        ext_type: "stdio".into(),
+        cmd: Some("my-tool-bin".into()),
+        args: vec!["--verbose".into()],
+        uri: None,
+        timeout: Some(60),
+        envs: HashMap::from([("KEY".into(), "val".into())]),
+        env_keys: vec!["SECRET".into()],
+        code: None,
+        dependencies: None,
+    };
+    let config = ext_ref_to_config(&ext).unwrap();
+    match config {
+        ExtensionConfig::Stdio {
+            name,
+            cmd,
+            args,
+            env_keys,
+            timeout,
+            ..
+        } => {
+            assert_eq!(name, "my-tool");
+            assert_eq!(cmd, "my-tool-bin");
+            assert_eq!(args, vec!["--verbose"]);
+            assert_eq!(env_keys, vec!["SECRET"]);
+            assert_eq!(timeout, Some(60));
+        }
+        _ => panic!("expected Stdio config"),
+    }
+}
+
+#[test]
+fn stdio_ext_requires_cmd() {
+    let ext = ExtensionRef {
+        name: "no-cmd".into(),
+        ext_type: "stdio".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: None,
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: None,
+        dependencies: None,
+    };
+    assert!(ext_ref_to_config(&ext).is_none());
+}
+
+#[test]
+fn streamable_http_ext_converts() {
+    let ext = ExtensionRef {
+        name: "remote-mcp".into(),
+        ext_type: "streamable_http".into(),
+        cmd: None,
+        args: vec![],
+        uri: Some("https://mcp.example.com".into()),
+        timeout: Some(120),
+        envs: HashMap::new(),
+        env_keys: vec!["API_KEY".into()],
+        code: None,
+        dependencies: None,
+    };
+    let config = ext_ref_to_config(&ext).unwrap();
+    match config {
+        ExtensionConfig::StreamableHttp {
+            name,
+            uri,
+            env_keys,
+            timeout,
+            ..
+        } => {
+            assert_eq!(name, "remote-mcp");
+            assert_eq!(uri, "https://mcp.example.com");
+            assert_eq!(env_keys, vec!["API_KEY"]);
+            assert_eq!(timeout, Some(120));
+        }
+        _ => panic!("expected StreamableHttp config"),
+    }
+}
+
+#[test]
+fn streamable_http_requires_uri() {
+    let ext = ExtensionRef {
+        name: "no-uri".into(),
+        ext_type: "streamable_http".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: None,
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: None,
+        dependencies: None,
+    };
+    assert!(ext_ref_to_config(&ext).is_none());
+}
+
+#[test]
+fn platform_ext_converts() {
+    let ext = ExtensionRef {
+        name: "platform-ext".into(),
+        ext_type: "platform".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: None,
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: None,
+        dependencies: None,
+    };
+    let config = ext_ref_to_config(&ext).unwrap();
+    match &config {
+        ExtensionConfig::Platform { name, .. } => assert_eq!(name, "platform-ext"),
+        _ => panic!("expected Platform config"),
+    }
+}
+
+#[test]
+fn inline_python_ext_converts() {
+    let ext = ExtensionRef {
+        name: "py-script".into(),
+        ext_type: "inline_python".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: Some(30),
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: Some("print('hello')".into()),
+        dependencies: Some(vec!["requests".into()]),
+    };
+    let config = ext_ref_to_config(&ext).unwrap();
+    match config {
+        ExtensionConfig::InlinePython {
+            name,
+            code,
+            timeout,
+            dependencies,
+            ..
+        } => {
+            assert_eq!(name, "py-script");
+            assert_eq!(code, "print('hello')");
+            assert_eq!(timeout, Some(30));
+            assert_eq!(dependencies, Some(vec!["requests".to_string()]));
+        }
+        _ => panic!("expected InlinePython config"),
+    }
+}
+
+#[test]
+fn inline_python_requires_code() {
+    let ext = ExtensionRef {
+        name: "no-code".into(),
+        ext_type: "inline_python".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: None,
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: None,
+        dependencies: None,
+    };
+    assert!(ext_ref_to_config(&ext).is_none());
+}
+
+#[test]
+fn unknown_ext_type_returns_none() {
+    let ext = ExtensionRef {
+        name: "mystery".into(),
+        ext_type: "quantum_entanglement".into(),
+        cmd: None,
+        args: vec![],
+        uri: None,
+        timeout: None,
+        envs: HashMap::new(),
+        env_keys: vec![],
+        code: None,
+        dependencies: None,
+    };
+    assert!(ext_ref_to_config(&ext).is_none());
+}
+
+// ── config_to_ext_ref ─────────────────────────────────────────────────
+
+#[test]
+fn builtin_config_to_ext_ref() {
+    let config = ExtensionConfig::Builtin {
+        name: "developer".into(),
+        description: "Dev tools".into(),
+        display_name: Some("Developer".into()),
+        timeout: Some(300),
+        bundled: Some(true),
+        available_tools: vec![],
+    };
+    let ext = config_to_ext_ref(&config).unwrap();
+    assert_eq!(ext.name, "developer");
+    assert_eq!(ext.ext_type, "builtin");
+    assert_eq!(ext.timeout, Some(300));
+    assert!(ext.cmd.is_none());
+}
+
+#[test]
+fn stdio_config_to_ext_ref() {
+    let config = ExtensionConfig::Stdio {
+        name: "tool".into(),
+        description: "A tool".into(),
+        cmd: "tool-bin".into(),
+        args: vec!["--flag".into()],
+        envs: Envs::new(HashMap::from([("K".into(), "V".into())])),
+        env_keys: vec!["SECRET".into()],
+        timeout: Some(60),
+        bundled: None,
+        available_tools: vec![],
+    };
+    let ext = config_to_ext_ref(&config).unwrap();
+    assert_eq!(ext.name, "tool");
+    assert_eq!(ext.ext_type, "stdio");
+    assert_eq!(ext.cmd, Some("tool-bin".into()));
+    assert_eq!(ext.args, vec!["--flag"]);
+    assert_eq!(ext.env_keys, vec!["SECRET"]);
+    assert_eq!(ext.timeout, Some(60));
+}
+
+#[test]
+fn streamable_http_config_to_ext_ref() {
+    let config = ExtensionConfig::StreamableHttp {
+        name: "remote".into(),
+        description: "Remote MCP".into(),
+        uri: "https://example.com/mcp".into(),
+        envs: Envs::new(HashMap::new()),
+        env_keys: vec![],
+        headers: HashMap::new(),
+        timeout: None,
+        bundled: None,
+        available_tools: vec![],
+    };
+    let ext = config_to_ext_ref(&config).unwrap();
+    assert_eq!(ext.name, "remote");
+    assert_eq!(ext.ext_type, "streamable_http");
+    assert_eq!(ext.uri, Some("https://example.com/mcp".into()));
+    assert!(ext.timeout.is_none());
+}
+
+#[test]
+fn platform_config_to_ext_ref() {
+    let config = ExtensionConfig::Platform {
+        name: "plat".into(),
+        description: "Platform ext".into(),
+        display_name: None,
+        bundled: None,
+        available_tools: vec![],
+    };
+    let ext = config_to_ext_ref(&config).unwrap();
+    assert_eq!(ext.name, "plat");
+    assert_eq!(ext.ext_type, "platform");
+    assert!(ext.timeout.is_none());
+}
+
+#[test]
+fn inline_python_config_to_ext_ref() {
+    let config = ExtensionConfig::InlinePython {
+        name: "pyscript".into(),
+        description: "Python script".into(),
+        code: "import os".into(),
+        timeout: Some(45),
+        dependencies: Some(vec!["numpy".into()]),
+        available_tools: vec![],
+    };
+    let ext = config_to_ext_ref(&config).unwrap();
+    assert_eq!(ext.name, "pyscript");
+    assert_eq!(ext.ext_type, "inline_python");
+    assert_eq!(ext.code, Some("import os".into()));
+    assert_eq!(ext.timeout, Some(45));
+    assert_eq!(ext.dependencies, Some(vec!["numpy".to_string()]));
+}
+
+// ── round-trip: ext_ref → config → ext_ref ────────────────────────────
+
+#[test]
+fn builtin_round_trip() {
+    let original = builtin_ext("dev");
+    let config = ext_ref_to_config(&original).unwrap();
+    let back = config_to_ext_ref(&config).unwrap();
+    assert_eq!(back.name, original.name);
+    assert_eq!(back.ext_type, original.ext_type);
+    assert_eq!(back.timeout, original.timeout);
+}
+
+#[test]
+fn stdio_round_trip() {
+    let original = ExtensionRef {
+        name: "tool".into(),
+        ext_type: "stdio".into(),
+        cmd: Some("cmd".into()),
+        args: vec!["a".into(), "b".into()],
+        uri: None,
+        timeout: Some(10),
+        envs: HashMap::new(),
+        env_keys: vec!["KEY".into()],
+        code: None,
+        dependencies: None,
+    };
+    let config = ext_ref_to_config(&original).unwrap();
+    let back = config_to_ext_ref(&config).unwrap();
+    assert_eq!(back.name, original.name);
+    assert_eq!(back.ext_type, original.ext_type);
+    assert_eq!(back.cmd, original.cmd);
+    assert_eq!(back.args, original.args);
+    assert_eq!(back.env_keys, original.env_keys);
+    assert_eq!(back.timeout, original.timeout);
+}

--- a/crates/opengoose-teams/src/recipe_bridge/tests/mod.rs
+++ b/crates/opengoose-teams/src/recipe_bridge/tests/mod.rs
@@ -4,6 +4,8 @@ use opengoose_profiles::AgentProfile;
 
 mod command;
 mod concurrency;
+mod conversion;
+mod extensions;
 mod fallback;
 mod round_trip;
 mod stream;


### PR DESCRIPTION
## Summary
- Add 18 unit tests for `conversion.rs` covering `settings_to_retry_config`, `parse_input_type`/`format_input_type` round-trips, `parse_requirement`/`format_requirement` round-trips, and edge cases (empty extensions, None settings, description mapping)
- Add 16 unit tests for `extensions.rs` covering all 5 extension types (`builtin`, `stdio`, `streamable_http`, `platform`, `inline_python`) in both directions plus round-trips and missing-field validation

## Test plan
- [x] All 34 new tests pass locally
- [x] Clippy clean
- [x] Formatting clean
- [x] Full test suite (334+ tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/300" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
