### PR TITLE
test(telegram): add polling loop coverage [OPE-520]

### DIFF
--- a/crates/opengoose-telegram/src/gateway/mod.rs
+++ b/crates/opengoose-telegram/src/gateway/mod.rs
@@ -23,6 +23,8 @@ mod delivery;
 mod polling;
 mod relay;
 mod streaming;
+#[cfg(test)]
+mod test_support;
 mod types;
 pub(crate) use types::*;
 

--- a/crates/opengoose-telegram/src/gateway/polling.rs
+++ b/crates/opengoose-telegram/src/gateway/polling.rs
@@ -9,6 +9,18 @@ use super::{BotInfo, TelegramGateway, TelegramResponse, Update};
 
 impl TelegramGateway {
     pub(crate) async fn run_polling_loop(&self, cancel: CancellationToken) -> anyhow::Result<()> {
+        self.run_polling_loop_with(cancel, Self::reconnect_delay)
+            .await
+    }
+
+    async fn run_polling_loop_with<F>(
+        &self,
+        cancel: CancellationToken,
+        reconnect_delay: F,
+    ) -> anyhow::Result<()>
+    where
+        F: Fn(u32) -> Duration,
+    {
         let bot_username = self.get_bot_username().await.unwrap_or_default();
         info!(bot_username = %bot_username, "telegram gateway starting");
 
@@ -56,7 +68,7 @@ impl TelegramGateway {
                                 break;
                             }
 
-                            let delay = Self::reconnect_delay(reconnect_attempts);
+                            let delay = reconnect_delay(reconnect_attempts);
                             warn!(%e, attempt = reconnect_attempts, ?delay, "telegram getUpdates error, retrying...");
                             tokio::select! {
                                 _ = cancel.cancelled() => {
@@ -122,5 +134,270 @@ impl TelegramGateway {
 
     pub(crate) fn reconnect_delay(reconnect_attempts: u32) -> Duration {
         Duration::from_secs(2u64.pow(reconnect_attempts.min(5)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use opengoose_types::{AppEventKind, EventBus, Platform};
+
+    use crate::gateway::MAX_RECONNECT_ATTEMPTS;
+    use crate::gateway::test_support::{MockResponse, MockTelegramApi, test_gateway};
+
+    fn drain_event_kinds(
+        rx: &mut tokio::sync::broadcast::Receiver<opengoose_types::AppEvent>,
+    ) -> Vec<AppEventKind> {
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event.kind);
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn get_updates_posts_timeout_and_offset() {
+        let api = MockTelegramApi::spawn(vec![MockResponse::json(serde_json::json!({
+            "ok": true,
+            "result": []
+        }))])
+        .await;
+        let gateway = test_gateway(&api.base_url, EventBus::new(16));
+
+        let updates = gateway.get_updates(Some(42)).await.unwrap();
+
+        assert!(updates.is_empty());
+
+        let requests = api.requests();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, "/bottest-token/getUpdates");
+        assert_eq!(requests[0].body["timeout"], 30);
+        assert_eq!(requests[0].body["offset"], 42);
+    }
+
+    #[tokio::test]
+    async fn get_updates_returns_api_and_json_errors() {
+        let api = MockTelegramApi::spawn(vec![
+            MockResponse::json(serde_json::json!({
+                "ok": false,
+                "description": "Unauthorized"
+            })),
+            MockResponse::raw("not-json"),
+        ])
+        .await;
+        let gateway = test_gateway(&api.base_url, EventBus::new(16));
+
+        let api_error = match gateway.get_updates(None).await {
+            Ok(_) => panic!("expected getUpdates API error"),
+            Err(error) => error,
+        };
+        assert!(
+            api_error
+                .to_string()
+                .contains("getUpdates failed: Unauthorized")
+        );
+
+        let json_error = match gateway.get_updates(None).await {
+            Ok(_) => panic!("expected getUpdates JSON error"),
+            Err(error) => error,
+        };
+        let decode_error = json_error
+            .downcast_ref::<reqwest::Error>()
+            .expect("expected reqwest decode error");
+        assert!(decode_error.is_decode());
+    }
+
+    #[tokio::test]
+    async fn get_bot_username_returns_none_when_lookup_fails() {
+        let api = MockTelegramApi::spawn(vec![
+            MockResponse::json(serde_json::json!({
+                "ok": true,
+                "result": {}
+            })),
+            MockResponse::raw("not-json"),
+        ])
+        .await;
+        let gateway = test_gateway(&api.base_url, EventBus::new(16));
+
+        assert_eq!(gateway.get_bot_username().await, None);
+        assert_eq!(gateway.get_bot_username().await, None);
+    }
+
+    #[test]
+    fn emit_disconnect_publishes_channel_disconnected_event() {
+        let bus = EventBus::new(16);
+        let mut events = bus.subscribe();
+        let gateway = test_gateway("http://127.0.0.1:1", bus.clone());
+
+        gateway.emit_disconnect("network timeout");
+
+        let event = events.try_recv().expect("disconnect event");
+        assert!(matches!(
+            event.kind,
+            AppEventKind::ChannelDisconnected {
+                platform: Platform::Telegram,
+                reason,
+            } if reason == "network timeout"
+        ));
+    }
+
+    #[tokio::test]
+    async fn run_polling_loop_emits_ready_once_advances_offset_and_falls_back_without_username() {
+        let api = MockTelegramApi::spawn(vec![
+            MockResponse::raw("not-json"),
+            MockResponse::json(serde_json::json!({
+                "ok": true,
+                "result": [
+                    { "update_id": 100 },
+                    { "update_id": 105 }
+                ]
+            })),
+            MockResponse::json(serde_json::json!({
+                "ok": true,
+                "result": []
+            })),
+        ])
+        .await;
+        let bus = EventBus::new(16);
+        let mut events = bus.subscribe();
+        let gateway = test_gateway(&api.base_url, bus.clone());
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+
+        let task = tokio::spawn(async move {
+            gateway
+                .run_polling_loop_with(task_cancel, |_| Duration::from_millis(1))
+                .await
+        });
+
+        api.wait_for_requests(3).await;
+        cancel.cancel();
+        task.await.unwrap().unwrap();
+
+        let requests = api.requests();
+        assert_eq!(requests[0].path, "/bottest-token/getMe");
+        assert_eq!(requests[1].path, "/bottest-token/getUpdates");
+        assert_eq!(requests[1].body["timeout"], 30);
+        assert!(requests[1].body.get("offset").is_none());
+        assert_eq!(requests[2].body["offset"], 106);
+
+        let event_kinds = drain_event_kinds(&mut events);
+        assert_eq!(
+            event_kinds
+                .iter()
+                .filter(|event| matches!(
+                    event,
+                    AppEventKind::ChannelReady {
+                        platform: Platform::Telegram
+                    }
+                ))
+                .count(),
+            1
+        );
+        assert!(event_kinds.iter().any(|event| matches!(
+            event,
+            AppEventKind::ChannelDisconnected {
+                platform: Platform::Telegram,
+                reason,
+            } if reason == "shutdown"
+        )));
+    }
+
+    #[tokio::test]
+    async fn run_polling_loop_stops_after_max_reconnect_attempts() {
+        let mut responses = vec![MockResponse::json(serde_json::json!({
+            "ok": true,
+            "result": { "username": "my_bot" }
+        }))];
+        responses.extend((0..MAX_RECONNECT_ATTEMPTS).map(|_| {
+            MockResponse::json(serde_json::json!({
+                "ok": false,
+                "description": "Unauthorized"
+            }))
+        }));
+
+        let api = MockTelegramApi::spawn(responses).await;
+        let bus = EventBus::new(16);
+        let mut events = bus.subscribe();
+        let gateway = test_gateway(&api.base_url, bus);
+
+        gateway
+            .run_polling_loop_with(CancellationToken::new(), |_| Duration::from_millis(1))
+            .await
+            .unwrap();
+
+        let event_kinds = drain_event_kinds(&mut events);
+        assert!(!event_kinds.iter().any(|event| matches!(
+            event,
+            AppEventKind::ChannelReady {
+                platform: Platform::Telegram
+            }
+        )));
+
+        let disconnect_reason = event_kinds.iter().find_map(|event| match event {
+            AppEventKind::ChannelDisconnected {
+                platform: Platform::Telegram,
+                reason,
+            } => Some(reason.as_str()),
+            _ => None,
+        });
+        assert_eq!(
+            disconnect_reason,
+            Some("getUpdates failed after 10 attempts: getUpdates failed: Unauthorized")
+        );
+        assert!(event_kinds.iter().any(|event| matches!(
+            event,
+            AppEventKind::Error { context, message }
+            if context == "telegram"
+                && message == "getUpdates failed after 10 attempts: getUpdates failed: Unauthorized"
+        )));
+    }
+
+    #[tokio::test]
+    async fn run_polling_loop_can_cancel_during_reconnect_sleep() {
+        let api = MockTelegramApi::spawn(vec![
+            MockResponse::json(serde_json::json!({
+                "ok": true,
+                "result": { "username": "my_bot" }
+            })),
+            MockResponse::json(serde_json::json!({
+                "ok": false,
+                "description": "temporary failure"
+            })),
+        ])
+        .await;
+        let bus = EventBus::new(16);
+        let mut events = bus.subscribe();
+        let gateway = test_gateway(&api.base_url, bus);
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+
+        let task = tokio::spawn(async move {
+            gateway
+                .run_polling_loop_with(task_cancel, |_| Duration::from_secs(60))
+                .await
+        });
+
+        api.wait_for_requests(2).await;
+        cancel.cancel();
+        task.await.unwrap().unwrap();
+
+        assert_eq!(api.requests().len(), 2);
+
+        let event_kinds = drain_event_kinds(&mut events);
+        assert!(event_kinds.iter().any(|event| matches!(
+            event,
+            AppEventKind::ChannelDisconnected {
+                platform: Platform::Telegram,
+                reason,
+            } if reason == "shutdown"
+        )));
+        assert!(!event_kinds.iter().any(|event| matches!(
+            event,
+            AppEventKind::Error { context, .. } if context == "telegram"
+        )));
     }
 }

--- a/crates/opengoose-telegram/src/gateway/streaming.rs
+++ b/crates/opengoose-telegram/src/gateway/streaming.rs
@@ -78,153 +78,20 @@ impl StreamResponder for TelegramGateway {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
-    use std::sync::{Arc, Mutex};
-
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
-
-    use opengoose_core::{Engine, GatewayBridge, StreamResponder};
-    use opengoose_persistence::Database;
+    use opengoose_core::StreamResponder;
     use opengoose_types::EventBus;
 
     use super::*;
-
-    #[derive(Debug, Clone)]
-    struct RecordedRequest {
-        path: String,
-        body: serde_json::Value,
-    }
-
-    struct MockTelegramApi {
-        base_url: String,
-        requests: Arc<Mutex<Vec<RecordedRequest>>>,
-        task: tokio::task::JoinHandle<()>,
-    }
-
-    impl MockTelegramApi {
-        async fn spawn(responses: Vec<serde_json::Value>) -> Self {
-            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-            let addr = listener.local_addr().unwrap();
-            let requests = Arc::new(Mutex::new(Vec::new()));
-            let queued_responses = Arc::new(Mutex::new(VecDeque::from(responses)));
-            let request_log = requests.clone();
-            let response_queue = queued_responses.clone();
-
-            let task = tokio::spawn(async move {
-                loop {
-                    let (mut socket, _) = match listener.accept().await {
-                        Ok(connection) => connection,
-                        Err(_) => break,
-                    };
-
-                    let request = match read_request(&mut socket).await {
-                        Ok(request) => request,
-                        Err(_) => continue,
-                    };
-                    request_log.lock().unwrap().push(request);
-
-                    let response = response_queue
-                        .lock()
-                        .unwrap()
-                        .pop_front()
-                        .unwrap_or_else(|| serde_json::json!({}));
-
-                    let body = response.to_string();
-                    let reply = format!(
-                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
-                        body.len(),
-                        body
-                    );
-
-                    let _ = socket.write_all(reply.as_bytes()).await;
-                }
-            });
-
-            Self {
-                base_url: format!("http://{addr}"),
-                requests,
-                task,
-            }
-        }
-
-        fn requests(&self) -> Vec<RecordedRequest> {
-            self.requests.lock().unwrap().clone()
-        }
-    }
-
-    impl Drop for MockTelegramApi {
-        fn drop(&mut self) {
-            self.task.abort();
-        }
-    }
-
-    async fn read_request(socket: &mut tokio::net::TcpStream) -> anyhow::Result<RecordedRequest> {
-        let mut buffer = Vec::new();
-        let mut chunk = [0; 1024];
-
-        loop {
-            let bytes_read = socket.read(&mut chunk).await?;
-            if bytes_read == 0 {
-                anyhow::bail!("client closed connection before request completed");
-            }
-
-            buffer.extend_from_slice(&chunk[..bytes_read]);
-            if let Some(header_end) = find_header_end(&buffer) {
-                let headers = std::str::from_utf8(&buffer[..header_end])?;
-                let path = headers
-                    .lines()
-                    .next()
-                    .and_then(|line| line.split_whitespace().nth(1))
-                    .ok_or_else(|| anyhow::anyhow!("missing request path"))?
-                    .to_string();
-                let content_length = headers
-                    .lines()
-                    .find_map(|line| {
-                        let (name, value) = line.split_once(':')?;
-                        (name.eq_ignore_ascii_case("content-length"))
-                            .then(|| value.trim().parse::<usize>().ok())
-                            .flatten()
-                    })
-                    .unwrap_or(0);
-                let body_start = header_end + 4;
-                if buffer.len() < body_start + content_length {
-                    continue;
-                }
-
-                let body = if content_length == 0 {
-                    serde_json::Value::Null
-                } else {
-                    serde_json::from_slice(&buffer[body_start..body_start + content_length])?
-                };
-
-                return Ok(RecordedRequest { path, body });
-            }
-        }
-    }
-
-    fn find_header_end(buffer: &[u8]) -> Option<usize> {
-        buffer.windows(4).position(|window| window == b"\r\n\r\n")
-    }
-
-    fn test_gateway(api_base_url: &str) -> TelegramGateway {
-        let bridge = Arc::new(GatewayBridge::new(Arc::new(Engine::new(
-            EventBus::new(16),
-            Database::open_in_memory().unwrap(),
-        ))));
-
-        TelegramGateway::with_api_base_url("test-token", bridge, EventBus::new(16), api_base_url)
-            .unwrap()
-    }
+    use crate::gateway::test_support::{MockResponse, MockTelegramApi, test_gateway};
 
     #[tokio::test]
     async fn create_draft_posts_placeholder_and_returns_handle() {
-        let api = MockTelegramApi::spawn(vec![serde_json::json!({
+        let api = MockTelegramApi::spawn(vec![MockResponse::json(serde_json::json!({
             "ok": true,
             "result": { "message_id": 42 }
-        })])
+        }))])
         .await;
-        let gateway = test_gateway(&api.base_url);
+        let gateway = test_gateway(&api.base_url, EventBus::new(16));
 
         let handle = gateway.create_draft("123").await.unwrap();
 
@@ -240,12 +107,12 @@ mod tests {
 
     #[tokio::test]
     async fn update_draft_truncates_content_before_editing() {
-        let api = MockTelegramApi::spawn(vec![serde_json::json!({
+        let api = MockTelegramApi::spawn(vec![MockResponse::json(serde_json::json!({
             "ok": true,
             "result": {}
-        })])
+        }))])
         .await;
-        let gateway = test_gateway(&api.base_url);
+        let gateway = test_gateway(&api.base_url, EventBus::new(16));
         let handle = DraftHandle {
             message_id: "42".to_string(),
             channel_id: "123".to_string(),
@@ -268,11 +135,11 @@ mod tests {
     #[tokio::test]
     async fn finalize_draft_updates_first_chunk_and_sends_overflow_message() {
         let api = MockTelegramApi::spawn(vec![
-            serde_json::json!({ "ok": true, "result": {} }),
-            serde_json::json!({}),
+            MockResponse::json(serde_json::json!({ "ok": true, "result": {} })),
+            MockResponse::json(serde_json::json!({})),
         ])
         .await;
-        let gateway = test_gateway(&api.base_url);
+        let gateway = test_gateway(&api.base_url, EventBus::new(16));
         let handle = DraftHandle {
             message_id: "42".to_string(),
             channel_id: "123".to_string(),

--- a/crates/opengoose-telegram/src/gateway/test_support.rs
+++ b/crates/opengoose-telegram/src/gateway/test_support.rs
@@ -1,0 +1,169 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use opengoose_core::{Engine, GatewayBridge};
+use opengoose_persistence::Database;
+use opengoose_types::EventBus;
+
+use super::TelegramGateway;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecordedRequest {
+    pub(crate) path: String,
+    pub(crate) body: serde_json::Value,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MockResponse {
+    body: String,
+}
+
+impl MockResponse {
+    pub(crate) fn json(body: serde_json::Value) -> Self {
+        Self {
+            body: body.to_string(),
+        }
+    }
+
+    pub(crate) fn raw(body: impl Into<String>) -> Self {
+        Self { body: body.into() }
+    }
+}
+
+pub(crate) struct MockTelegramApi {
+    pub(crate) base_url: String,
+    requests: Arc<Mutex<Vec<RecordedRequest>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl MockTelegramApi {
+    pub(crate) async fn spawn(responses: Vec<MockResponse>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let queued_responses = Arc::new(Mutex::new(VecDeque::from(responses)));
+        let request_log = requests.clone();
+        let response_queue = queued_responses.clone();
+
+        let task = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = match listener.accept().await {
+                    Ok(connection) => connection,
+                    Err(_) => break,
+                };
+
+                let request = match read_request(&mut socket).await {
+                    Ok(request) => request,
+                    Err(_) => continue,
+                };
+                request_log.lock().unwrap().push(request);
+
+                let response = response_queue
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .unwrap_or_else(|| MockResponse::json(serde_json::json!({})));
+
+                let reply = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    response.body.len(),
+                    response.body,
+                );
+
+                let _ = socket.write_all(reply.as_bytes()).await;
+            }
+        });
+
+        Self {
+            base_url: format!("http://{addr}"),
+            requests,
+            task,
+        }
+    }
+
+    pub(crate) fn requests(&self) -> Vec<RecordedRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+
+    pub(crate) async fn wait_for_requests(&self, expected_count: usize) {
+        let wait = async {
+            loop {
+                if self.requests.lock().unwrap().len() >= expected_count {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+
+        tokio::time::timeout(Duration::from_secs(1), wait)
+            .await
+            .expect("timed out waiting for mock Telegram requests");
+    }
+}
+
+impl Drop for MockTelegramApi {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+async fn read_request(socket: &mut tokio::net::TcpStream) -> anyhow::Result<RecordedRequest> {
+    let mut buffer = Vec::new();
+    let mut chunk = [0; 1024];
+
+    loop {
+        let bytes_read = socket.read(&mut chunk).await?;
+        if bytes_read == 0 {
+            anyhow::bail!("client closed connection before request completed");
+        }
+
+        buffer.extend_from_slice(&chunk[..bytes_read]);
+        if let Some(header_end) = find_header_end(&buffer) {
+            let headers = std::str::from_utf8(&buffer[..header_end])?;
+            let path = headers
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .ok_or_else(|| anyhow::anyhow!("missing request path"))?
+                .to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    (name.eq_ignore_ascii_case("content-length"))
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            let body_start = header_end + 4;
+            if buffer.len() < body_start + content_length {
+                continue;
+            }
+
+            let body = if content_length == 0 {
+                serde_json::Value::Null
+            } else {
+                serde_json::from_slice(&buffer[body_start..body_start + content_length])?
+            };
+
+            return Ok(RecordedRequest { path, body });
+        }
+    }
+}
+
+fn find_header_end(buffer: &[u8]) -> Option<usize> {
+    buffer.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+pub(crate) fn test_gateway(api_base_url: &str, event_bus: EventBus) -> TelegramGateway {
+    let bridge = Arc::new(GatewayBridge::new(Arc::new(Engine::new(
+        EventBus::new(16),
+        Database::open_in_memory().unwrap(),
+    ))));
+
+    TelegramGateway::with_api_base_url("test-token", bridge, event_bus, api_base_url).unwrap()
+}


### PR DESCRIPTION
## Summary
- add reusable mock Telegram API test support shared by polling and streaming tests
- cover polling request construction, username lookup fallback, ready emission, offset advancement, max retry termination, and shutdown during reconnect sleep
- keep production behavior unchanged apart from a small internal backoff hook used to exercise retry paths in tests

## Verification
- cargo test -p opengoose-telegram

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced internal test infrastructure with improved utilities and mock implementations.
  * Expanded test coverage for gateway polling, event handling, and streaming functionality.

* **Refactor**
  * Reorganized test support modules for improved consistency and code reusability.
  * No changes to production behavior; improvements focus on test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->