### PR TITLE
fix: isolate runner tests from SQLite contention (OPE-525)

### DIFF
--- a/crates/opengoose-teams/src/runner/tests.rs
+++ b/crates/opengoose-teams/src/runner/tests.rs
@@ -5,6 +5,30 @@ use super::types::{
 };
 use opengoose_profiles::{AgentProfile, ProfileSettings, ProviderFallback};
 
+use std::sync::OnceLock;
+
+/// Redirect Goose's SQLite database to a per-process temp directory so that
+/// concurrent test binaries (from `cargo test`) don't contend on the same DB
+/// file, which causes intermittent SQLITE_CANTOPEN errors.
+static GOOSE_TEST_ROOT: OnceLock<std::path::PathBuf> = OnceLock::new();
+
+fn ensure_goose_test_root() {
+    GOOSE_TEST_ROOT.get_or_init(|| {
+        let root = std::env::temp_dir().join(format!(
+            "opengoose-teams-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        // Safety: called once via OnceLock before any Goose config is
+        // initialised; concurrent tests in this binary are not yet running
+        // env-dependent init paths.
+        unsafe {
+            std::env::set_var("GOOSE_PATH_ROOT", &root);
+        }
+        root
+    });
+}
+
 #[test]
 fn test_parse_broadcast() {
     let output = parse_agent_output(
@@ -407,6 +431,7 @@ use std::path::PathBuf;
 
 #[tokio::test]
 async fn test_from_inline_prompt_sets_profile_name() {
+    ensure_goose_test_root();
     let runner = AgentRunner::from_inline_prompt("You are a test bot.", "test-bot")
         .await
         .unwrap();
@@ -415,6 +440,7 @@ async fn test_from_inline_prompt_sets_profile_name() {
 
 #[tokio::test]
 async fn test_from_inline_prompt_default_max_turns() {
+    ensure_goose_test_root();
     let runner = AgentRunner::from_inline_prompt("You are helpful.", "helper")
         .await
         .unwrap();
@@ -423,6 +449,7 @@ async fn test_from_inline_prompt_default_max_turns() {
 
 #[tokio::test]
 async fn test_from_inline_prompt_default_retry_config_is_none() {
+    ensure_goose_test_root();
     let runner = AgentRunner::from_inline_prompt("You are helpful.", "helper")
         .await
         .unwrap();
@@ -431,6 +458,7 @@ async fn test_from_inline_prompt_default_retry_config_is_none() {
 
 #[tokio::test]
 async fn test_from_inline_prompt_cwd_is_current_dir() {
+    ensure_goose_test_root();
     let runner = AgentRunner::from_inline_prompt("prompt", "agent")
         .await
         .unwrap();
@@ -440,6 +468,7 @@ async fn test_from_inline_prompt_cwd_is_current_dir() {
 
 #[tokio::test]
 async fn test_from_inline_prompt_session_id_is_nonempty() {
+    ensure_goose_test_root();
     let runner = AgentRunner::from_inline_prompt("prompt", "agent")
         .await
         .unwrap();
@@ -451,6 +480,7 @@ async fn test_from_inline_prompt_session_id_is_nonempty() {
 
 #[tokio::test]
 async fn test_from_inline_prompt_produces_unique_sessions() {
+    ensure_goose_test_root();
     let r1 = AgentRunner::from_inline_prompt("prompt", "agent")
         .await
         .unwrap();
@@ -466,6 +496,7 @@ async fn test_from_inline_prompt_produces_unique_sessions() {
 
 #[tokio::test]
 async fn test_from_profile_keyed_returns_valid_session() {
+    ensure_goose_test_root();
     let profile = make_profile(None);
     let runner = AgentRunner::from_profile_keyed(&profile, "my-stable-session".to_string())
         .await
@@ -476,6 +507,7 @@ async fn test_from_profile_keyed_returns_valid_session() {
 
 #[tokio::test]
 async fn test_from_profile_keyed_with_project_uses_project_cwd() {
+    ensure_goose_test_root();
     let profile = make_profile(None);
     let project = ProjectContext {
         title: "test-project".to_string(),
@@ -493,6 +525,7 @@ async fn test_from_profile_keyed_with_project_uses_project_cwd() {
 
 #[tokio::test]
 async fn test_from_profile_keyed_without_project_uses_process_cwd() {
+    ensure_goose_test_root();
     let profile = make_profile(None);
     let runner = AgentRunner::from_profile_keyed_with_project(&profile, "sess2".to_string(), None)
         .await
@@ -503,6 +536,7 @@ async fn test_from_profile_keyed_without_project_uses_process_cwd() {
 
 #[tokio::test]
 async fn test_instructions_takes_precedence_over_prompt() {
+    ensure_goose_test_root();
     // When both `instructions` and `prompt` are set, `instructions` wins.
     let profile = AgentProfile {
         version: "1.0.0".to_string(),
@@ -524,6 +558,7 @@ async fn test_instructions_takes_precedence_over_prompt() {
 
 #[tokio::test]
 async fn test_prompt_field_used_when_no_instructions() {
+    ensure_goose_test_root();
     let profile = AgentProfile {
         version: "1.0.0".to_string(),
         title: "prompt-only".to_string(),
@@ -544,6 +579,7 @@ async fn test_prompt_field_used_when_no_instructions() {
 
 #[tokio::test]
 async fn test_custom_max_turns_from_settings() {
+    ensure_goose_test_root();
     let profile = make_profile(Some(ProfileSettings {
         max_turns: Some(25),
         ..Default::default()
@@ -554,6 +590,7 @@ async fn test_custom_max_turns_from_settings() {
 
 #[tokio::test]
 async fn test_retry_config_from_settings() {
+    ensure_goose_test_root();
     let profile = make_profile(Some(ProfileSettings {
         max_retries: Some(3),
         retry_checks: vec!["cargo test".to_string()],
@@ -572,6 +609,7 @@ async fn test_retry_config_from_settings() {
 
 #[tokio::test]
 async fn test_retry_config_none_without_max_retries() {
+    ensure_goose_test_root();
     let profile = make_profile(Some(ProfileSettings {
         retry_checks: vec!["cargo test".to_string()],
         ..Default::default()
@@ -582,6 +620,7 @@ async fn test_retry_config_none_without_max_retries() {
 
 #[tokio::test]
 async fn test_provider_chain_plumbed_from_profile() {
+    ensure_goose_test_root();
     let profile = make_profile(Some(ProfileSettings {
         goose_provider: Some("openai".to_string()),
         goose_model: Some("gpt-4.1".to_string()),
@@ -599,6 +638,7 @@ async fn test_provider_chain_plumbed_from_profile() {
 
 #[tokio::test]
 async fn test_unsupported_extension_skipped_gracefully() {
+    ensure_goose_test_root();
     let profile = AgentProfile {
         version: "1.0.0".to_string(),
         title: "ext-test".to_string(),
@@ -630,6 +670,7 @@ async fn test_unsupported_extension_skipped_gracefully() {
 
 #[tokio::test]
 async fn test_project_context_with_empty_goal() {
+    ensure_goose_test_root();
     let profile = make_profile(None);
     let project = ProjectContext {
         title: "empty-goal".to_string(),
@@ -647,6 +688,7 @@ async fn test_project_context_with_empty_goal() {
 
 #[tokio::test]
 async fn test_no_instructions_no_prompt_still_constructs() {
+    ensure_goose_test_root();
     // Neither instructions nor prompt — falls through to workspace identity path.
     let profile = AgentProfile {
         version: "1.0.0".to_string(),


### PR DESCRIPTION
## Summary
- Set `GOOSE_PATH_ROOT` to a unique temp dir per test binary in `opengoose-teams` runner tests
- Prevents concurrent `cargo test` binaries from contending on the same Goose SQLite database file
- Fixes intermittent `SQLITE_CANTOPEN` (code 14) failure in `test_from_inline_prompt_produces_unique_sessions`
- Follows existing pattern from `opengoose-core/src/bridge/tests.rs`

## Test plan
- [x] `test_from_inline_prompt_produces_unique_sessions` passes in isolation
- [x] Full `cargo test` workspace passes (0 failures, 2128+ tests)
- [x] Zero Clippy warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/307" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
