### PR TITLE
test(runner): expand AgentRunner construction coverage [OPE-521]

### DIFF
--- a/crates/opengoose-teams/src/runner/tests.rs
+++ b/crates/opengoose-teams/src/runner/tests.rs
@@ -494,10 +494,9 @@ async fn test_from_profile_keyed_with_project_uses_project_cwd() {
 #[tokio::test]
 async fn test_from_profile_keyed_without_project_uses_process_cwd() {
     let profile = make_profile(None);
-    let runner =
-        AgentRunner::from_profile_keyed_with_project(&profile, "sess2".to_string(), None)
-            .await
-            .unwrap();
+    let runner = AgentRunner::from_profile_keyed_with_project(&profile, "sess2".to_string(), None)
+        .await
+        .unwrap();
     let expected = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/"));
     assert_eq!(runner.cwd(), expected);
 }
@@ -562,7 +561,10 @@ async fn test_retry_config_from_settings() {
         ..Default::default()
     }));
     let runner = AgentRunner::from_profile(&profile).await.unwrap();
-    let rc = runner.retry_config.as_ref().expect("should have retry config");
+    let rc = runner
+        .retry_config
+        .as_ref()
+        .expect("should have retry config");
     assert_eq!(rc.max_retries, 3);
     assert_eq!(rc.checks.len(), 1);
     assert_eq!(rc.on_failure.as_deref(), Some("cargo clean"));


### PR DESCRIPTION
## Summary

- Adds 17 async `#[tokio::test]` tests for `AgentRunner` construction paths in `runner/construction.rs`
- Covers `from_inline_prompt`, `from_profile_keyed`, and `from_profile_keyed_with_project`
- Tests verify: profile name plumbing, default/custom max_turns, retry config extraction, provider chain propagation, cwd selection (process vs project), session uniqueness, prompt precedence (instructions > prompt > workspace), unsupported extension skip behavior, and bare-agent construction

## Test plan

- [x] `cargo test -p opengoose-teams --lib runner::tests` — all 49 runner tests pass (32 existing + 17 new)
- [x] `cargo test -p opengoose-teams --lib` — full crate suite passes (352 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
