### PR TITLE
fix(ci): remove copilot-requests permission causing startup_failure

### DIFF
--- a/.github/workflows/ci-coach.lock.yml
+++ b/.github/workflows/ci-coach.lock.yml
@@ -257,7 +257,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      copilot-requests: write
       issues: read
       pull-requests: read
     concurrency:

--- a/.github/workflows/ci-coach.md
+++ b/.github/workflows/ci-coach.md
@@ -24,8 +24,7 @@ imports:
   - shared/ci-data-analysis.md
   - shared/ci-optimization-strategies.md
   - shared/reporting.md
-features:
-  copilot-requests: true
+features: {}
 ---
 
 # CI Optimization Coach

--- a/.github/workflows/cli-consistency-checker.lock.yml
+++ b/.github/workflows/cli-consistency-checker.lock.yml
@@ -228,7 +228,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      copilot-requests: write
       issues: read
       pull-requests: read
     concurrency:

--- a/.github/workflows/cli-consistency-checker.md
+++ b/.github/workflows/cli-consistency-checker.md
@@ -25,8 +25,7 @@ safe-outputs:
     labels: [automation, cli, documentation, cookie]
     max: 1
 timeout-minutes: 20
-features:
-  copilot-requests: true
+features: {}
 source: github/gh-aw/.github/workflows/cli-consistency-checker.md@b28e62023cd0a102f6d701e4272f9acedb04f3e1
 ---
 

--- a/.github/workflows/daily-testify-uber-super-expert.lock.yml
+++ b/.github/workflows/daily-testify-uber-super-expert.lock.yml
@@ -258,7 +258,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      copilot-requests: write
       issues: read
       pull-requests: read
     concurrency:

--- a/.github/workflows/daily-testify-uber-super-expert.md
+++ b/.github/workflows/daily-testify-uber-super-expert.md
@@ -23,8 +23,7 @@ safe-outputs:
     title-prefix: "[rust-test-expert] "
 description: Daily expert that analyzes one test file and creates an issue with Rust testing improvements
 engine: copilot
-features:
-  copilot-requests: true
+features: {}
 name: Daily Rust Testing Expert
 source: github/gh-aw/.github/workflows/daily-testify-uber-super-expert.md@b2d8af7543ec40f72bb3b8fea5148c2d3ee401c7
 strict: true


### PR DESCRIPTION
## Summary

- Removes the `copilot-requests: write` permission scope from ci-coach, cli-consistency-checker, and daily-testify-uber-super-expert workflows
- This permission is a GitHub-internal scope not available on external repositories, causing persistent `startup_failure` on every scheduled run
- Fixes both the `.md` source files and the compiled `.lock.yml` files

## Root cause

The `copilot-requests` permission scope is only valid within GitHub's internal infrastructure (dotcom/GHES). When GitHub Actions encounters an unrecognized permission scope, it rejects the entire workflow file at parse time, resulting in `startup_failure` before any jobs can be created or run.

The three affected workflows all had `features: copilot-requests: true` in their `.md` frontmatter, which compiled to `copilot-requests: write` in the `.lock.yml` agent job permissions. Other `.lock.yml` workflows in the repo (e.g., ci-doctor, code-simplifier) that lack this permission run successfully.

Closes #297

## Test plan

- [ ] Verify ci-coach workflow can be triggered via `workflow_dispatch` without startup_failure
- [ ] Verify cli-consistency-checker workflow can be triggered via `workflow_dispatch` without startup_failure
- [ ] Verify daily-testify-uber-super-expert workflow can be triggered via `workflow_dispatch` without startup_failure
- [ ] Confirm the next scheduled run completes without startup_failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/soilspoon/opengoose/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed copilot-requests permissions and feature toggles from GitHub Actions workflow configurations across multiple CI/CD pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->